### PR TITLE
Expose gUM and gDM feature detection methods

### DIFF
--- a/.changeset/witty-seahorses-try.md
+++ b/.changeset/witty-seahorses-try.md
@@ -1,0 +1,6 @@
+---
+'@signalwire/js': minor
+'@signalwire/webrtc': minor
+---
+
+Exports methods to check if the environment supports `getUserMedia` or `getDisplayMedia`

--- a/packages/js/src/webrtc.ts
+++ b/packages/js/src/webrtc.ts
@@ -17,6 +17,8 @@ export {
   createMicrophoneDeviceWatcher,
   createSpeakerDeviceWatcher,
   supportsMediaDevices,
+  supportsGetUserMedia,
+  supportsGetDisplayMedia,
   getUserMedia,
   getDisplayMedia,
   enumerateDevices,

--- a/packages/webrtc/src/index.ts
+++ b/packages/webrtc/src/index.ts
@@ -23,6 +23,8 @@ export {
 } from './utils/deviceHelpers'
 export {
   supportsMediaDevices,
+  supportsGetUserMedia,
+  supportsGetDisplayMedia,
   getUserMedia,
   getDisplayMedia,
   enumerateDevices,

--- a/packages/webrtc/src/utils/webrtcHelpers.native.ts
+++ b/packages/webrtc/src/utils/webrtcHelpers.native.ts
@@ -23,7 +23,7 @@ export const supportsGetUserMedia = () => {
 }
 
 export const supportsGetDisplayMedia = () => {
-  return typeof RNmediaDevices.getDisplayMedia === 'function'
+  return typeof RNmediaDevices?.getDisplayMedia === 'function'
 }
 
 export const enumerateDevices = () => RNmediaDevices.enumerateDevices()

--- a/packages/webrtc/src/utils/webrtcHelpers.native.ts
+++ b/packages/webrtc/src/utils/webrtcHelpers.native.ts
@@ -18,6 +18,14 @@ export const getDisplayMedia = (constraints: MediaStreamConstraints) => {
   return RNmediaDevices.getDisplayMedia(constraints)
 }
 
+export const supportsGetUserMedia = () => {
+  return typeof RNmediaDevices?.getUserMedia === 'function'
+}
+
+export const supportsGetDisplayMedia = () => {
+  return typeof RNmediaDevices.getDisplayMedia === 'function'
+}
+
 export const enumerateDevices = () => RNmediaDevices.enumerateDevices()
 
 export const enumerateDevicesByKind = async (filterByKind: string) => {

--- a/packages/webrtc/src/utils/webrtcHelpers.ts
+++ b/packages/webrtc/src/utils/webrtcHelpers.ts
@@ -8,6 +8,15 @@ export const supportsMediaDevices = () => {
   return typeof navigator !== 'undefined' && !!navigator.mediaDevices
 }
 
+export const supportsGetUserMedia = () => {
+  return typeof navigator?.mediaDevices?.getUserMedia === 'function'
+}
+
+export const supportsGetDisplayMedia = () => {
+  // @ts-expect-error
+  return typeof navigator?.mediaDevices?.getDisplayMedia === 'function'
+}
+
 export const getMediaDevicesApi = () => {
   if (!supportsMediaDevices()) {
     throw new Error("The media devices API isn't supported in this environment")
@@ -80,7 +89,7 @@ export const getUserMedia = (
 }
 
 export const getDisplayMedia = (constraints: MediaStreamConstraints) => {
-  // @ts-ignore
+  // @ts-expect-error
   return getMediaDevicesApi().getDisplayMedia(constraints)
 }
 


### PR DESCRIPTION
This PR exposes 2 additional methods:

- `supportsGetUserMedia`: returns a bool indicating whether the client supports getUserMedia or not
- `supportsGetDisplayMedia`: returns a bool indicating whether the client supports getDisplayMedia or not