### PR TITLE
Allow speakerId to be set before joining a room

### DIFF
--- a/.changeset/odd-toes-ring.md
+++ b/.changeset/odd-toes-ring.md
@@ -1,0 +1,6 @@
+---
+'@signalwire/js': minor
+'@signalwire/webrtc': minor
+---
+
+Allow `speakerId` to be set when creating a room object to set the audio output device before join.

--- a/packages/js/src/Client.ts
+++ b/packages/js/src/Client.ts
@@ -36,6 +36,7 @@ export class Client extends BaseClient {
             makeMediaElementsSaga({
               rootElementId,
               applyLocalVideoOverlay,
+              speakerId: options.speakerId,
             })
           )
         }

--- a/packages/js/src/createRoomObject.ts
+++ b/packages/js/src/createRoomObject.ts
@@ -47,6 +47,7 @@ export const createRoomObject = (
       autoJoin = false,
       stopCameraWhileMuted = true,
       stopMicrophoneWhileMuted = true,
+      speakerId,
       ...userOptions
     } = roomOptions
 
@@ -72,6 +73,7 @@ export const createRoomObject = (
       applyLocalVideoOverlay,
       stopCameraWhileMuted,
       stopMicrophoneWhileMuted,
+      speakerId,
     })
 
     // WebRTC connection left the room.

--- a/packages/js/src/features/mediaElements/mediaElementsSagas.ts
+++ b/packages/js/src/features/mediaElements/mediaElementsSagas.ts
@@ -16,9 +16,11 @@ import type { Room } from '../../Room'
 export const makeMediaElementsSaga = ({
   rootElementId,
   applyLocalVideoOverlay,
+  speakerId,
 }: {
   rootElementId?: string
   applyLocalVideoOverlay?: boolean
+  speakerId?: string
 }) =>
   function* mediaElementsSaga({
     instance: room,
@@ -76,6 +78,7 @@ export const makeMediaElementsSaga = ({
             audioTask = runSaga(audioElementSetupWorker, {
               track: event.track,
               element: audioEl,
+              speakerId,
               room,
             })
             break
@@ -149,13 +152,19 @@ function* audioElementActionsWatcher({
 function* audioElementSetupWorker({
   track,
   element,
+  speakerId,
   room,
 }: {
   track: MediaStreamTrack
   element: HTMLAudioElement
+  speakerId?: string
   room: Room
 }): SagaIterator {
   setAudioMediaTrack({ track, element })
+  if (speakerId) {
+    // Catch no-op since setMediaElementSinkId already provides logs
+    setMediaElementSinkId(element, speakerId).catch(() => {})
+  }
 
   yield fork(audioElementActionsWatcher, {
     element,

--- a/packages/webrtc/src/utils/interfaces.ts
+++ b/packages/webrtc/src/utils/interfaces.ts
@@ -34,7 +34,6 @@ export interface ConnectionOptions {
   camId?: string
   /** @internal */
   camLabel?: string
-  /** @internal */
   speakerId?: string
   /** @internal */
   userVariables?: { [key: string]: any }


### PR DESCRIPTION
This PR add the ability to set `speakerId` on `createRoomObject` or `joinRoom` methods to set the audio output device before joining.