### PR TITLE
Swap prepare with prepublishOnly script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,9 @@
         "prettier": "^2.3.2",
         "typedoc": "^0.21.2",
         "typescript": "^4.2.3"
+      },
+      "devDependencies": {
+        "yarn": "^1.22.11"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -12428,6 +12431,20 @@
         "node": ">=8"
       }
     },
+    "node_modules/yarn": {
+      "version": "1.22.11",
+      "resolved": "https://registry.npmjs.org/yarn/-/yarn-1.22.11.tgz",
+      "integrity": "sha512-AWje4bzqO9RUn3sdnM5N8n4ZJ0BqCc/kqFJvpOI5/EVkINXui0yuvU7NDCEF//+WaxHuNay2uOHxA4+tq1P3cg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "yarn": "bin/yarn.js",
+        "yarnpkg": "bin/yarn.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/yn": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
@@ -21314,6 +21331,12 @@
           "version": "5.3.1"
         }
       }
+    },
+    "yarn": {
+      "version": "1.22.11",
+      "resolved": "https://registry.npmjs.org/yarn/-/yarn-1.22.11.tgz",
+      "integrity": "sha512-AWje4bzqO9RUn3sdnM5N8n4ZJ0BqCc/kqFJvpOI5/EVkINXui0yuvU7NDCEF//+WaxHuNay2uOHxA4+tq1P3cg==",
+      "dev": true
     },
     "yn": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -29,5 +29,8 @@
     "prettier": "^2.3.2",
     "typedoc": "^0.21.2",
     "typescript": "^4.2.3"
+  },
+  "devDependencies": {
+    "yarn": "^1.22.11"
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,9 +28,7 @@
     "jest": "^27.0.6",
     "prettier": "^2.3.2",
     "typedoc": "^0.21.2",
-    "typescript": "^4.2.3"
-  },
-  "devDependencies": {
+    "typescript": "^4.2.3",
     "yarn": "^1.22.11"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -34,7 +34,7 @@
     "start:node": "sw-build --dev --node --watchFormat=cjs",
     "build": "tsc --project tsconfig.build.json && sw-build --web && sw-build --node",
     "test": "NODE_ENV=test jest",
-    "prepare": "npm run build"
+    "prepublishOnly": "npm run build"
   },
   "dependencies": {
     "@reduxjs/toolkit": "^1.6.0",

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -37,7 +37,8 @@
     "test": "NODE_ENV=test jest",
     "example": "(cd examples && npm run dev)",
     "docs": "typedoc --options typedoc.js --readme README.md",
-    "docs:watch": "npm run docs -- --watch"
+    "docs:watch": "npm run docs -- --watch",
+    "prepublishOnly": "npm run build"
   },
   "dependencies": {
     "@signalwire/core": "3.0.0",

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -35,7 +35,7 @@
     "start": "sw-build --dev --node",
     "build": "tsc --project tsconfig.build.json && sw-build --node",
     "test": "NODE_ENV=test jest",
-    "prepare": "npm run build",
+    "prepublishOnly": "npm run build",
     "docs": "typedoc --options typedoc.js --readme README.md",
     "docs:watch": "npm run docs -- --watch"
   },

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -18,7 +18,7 @@
     "start": "sw-build --dev --node",
     "build": "tsc --project tsconfig.build.json && sw-build --node",
     "test": "NODE_ENV=test jest",
-    "prepare": "npm run build"
+    "prepublishOnly": "npm run build"
   },
   "dependencies": {
     "@signalwire/core": "3.0.0",

--- a/packages/webrtc/package.json
+++ b/packages/webrtc/package.json
@@ -34,7 +34,7 @@
     "start": "tsc --watch --project tsconfig.build.json",
     "build": "tsc --project tsconfig.build.json && tsc --project tsconfig.cjs.json",
     "test": "NODE_ENV=test jest",
-    "prepare": "npm run build",
+    "prepublishOnly": "npm run build",
     "docs": "typedoc --options typedoc.js --readme README.md",
     "docs:watch": "npm run docs -- --watch"
   },


### PR DESCRIPTION
Starting from [NPM v7.20.0](https://github.com/npm/cli/releases/tag/v7.20.0) the `prepare` script runs on local `npm install` even when using workspaces. This PR swap `prepare` with `prepublishOnly` to allow `npm i` to install the deps for each workspace and **then** build it with custom scripts like `npm run build`. 