### PR TITLE
Add logLevel param and review the SDK logs

### DIFF
--- a/.changeset/five-forks-marry.md
+++ b/.changeset/five-forks-marry.md
@@ -1,0 +1,7 @@
+---
+'@signalwire/core': minor
+'@signalwire/webrtc': minor
+'@signalwire/js': minor
+---
+
+Allow to set the logger level via `logLevel` argument on the `UserOptions` interface.

--- a/packages/core/src/BaseComponent.ts
+++ b/packages/core/src/BaseComponent.ts
@@ -99,7 +99,7 @@ export class BaseComponent implements Emitter {
   /** @internal */
   private addEventToRegisterQueue(options: EventRegisterHandlers) {
     const [event, fn, context] = options.params
-    logger.debug('Adding event to the register queue', { event, fn, context })
+    logger.trace('Adding event to the register queue', { event, fn, context })
     // @ts-ignore
     this._eventsRegisterQueue.add({
       type: options.type,
@@ -110,7 +110,7 @@ export class BaseComponent implements Emitter {
 
   /** @internal */
   private addEventToEmitQueue(event: string | symbol, args: any[]) {
-    logger.debug('Adding to the emit queue', event)
+    logger.trace('Adding to the emit queue', event)
     this._eventsEmitQueue.add({ event, args })
   }
 
@@ -158,7 +158,7 @@ export class BaseComponent implements Emitter {
     const [event, fn, context] = params
     const handler = this.applyEventHandlerTransform(event, fn)
     const namespacedEvent = this._getNamespacedEvent(event)
-    logger.debug('Registering event', namespacedEvent)
+    logger.trace('Registering event', namespacedEvent)
     this.trackEvent(event)
     return this.emitter.on(namespacedEvent, handler, context)
   }
@@ -172,7 +172,7 @@ export class BaseComponent implements Emitter {
     const [event, fn, context] = params
     const handler = this.applyEventHandlerTransform(event, fn)
     const namespacedEvent = this._getNamespacedEvent(event)
-    logger.debug('Registering event', namespacedEvent)
+    logger.trace('Registering event', namespacedEvent)
     this.trackEvent(event)
     return this.emitter.once(namespacedEvent, handler, context)
   }
@@ -186,7 +186,7 @@ export class BaseComponent implements Emitter {
     const [event, fn, context, once] = params
     const handler = this.getAndRemoveStableEventHandler(fn)
     const namespacedEvent = this._getNamespacedEvent(event)
-    logger.debug('Removing event listener', namespacedEvent)
+    logger.trace('Removing event listener', namespacedEvent)
     return this.emitter.off(namespacedEvent, handler, context, once)
   }
 
@@ -221,7 +221,6 @@ export class BaseComponent implements Emitter {
     }
 
     const namespacedEvent = this._getNamespacedEvent(event)
-    logger.debug('Adding to the emit queue', namespacedEvent)
     return this.emitter.emit(namespacedEvent, ...args)
   }
 

--- a/packages/core/src/BaseSession.ts
+++ b/packages/core/src/BaseSession.ts
@@ -57,8 +57,12 @@ export class BaseSession {
   private _status: SessionStatus = 'unknown'
 
   constructor(public options: SessionOptions) {
-    if (options.host) {
-      this._host = checkWebSocketHost(options.host)
+    const { host, logLevel = 'info' } = options
+    if (host) {
+      this._host = checkWebSocketHost(host)
+    }
+    if (logLevel) {
+      this.logger.setLevel(logLevel)
     }
     this._onSocketOpen = this._onSocketOpen.bind(this)
     this._onSocketError = this._onSocketError.bind(this)

--- a/packages/core/src/BaseSession.ts
+++ b/packages/core/src/BaseSession.ts
@@ -66,8 +66,6 @@ export class BaseSession {
     this._onSocketMessage = this._onSocketMessage.bind(this)
     this.execute = this.execute.bind(this)
     this.connect = this.connect.bind(this)
-
-    this.logger.setLevel(this.logger.levels.INFO)
   }
 
   get rpcConnectResult() {

--- a/packages/core/src/BaseSession.ts
+++ b/packages/core/src/BaseSession.ts
@@ -172,7 +172,7 @@ export class BaseSession {
       promise = Promise.resolve()
     }
 
-    logger.debug('SEND: \n', JSON.stringify(msg, null, 2), '\n')
+    logger.trace('SEND: \n', JSON.stringify(msg, null, 2), '\n')
     this._socket!.send(JSON.stringify(msg))
 
     return timeoutPromise(
@@ -237,7 +237,7 @@ export class BaseSession {
 
   protected _onSocketMessage(event: MessageEvent) {
     const payload: any = safeParseJson(event.data)
-    logger.debug('RECV: \n', JSON.stringify(payload, null, 2), '\n')
+    logger.trace('RECV: \n', JSON.stringify(payload, null, 2), '\n')
     const request = this._requests.get(payload.id)
     if (request) {
       const { rpcRequest, resolve, reject } = request

--- a/packages/core/src/redux/features/session/sessionSaga.ts
+++ b/packages/core/src/redux/features/session/sessionSaga.ts
@@ -332,7 +332,7 @@ export function* sessionChannelWatcher({
     } catch (error) {
       logger.error('sessionChannelWorker error:', error)
     } finally {
-      logger.warn('sessionChannelWorker finally')
+      logger.debug('sessionChannelWorker finally')
     }
   }
 }

--- a/packages/core/src/setupTests.ts
+++ b/packages/core/src/setupTests.ts
@@ -7,6 +7,7 @@ jest.mock('./utils', () => {
       log: jest.fn(),
       info: jest.fn(),
       debug: jest.fn(),
+      trace: jest.fn(),
       levels: jest.fn(),
       setLevel: jest.fn(),
     },

--- a/packages/core/src/utils/interfaces.ts
+++ b/packages/core/src/utils/interfaces.ts
@@ -67,6 +67,8 @@ export interface SessionOptions {
   project?: string
   token: string
   autoConnect?: boolean
+  // From `LogLevelDesc` of loglevel to simplify our docs
+  logLevel?: 'trace' | 'debug' | 'info' | 'warn' | 'error' | 'silent'
 }
 
 export interface UserOptions extends SessionOptions {

--- a/packages/core/src/utils/logger.ts
+++ b/packages/core/src/utils/logger.ts
@@ -15,6 +15,11 @@ logger.methodFactory = (methodName, logLevel, loggerName) => {
     rawMethod.apply(undefined, messages)
   }
 }
-logger.setLevel(logger.getLevel())
+
+const level =
+  'development' === process.env.NODE_ENV
+    ? logger.levels.DEBUG
+    : logger.getLevel()
+logger.setLevel(level)
 
 export { logger }

--- a/packages/webrtc/src/BaseConnection.ts
+++ b/packages/webrtc/src/BaseConnection.ts
@@ -111,7 +111,7 @@ export class BaseConnection
     }
 
     this.setState('new')
-    logger.info('New Call with Options:', this.options)
+    logger.debug('New Call with Options:', this.options)
   }
 
   get active() {

--- a/packages/webrtc/src/RTCPeer.ts
+++ b/packages/webrtc/src/RTCPeer.ts
@@ -23,7 +23,7 @@ export default class RTCPeer {
 
   constructor(public call: BaseConnection, public type: RTCSdpType) {
     this.options = call.options
-    logger.info('New Peer with type:', this.type, 'Options:', this.options)
+    logger.debug('New Peer with type:', this.type, 'Options:', this.options)
 
     this._onIce = this._onIce.bind(this)
     this.instance = RTCPeerConnection(this.config)
@@ -81,7 +81,7 @@ export default class RTCPeer {
       sdpSemantics: 'unified-plan',
       ...rtcPeerConfig,
     }
-    logger.info('RTC config', config)
+    logger.debug('RTC config', config)
     return config
   }
 
@@ -251,7 +251,7 @@ export default class RTCPeer {
       this.instance.addEventListener('icecandidate', this._onIce)
 
       if (this.isOffer) {
-        logger.info('Trying to generate offer')
+        logger.debug('Trying to generate offer')
         const offer = await this.instance.createOffer({
           /**
            * While this property is deprected, on Browsers where this
@@ -265,7 +265,7 @@ export default class RTCPeer {
       }
 
       if (this.isAnswer) {
-        logger.info('Trying to generate answer')
+        logger.debug('Trying to generate answer')
         await this._setRemoteDescription({
           sdp: this.options.remoteSdp,
           type: 'offer',
@@ -390,11 +390,11 @@ export default class RTCPeer {
     }
     const { sdp, type } = this.instance.localDescription
     if (sdp.indexOf('candidate') === -1) {
-      logger.info('No candidate - retry \n')
+      logger.debug('No candidate - retry \n')
       this.startNegotiation(true)
       return
     }
-    logger.info('LOCAL SDP \n', `Type: ${type}`, '\n\n', sdp)
+    logger.debug('LOCAL SDP \n', `Type: ${type}`, '\n\n', sdp)
     this.instance.removeEventListener('icecandidate', this._onIce)
     this.call.onLocalSDPReady(this.instance.localDescription)
   }
@@ -407,7 +407,7 @@ export default class RTCPeer {
       )
     }
     if (event.candidate) {
-      logger.info('IceCandidate:', event.candidate)
+      logger.debug('IceCandidate:', event.candidate)
       this.call.emit('icecandidate', event)
     } else {
       this._sdpReady()
@@ -477,7 +477,7 @@ export default class RTCPeer {
 
   private _attachListeners() {
     this.instance.addEventListener('signalingstatechange', () => {
-      logger.info('signalingState:', this.instance.signalingState)
+      logger.debug('signalingState:', this.instance.signalingState)
 
       switch (this.instance.signalingState) {
         case 'stable':
@@ -500,11 +500,11 @@ export default class RTCPeer {
     })
 
     this.instance.addEventListener('iceconnectionstatechange', () => {
-      logger.info('iceConnectionState:', this.instance.iceConnectionState)
+      logger.debug('iceConnectionState:', this.instance.iceConnectionState)
     })
 
     this.instance.addEventListener('icegatheringstatechange', () => {
-      logger.info('iceGatheringState:', this.instance.iceGatheringState)
+      logger.debug('iceGatheringState:', this.instance.iceGatheringState)
     })
 
     // this.instance.addEventListener('icecandidateerror', (event) => {

--- a/packages/webrtc/src/utils/webrtcHelpers.ts
+++ b/packages/webrtc/src/utils/webrtcHelpers.ts
@@ -125,10 +125,10 @@ export const setMediaElementSinkId = async (
   deviceId: string
 ): Promise<undefined> => {
   if (el === null) {
-    logger.info('No HTMLMediaElement to attach the speakerId')
+    logger.warn('No HTMLMediaElement to attach the speakerId')
     return
   } else if (typeof deviceId !== 'string') {
-    logger.info(`Invalid speaker deviceId: '${deviceId}'`)
+    logger.warn(`Invalid speaker deviceId: '${deviceId}'`)
     return
   } else if (!supportsMediaOutput()) {
     logger.warn('Browser does not support output device selection.')


### PR DESCRIPTION
In this PR i changed some `logger.debug` to be `logger.trace` and set the level to `'debug'` for the development build.

It also includes a new field `logLevel` so we can change it for production builds too.