### PR TITLE
Remove option to `autoConnect` from `createWebSocketClient`

### DIFF
--- a/.changeset/few-pets-obey.md
+++ b/.changeset/few-pets-obey.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/node': patch
+---
+
+Remove option to `autoConnect` from the websocket client

--- a/packages/node/examples/ts-vanilla-websockets/index.ts
+++ b/packages/node/examples/ts-vanilla-websockets/index.ts
@@ -6,9 +6,6 @@ async function run() {
       host: 'relay.swire.io',
       project: '<project-id>',
       token: '<project-token>',
-      // TODO: this shouldn't be an option since we need to handle
-      // .on() calls
-      // autoConnect: true,
     })
 
     // @ts-ignore

--- a/packages/node/src/createWebSocketClient.ts
+++ b/packages/node/src/createWebSocketClient.ts
@@ -9,7 +9,11 @@ import StrictEventEmitter from 'strict-event-emitter-types'
 import { Client } from './Client'
 import { Session } from './Session'
 
-export const createWebSocketClient = async (userOptions: UserOptions) => {
+type CreateWebSocketClientOptions = Omit<UserOptions, 'autoConnect'>
+
+export const createWebSocketClient = async (
+  userOptions: CreateWebSocketClientOptions
+) => {
   const baseUserOptions = {
     ...userOptions,
     emitter: getEventEmitter<ClientEvents>(userOptions),
@@ -32,8 +36,5 @@ export const createWebSocketClient = async (userOptions: UserOptions) => {
     },
   })(baseUserOptions)
 
-  if (baseUserOptions.autoConnect) {
-    await client.connect()
-  }
   return client
 }


### PR DESCRIPTION
The code in this changeset removes the option to `autoConnect` when using `createWebSocketClient`. The reason behind this change is to avoid having to call individual `.connect()` per product namespace (something like `client.video.connect()`) since we need to `subscribe` to all the events the user has attached `on()` (and we wouldn't have a way to know when the dev is "done" attaching event listeners). This way an individual call to `client.connect()` will take care of initializing all the namespaces at once.

Related ticket: https://github.com/signalwire/cloud-support/issues/1162