### PR TITLE
Node typings + change on global events

### DIFF
--- a/.changeset/cuddly-doors-visit.md
+++ b/.changeset/cuddly-doors-visit.md
@@ -1,0 +1,6 @@
+---
+'@signalwire/core': patch
+'@signalwire/node': patch
+---
+
+Add typings for the RealTime video and room event listenres.

--- a/.changeset/cuddly-doors-visit.md
+++ b/.changeset/cuddly-doors-visit.md
@@ -1,6 +1,7 @@
 ---
 '@signalwire/core': patch
 '@signalwire/node': patch
+'@signalwire/webrtc': patch
 ---
 
 Add typings for the RealTime video and room event listenres.

--- a/packages/core/src/BaseComponent.ts
+++ b/packages/core/src/BaseComponent.ts
@@ -71,7 +71,7 @@ export class BaseComponent implements Emitter {
       typeof event === 'string' &&
       !event.startsWith(this._eventsPrefix)
     ) {
-      return `${this._eventsPrefix}${event}`
+      return `${this._eventsPrefix}.${event}`
     }
 
     return event

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,6 +6,7 @@ import { BaseClient } from './BaseClient'
 import { BaseComponent } from './BaseComponent'
 import { EventEmitter, getEventEmitter } from './utils/EventEmitter'
 import * as sessionSelectors from './redux/features/session/sessionSelectors'
+import { GLOBAL_VIDEO_EVENTS } from './utils/constants'
 
 export {
   uuid,
@@ -19,6 +20,7 @@ export {
   EventEmitter,
   getEventEmitter,
   isGlobalEvent,
+  GLOBAL_VIDEO_EVENTS,
 }
 
 export * from './RPCMessages'

--- a/packages/core/src/redux/features/pubSub/pubSubSaga.ts
+++ b/packages/core/src/redux/features/pubSub/pubSubSaga.ts
@@ -1,6 +1,6 @@
 import { SagaIterator } from 'redux-saga'
 import { take } from '@redux-saga/core/effects'
-import { logger, isGlobalEvent } from '../../../utils'
+import { logger, isInternalGlobalEvent } from '../../../utils'
 import type { Emitter } from '../../../utils/interfaces'
 import { getNamespacedEvent } from '../../../utils/EventEmitter'
 import { PubSubChannel, PubSubAction } from '../../interfaces'
@@ -35,7 +35,7 @@ export function* pubSubSaga({
        * (non-namespaced/global Event Emitter) so we must trigger the
        * event twice to reach everyone.
        */
-      if (isGlobalEvent(type)) {
+      if (isInternalGlobalEvent(type)) {
         emitter.emit(type, payload)
       }
 

--- a/packages/core/src/utils/constants.ts
+++ b/packages/core/src/utils/constants.ts
@@ -11,7 +11,7 @@ export enum WebSocketState {
   CLOSED = 3,
 }
 
-const PRODUCT_PREFIX_VIDEO = 'video'
+export const PRODUCT_PREFIX_VIDEO = 'video'
 
 export const GLOBAL_VIDEO_EVENTS = ['room.started', 'room.ended'] as const
 

--- a/packages/core/src/utils/constants.ts
+++ b/packages/core/src/utils/constants.ts
@@ -13,10 +13,6 @@ export enum WebSocketState {
 
 const PRODUCT_PREFIX_VIDEO = 'video'
 
-/**
- * Events that are consumed by the user of this library when listening
- * for global events from a client instance.
- */
 export const GLOBAL_VIDEO_EVENTS = ['room.started', 'room.ended'] as const
 
 /**

--- a/packages/core/src/utils/constants.ts
+++ b/packages/core/src/utils/constants.ts
@@ -11,7 +11,21 @@ export enum WebSocketState {
   CLOSED = 3,
 }
 
-export const GLOBAL_VIDEO_EVENTS = [
-  'video.room.started',
-  'video.room.ended',
-] as const
+const PRODUCT_PREFIX_VIDEO = 'video'
+
+/**
+ * Events that are consumed by the user of this library when listening
+ * for global events from a client instance.
+ */
+export const GLOBAL_VIDEO_EVENTS = ['room.started', 'room.ended'] as const
+
+/**
+ * For internal usage only. These are the fully qualified event names
+ * sent by the server
+ * @internal
+ */
+export const INTERNAL_GLOBAL_VIDEO_EVENTS = GLOBAL_VIDEO_EVENTS.map(
+  (event) => `${PRODUCT_PREFIX_VIDEO}.${event}` as const
+)
+
+export const PRODUCT_PREFIXES = [PRODUCT_PREFIX_VIDEO] as const

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -1,4 +1,8 @@
-import { STORAGE_PREFIX, GLOBAL_VIDEO_EVENTS } from './constants'
+import {
+  STORAGE_PREFIX,
+  GLOBAL_VIDEO_EVENTS,
+  INTERNAL_GLOBAL_VIDEO_EVENTS,
+} from './constants'
 
 export { v4 as uuid } from 'uuid'
 export { logger } from './logger'
@@ -47,9 +51,16 @@ export const timeoutPromise = (
   ]).finally(() => clearTimeout(timer))
 }
 
+/** @internal */
 export const isGlobalEvent = (event: string) => {
   // @ts-ignore
   return GLOBAL_VIDEO_EVENTS.includes(event)
+}
+
+/** @internal */
+export const isInternalGlobalEvent = (event: string) => {
+  // @ts-ignore
+  return INTERNAL_GLOBAL_VIDEO_EVENTS.includes(event)
 }
 
 export const getGlobalEvents = (kind: 'all' | 'video' = 'all') => {

--- a/packages/core/src/utils/interfaces.ts
+++ b/packages/core/src/utils/interfaces.ts
@@ -1,7 +1,11 @@
 import type { EventEmitter } from '../utils/EventEmitter'
 import { BaseSession } from '../BaseSession'
 import { SDKStore } from '../redux'
-import { GLOBAL_VIDEO_EVENTS } from './constants'
+import {
+  GLOBAL_VIDEO_EVENTS,
+  INTERNAL_GLOBAL_VIDEO_EVENTS,
+  PRODUCT_PREFIXES,
+} from './constants'
 
 /**
  * Minimal interface the emitter must fulfill
@@ -207,13 +211,17 @@ export type ExecuteTransform<InputType = unknown, OutputType = unknown> = (
   payload: InputType
 ) => OutputType
 
-export type GlobalVideoEvents = typeof GLOBAL_VIDEO_EVENTS[number]
-
 export type RoomCustomMethods<T> = {
   [k in keyof T]: PropertyDescriptor
 }
 
-export type EventsPrefix = '' | 'video.'
+export type EventsPrefix = '' | typeof PRODUCT_PREFIXES[number]
+/**
+ * See {@link GLOBAL_VIDEO_EVENTS} for the full list of events.
+ */
+export type GlobalVideoEvents = typeof GLOBAL_VIDEO_EVENTS[number]
+export type InternalGlobalVideoEvents =
+  typeof INTERNAL_GLOBAL_VIDEO_EVENTS[number]
 
 export type EventTransform = <InputType>(
   handler: any

--- a/packages/node/examples/ts-vanilla-websockets/index.ts
+++ b/packages/node/examples/ts-vanilla-websockets/index.ts
@@ -13,29 +13,15 @@ async function run() {
         console.log('---> MEMBER TALKING!!!')
       })
 
-      room.on('member.joined', (payload: any) => {
+      room.on('member.joined', (payload) => {
         console.log('---> member.joined', payload)
       })
 
       room.run()
 
-      // TODO: remove this once we figure out why this is happening.
-      // Note: This returns empty member list
-      // room.getMembers().then((payload: any) => {
-      //   console.log('---> Members', JSON.stringify(payload, null, 2))
-      // })
-
-      // Note: This returns the proper list
-      // setTimeout(() => {
-      //   room.getMembers().then((payload: any) => {
-      //     console.log('---> Members', JSON.stringify(payload, null, 2))
-      //   })
-      // }, 3000)
-
       console.log('🟢 ROOOM STARTED 🟢')
     })
 
-    // @ts-ignore
     client.video.on('room.ended', () => {
       console.log('🔴 ROOOM ENDED 🔴')
     })

--- a/packages/node/examples/ts-vanilla-websockets/index.ts
+++ b/packages/node/examples/ts-vanilla-websockets/index.ts
@@ -8,7 +8,6 @@ async function run() {
       token: '<project-token>',
     })
 
-    // @ts-ignore
     client.video.on('room.started', (room) => {
       room.on('member.talking', () => {
         console.log('---> MEMBER TALKING!!!')

--- a/packages/node/src/Client.ts
+++ b/packages/node/src/Client.ts
@@ -4,6 +4,7 @@ import {
   SessionState,
   GlobalVideoEvents,
   connect,
+  EventsPrefix,
 } from '@signalwire/core'
 import { Video } from './Video'
 import { RealTimeVideoApiEvents } from './types/video'
@@ -13,10 +14,8 @@ interface Consumer {
   run: () => Promise<unknown>
 }
 
-type ClientNamespaces = 'video'
-
 export class Client extends BaseClient {
-  private _consumers: Map<ClientNamespaces, Consumer> = new Map()
+  private _consumers: Map<EventsPrefix, Consumer> = new Map()
 
   async onAuth(session: SessionState) {
     if (session.authStatus === 'authorized') {

--- a/packages/node/src/Client.ts
+++ b/packages/node/src/Client.ts
@@ -6,7 +6,7 @@ import {
   connect,
 } from '@signalwire/core'
 import { Video } from './Video'
-import { RelayVideoApiEvents } from './types/video'
+import { RealTimeVideoApiEvents } from './types/video'
 
 interface Consumer {
   on: (event: GlobalVideoEvents, handler: any) => void
@@ -26,7 +26,7 @@ export class Client extends BaseClient {
     }
   }
 
-  get video(): StrictEventEmitter<Video, RelayVideoApiEvents> {
+  get video(): StrictEventEmitter<Video, RealTimeVideoApiEvents> {
     if (this._consumers.has('video')) {
       return this._consumers.get('video') as Video
     }

--- a/packages/node/src/Room.ts
+++ b/packages/node/src/Room.ts
@@ -2,7 +2,7 @@ import { Rooms, RoomCustomMethods } from '@signalwire/core'
 import { BaseConsumer } from './BaseConsumer'
 
 class Room extends BaseConsumer {
-  protected _eventsPrefix = 'video.' as const
+  protected _eventsPrefix = 'video' as const
 
   // This is needed for the custom methods.
   roomSessionId = this.options.namespace

--- a/packages/node/src/Video.ts
+++ b/packages/node/src/Video.ts
@@ -4,7 +4,7 @@ import { Room } from './Room'
 
 class Video extends BaseConsumer {
   /** @internal */
-  protected _eventsPrefix = 'video.' as const
+  protected _eventsPrefix = 'video' as const
   /** @internal */
   protected subscribeParams = {
     get_initial_state: true,

--- a/packages/node/src/types/video.ts
+++ b/packages/node/src/types/video.ts
@@ -1,13 +1,49 @@
-import type { GlobalVideoEvents } from '@signalwire/core'
+import StrictEventEmitter from 'strict-event-emitter-types'
+import type {
+  GlobalVideoEvents,
+  RoomEventNames,
+  LayoutEvent,
+  MemberJoinedEventName,
+  MemberLeftEventName,
+  MemberUpdatedEventName,
+  MemberUpdatedEventNames,
+  MemberTalkingEventNames,
+  RoomEvent,
+} from '@signalwire/core'
 import { Room } from '../Room'
 
-type RealTimeVideoApiGlobalEvents = GlobalVideoEvents
+// `Video` namespace related typings
+export type RealTimeVideoApiGlobalEvents = GlobalVideoEvents
 
-export type EventsHandlerMapping = Record<
+export type RealTimeVideoApiEventsHandlerMapping = Record<
   RealTimeVideoApiGlobalEvents,
-  (room: Room) => void
+  (room: StrictEventEmitter<Room, RealTimeRoomApiEvents>) => void
 >
 
 export type RealTimeVideoApiEvents = {
-  [k in RealTimeVideoApiGlobalEvents]: EventsHandlerMapping[k]
+  [k in RealTimeVideoApiGlobalEvents]: RealTimeVideoApiEventsHandlerMapping[k]
+}
+
+// `Room` related typings
+export type RealTimeRoomApiEventNames = Exclude<RoomEventNames, 'track'>
+
+// TODO: replace `any` with proper types.
+export type RealTimeRoomApiEventsHandlerMapping = Record<
+  LayoutEvent,
+  (layout: any) => void
+> &
+  Record<MemberJoinedEventName, (member: any) => void> &
+  Record<MemberLeftEventName, (member: any) => void> &
+  Record<
+    MemberUpdatedEventName | MemberUpdatedEventNames,
+    (member: any) => void
+  > &
+  Record<MemberTalkingEventNames, (member: any) => void> &
+  Record<
+    RoomEvent,
+    (room: StrictEventEmitter<Room, RealTimeRoomApiEvents>) => void
+  >
+
+export type RealTimeRoomApiEvents = {
+  [k in RealTimeRoomApiEventNames]: RealTimeRoomApiEventsHandlerMapping[k]
 }

--- a/packages/node/src/types/video.ts
+++ b/packages/node/src/types/video.ts
@@ -24,7 +24,7 @@ export type RealTimeVideoApiEvents = {
   [k in RealTimeVideoApiGlobalEvents]: RealTimeVideoApiEventsHandlerMapping[k]
 }
 
-// `Room` related typings
+// `Room`, `Member`, etc. related typings
 export type RealTimeRoomApiEventNames = Exclude<RoomEventNames, 'track'>
 
 // TODO: replace `any` with proper types.

--- a/packages/node/src/types/video.ts
+++ b/packages/node/src/types/video.ts
@@ -1,11 +1,13 @@
 import type { GlobalVideoEvents } from '@signalwire/core'
 import { Room } from '../Room'
 
+type RealTimeVideoApiGlobalEvents = GlobalVideoEvents
+
 export type EventsHandlerMapping = Record<
-  GlobalVideoEvents,
+  RealTimeVideoApiGlobalEvents,
   (room: Room) => void
 >
 
-export type RelayVideoApiEvents = {
-  [k in GlobalVideoEvents]: EventsHandlerMapping[k]
+export type RealTimeVideoApiEvents = {
+  [k in RealTimeVideoApiGlobalEvents]: EventsHandlerMapping[k]
 }

--- a/packages/webrtc/src/BaseConnection.ts
+++ b/packages/webrtc/src/BaseConnection.ts
@@ -89,7 +89,7 @@ export class BaseConnection
   public doReinvite = false
 
   /** @internal */
-  protected _eventsPrefix = 'video.' as const
+  protected _eventsPrefix = 'video' as const
 
   private state: BaseConnectionState = 'new'
   private prevState: BaseConnectionState = 'new'


### PR DESCRIPTION
The code in this changeset includes:

1. Add proper types for `client.Video` and `Room` object being sent on room events (`room.started`).
2. Split global events between user-facing and internal.
3. Changed the way we defined `_eventsPrefix` to not include the trailing `.`
4. Add typing structure to be able type the event handlers for `Member`, `Layout`, etc.