### PR TITLE
Remove BaseComponent "id" property

### DIFF
--- a/.changeset/five-crabs-try.md
+++ b/.changeset/five-crabs-try.md
@@ -1,0 +1,7 @@
+---
+'@signalwire/core': patch
+'@signalwire/js': patch
+'@signalwire/webrtc': patch
+---
+
+Internal refactor to allow children objects to use `id` as a property.

--- a/.changeset/five-crabs-try.md
+++ b/.changeset/five-crabs-try.md
@@ -1,7 +1,5 @@
 ---
 '@signalwire/core': patch
-'@signalwire/js': patch
-'@signalwire/webrtc': patch
 ---
 
 Internal refactor to allow children objects to use `id` as a property.

--- a/packages/core/src/BaseComponent.ts
+++ b/packages/core/src/BaseComponent.ts
@@ -37,11 +37,11 @@ const identity: ExecuteTransform<any, any> = (payload) => payload
 
 export class BaseComponent implements Emitter {
   /** @internal */
-  readonly #uuid = uuid()
+  private readonly uuid = uuid()
 
   /** @internal */
   get __uuid() {
-    return this.#uuid
+    return this.uuid
   }
 
   /** @internal */

--- a/packages/core/src/BaseComponent.ts
+++ b/packages/core/src/BaseComponent.ts
@@ -36,7 +36,11 @@ type EventRegisterHandlers =
 const identity: ExecuteTransform<any, any> = (payload) => payload
 
 export class BaseComponent implements Emitter {
-  id = uuid()
+  readonly #uuid = uuid()
+
+  get __uuid() {
+    return this.#uuid
+  }
 
   /** @internal */
   protected _eventsPrefix: EventsPrefix = ''
@@ -280,7 +284,7 @@ export class BaseComponent implements Emitter {
       this.store.dispatch(
         executeAction({
           requestId,
-          componentId: this.id,
+          componentId: this.__uuid,
           method,
           params,
         })
@@ -296,7 +300,7 @@ export class BaseComponent implements Emitter {
 
       this.store.dispatch({
         dispatchId,
-        ...makeCustomSagaAction(this.id, action),
+        ...makeCustomSagaAction(this.__uuid, action),
       })
     })
   }

--- a/packages/core/src/BaseComponent.ts
+++ b/packages/core/src/BaseComponent.ts
@@ -36,8 +36,10 @@ type EventRegisterHandlers =
 const identity: ExecuteTransform<any, any> = (payload) => payload
 
 export class BaseComponent implements Emitter {
+  /** @internal */
   readonly #uuid = uuid()
 
+  /** @internal */
   get __uuid() {
     return this.#uuid
   }

--- a/packages/core/src/redux/connect.test.ts
+++ b/packages/core/src/redux/connect.test.ts
@@ -29,12 +29,12 @@ describe('Connect', () => {
     mockOnRemoteSDP.mockClear()
 
     updateStateAction = componentActions.upsert({
-      id: instance.id,
+      id: instance.__uuid,
       state: 'active',
     })
 
     updateRemoteSDPAction = componentActions.upsert({
-      id: instance.id,
+      id: instance.__uuid,
       remoteSDP: '<SDP>',
     })
   })
@@ -44,7 +44,7 @@ describe('Connect', () => {
 
     expect(instance.emit).toHaveBeenCalledTimes(1)
     expect(instance.emit).toHaveBeenCalledWith({
-      id: instance.id,
+      id: instance.__uuid,
       state: 'active',
     })
   })
@@ -70,7 +70,7 @@ describe('Connect', () => {
 
     expect(mockOnRemoteSDP).toHaveBeenCalledTimes(1)
     expect(mockOnRemoteSDP).toHaveBeenCalledWith({
-      id: instance.id,
+      id: instance.__uuid,
       remoteSDP: '<SDP>',
     })
   })

--- a/packages/js/src/Room.ts
+++ b/packages/js/src/Room.ts
@@ -53,7 +53,7 @@ class Room extends BaseConnection implements BaseRoomInterface {
       remoteStream: undefined,
       userVariables: {
         ...(this.options?.userVariables || {}),
-        memberCallId: this.id,
+        memberCallId: this.__uuid,
         memberId: this.memberId,
       },
     }
@@ -135,7 +135,7 @@ class Room extends BaseConnection implements BaseRoomInterface {
       recoverCall: false,
       userVariables: {
         ...(this.options?.userVariables || {}),
-        memberCallId: this.id,
+        memberCallId: this.__uuid,
         memberId: this.memberId,
       },
     }

--- a/packages/js/src/features/mediaElements/mediaElementsSagas.ts
+++ b/packages/js/src/features/mediaElements/mediaElementsSagas.ts
@@ -116,7 +116,7 @@ function* audioElementActionsWatcher({
   // we might want to have a single action per custom saga and use it
   // in a similar fashion to `executeAction`
   const setSpeakerActionType = actions.getCustomSagaActionType(
-    room.id,
+    room.__uuid,
     audioSetSpeakerAction
   )
 

--- a/packages/webrtc/src/BaseConnection.ts
+++ b/packages/webrtc/src/BaseConnection.ts
@@ -114,6 +114,10 @@ export class BaseConnection
     logger.debug('New Call with Options:', this.options)
   }
 
+  get id() {
+    return this.__uuid
+  }
+
   get active() {
     return this.state === 'active'
   }
@@ -158,7 +162,7 @@ export class BaseConnection
     return {
       sessid: this.options.sessionid,
       dialogParams: {
-        id: this.id,
+        id: this.__uuid,
         destinationNumber,
         attach,
         callerName,
@@ -334,7 +338,7 @@ export class BaseConnection
       try {
         logger.debug(
           'updateConstraints trying constraints',
-          this.id,
+          this.__uuid,
           constraints
         )
         if (!Object.keys(constraints).length) {


### PR DESCRIPTION
This PR _replace_ `id` with `__uuid` on `BaseComponent` to allow us to use `id` on children objects while keeping `__uuid` as internal only.