### PR TITLE
Add `toExternalJSON` for formatting end user payload

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,4 @@
-import { uuid, logger, isGlobalEvent, toCamelCaseObject } from './utils'
+import { uuid, logger, isGlobalEvent, toExternalJSON } from './utils'
 import { BaseSession } from './BaseSession'
 import { BaseJWTSession } from './BaseJWTSession'
 import { configureStore, connect } from './redux'
@@ -20,7 +20,7 @@ export {
   EventEmitter,
   getEventEmitter,
   isGlobalEvent,
-  toCamelCaseObject,
+  toExternalJSON,
   GLOBAL_VIDEO_EVENTS,
 }
 

--- a/packages/core/src/utils/index.test.ts
+++ b/packages/core/src/utils/index.test.ts
@@ -1,4 +1,4 @@
-import { checkWebSocketHost, timeoutPromise, toCamelCaseObject } from './'
+import { checkWebSocketHost, timeoutPromise } from './'
 
 describe('checkWebSocketHost', () => {
   it('should add wss protocol if not present', () => {
@@ -34,29 +34,5 @@ describe('timeoutPromise', () => {
     const promise = new Promise(() => null)
     const error = 'ERROR'
     await expect(timeoutPromise(promise, 5, error)).rejects.toEqual(error)
-  })
-})
-
-describe('toCamelCaseObject', () => {
-  it('converts all the keys from snake_case to camelCase', async () => {
-    const input = {
-      snake_case: 'test',
-      camelCase: 'test',
-      PascalCase: 'test',
-      'kebab-case': 'test',
-      flat: 'test',
-      UPPERCASE: 'test',
-      _private: 'test',
-    }
-    const output = {
-      snakeCase: 'test',
-      camelCase: 'test',
-      PascalCase: 'test',
-      'kebab-case': 'test',
-      flat: 'test',
-      UPPERCASE: 'test',
-      _private: 'test',
-    }
-    expect(toCamelCaseObject(input)).toStrictEqual(output)
   })
 })

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -7,6 +7,7 @@ import {
 export { v4 as uuid } from 'uuid'
 export { logger } from './logger'
 export * from './parseRPCResponse'
+export * from './toExternalJSON'
 
 export const mutateStorageKey = (key: string) => `${STORAGE_PREFIX}${key}`
 
@@ -63,30 +64,4 @@ export const getGlobalEvents = (kind: 'all' | 'video' = 'all') => {
         ...GLOBAL_VIDEO_EVENTS,
       ]
   }
-}
-
-/**
- * Converts values from snake_case to camelCase
- * @internal
- */
-const fromSnakeToCamelCase = (input: string) => {
-  return input.split('_').reduce((reducer, part, index) => {
-    const fc = part.trim().charAt(0)
-    const remainingChars = part.substr(1).toLowerCase()
-
-    return `${reducer}${
-      index === 0 ? fc.toLowerCase() : fc.toUpperCase()
-    }${remainingChars}`
-  }, '')
-}
-
-/**
- * Converts a record from snake_case to camelCase properties
- * @internal
- */
-export const toCamelCaseObject = (input: Record<string, unknown>) => {
-  return Object.entries(input).reduce((reducer, [key, value]) => {
-    reducer[fromSnakeToCamelCase(key)] = value
-    return reducer
-  }, {} as Record<string, unknown>)
 }

--- a/packages/core/src/utils/toExternalJSON.test.ts
+++ b/packages/core/src/utils/toExternalJSON.test.ts
@@ -1,0 +1,61 @@
+import { toExternalJSON } from './toExternalJSON'
+
+describe('toExternalJSON', () => {
+  it('converts all the keys from snake_case to camelCase', async () => {
+    const input = {
+      snake_case: 'test',
+      another_prop: null,
+      some_other_property: {
+        nested_property: {
+          nested_prop_2: 'nested prop value',
+        },
+        prop_2: 'test',
+      },
+    }
+
+    const output = {
+      snakeCase: 'test',
+      anotherProp: null,
+      someOtherProperty: {
+        nestedProperty: {
+          nestedProp2: 'nested prop value',
+        },
+        prop2: 'test',
+      },
+    }
+
+    expect(toExternalJSON(input)).toStrictEqual(output)
+  })
+
+  it('converts the values from `updated` keys to be camelCase', () => {
+    const input = {
+      updated: ['camel_case_prop_1', 'camel_case_prop_2', 'camel_case_prop_3'],
+    }
+
+    const output = {
+      updated: ['camelCaseProp1', 'camelCaseProp2', 'camelCaseProp3'],
+    }
+
+    expect(toExternalJSON(input)).toStrictEqual(output)
+  })
+
+  it('converts values for any specified property in `options.propsToUpdateValue`', () => {
+    const input = {
+      updated_two: [
+        'camel_case_prop_1',
+        'camel_case_prop_2',
+        'camel_case_prop_3',
+      ],
+    }
+
+    const output = {
+      updatedTwo: ['camelCaseProp1', 'camelCaseProp2', 'camelCaseProp3'],
+    }
+
+    expect(
+      toExternalJSON(input, {
+        propsToUpdateValue: ['updated_two'],
+      })
+    ).toStrictEqual(output)
+  })
+})

--- a/packages/node/src/Video.ts
+++ b/packages/node/src/Video.ts
@@ -1,4 +1,4 @@
-import { RoomCustomMethods, connect, toCamelCaseObject } from '@signalwire/core'
+import { RoomCustomMethods, connect, toExternalJSON } from '@signalwire/core'
 import { BaseConsumer } from './BaseConsumer'
 import { Room } from './Room'
 
@@ -34,7 +34,7 @@ class Video extends BaseConsumer {
           return room
         },
         payloadTransform: (payload: any) => {
-          return toCamelCaseObject(payload)
+          return toExternalJSON(payload)
         },
       },
     ],


### PR DESCRIPTION
The code in this changeset includes an improvement over the `toCamelCaseObject` to handle nested objects and to have the ability to process/convert certain values (on top of just properties, which we need for the `updated` property including all the properties that have been updated).

The change in name was to avoid creating confusion around `toCamelCaseObject` since that util was never meant to be a general purpose object casing conversion but something to cover our specific needs. 