### PR TITLE
Fix bug with cached instances in emitterTransforms

### DIFF
--- a/packages/core/src/BaseComponent.ts
+++ b/packages/core/src/BaseComponent.ts
@@ -167,6 +167,16 @@ export class BaseComponent implements Emitter {
         this._eventsTransformsCache.get(namespacedEvent),
         {
           get(target: any, prop: any, receiver: any) {
+            if (
+              prop === '_eventsNamespace' &&
+              transform.getInstanceEventNamespace
+            ) {
+              return transform.getInstanceEventNamespace(payload)
+            }
+            if (prop === 'eventChannel' && transform.getInstanceEventChannel) {
+              return transform.getInstanceEventChannel(payload)
+            }
+
             if (prop in transformedPayload) {
               return transformedPayload[prop]
             }
@@ -224,7 +234,7 @@ export class BaseComponent implements Emitter {
     const [event, fn, context] = this._getOptionsFromParams(params)
     const handler = this.applyEventHandlerTransform(event, fn)
     const namespacedEvent = this._getNamespacedEvent(event)
-    logger.trace('Registering event', namespacedEvent)
+    // logger.debug('Registering event', event, namespacedEvent)
     this.trackEvent(event)
     return this.emitter.on(namespacedEvent, handler, context)
   }

--- a/packages/core/src/BaseComponent.ts
+++ b/packages/core/src/BaseComponent.ts
@@ -234,7 +234,7 @@ export class BaseComponent implements Emitter {
     const [event, fn, context] = this._getOptionsFromParams(params)
     const handler = this.applyEventHandlerTransform(event, fn)
     const namespacedEvent = this._getNamespacedEvent(event)
-    logger.trace('Registering event', event, namespacedEvent)
+    logger.trace('Registering event', namespacedEvent)
     this.trackEvent(event)
     return this.emitter.on(namespacedEvent, handler, context)
   }

--- a/packages/core/src/BaseComponent.ts
+++ b/packages/core/src/BaseComponent.ts
@@ -234,7 +234,7 @@ export class BaseComponent implements Emitter {
     const [event, fn, context] = this._getOptionsFromParams(params)
     const handler = this.applyEventHandlerTransform(event, fn)
     const namespacedEvent = this._getNamespacedEvent(event)
-    // logger.debug('Registering event', event, namespacedEvent)
+    logger.trace('Registering event', event, namespacedEvent)
     this.trackEvent(event)
     return this.emitter.on(namespacedEvent, handler, context)
   }

--- a/packages/core/src/utils/interfaces.ts
+++ b/packages/core/src/utils/interfaces.ts
@@ -226,6 +226,8 @@ export type InternalGlobalVideoEvents =
 export interface EventTransform {
   instanceFactory: (payload: any) => any
   payloadTransform: (payload: any) => any
+  getInstanceEventNamespace?: (payload: any) => string
+  getInstanceEventChannel?: (payload: any) => string
 }
 
 export type BaseEventHandler = (...args: any[]) => void

--- a/packages/realtime-api/examples/ts-vanilla-websockets/package-lock.json
+++ b/packages/realtime-api/examples/ts-vanilla-websockets/package-lock.json
@@ -1,0 +1,12 @@
+{
+  "name": "ts-websocket",
+  "version": "0.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "ts-websocket",
+      "version": "0.0.0"
+    }
+  }
+}

--- a/packages/realtime-api/examples/ts-vanilla-websockets/package.json
+++ b/packages/realtime-api/examples/ts-vanilla-websockets/package.json
@@ -1,5 +1,6 @@
 {
   "name": "ts-websocket",
+  "private": true,
   "version": "0.0.0",
   "type": "module",
   "scripts": {

--- a/packages/realtime-api/jest.config.js
+++ b/packages/realtime-api/jest.config.js
@@ -2,4 +2,5 @@ module.exports = {
   transform: {
     '\\.[jt]sx?$': ['babel-jest', { configFile: './../../babel.config.js' }],
   },
+  setupFiles: ['./src/setupTests.ts'],
 }

--- a/packages/realtime-api/src/Video.test.ts
+++ b/packages/realtime-api/src/Video.test.ts
@@ -1,0 +1,115 @@
+import { connect, EventEmitter } from '@signalwire/core'
+import { configureJestStore } from './testUtils'
+import { Video } from './Video'
+
+describe('Member Object', () => {
+  let store: any
+  let video: Video
+
+  beforeEach(() => {
+    store = configureJestStore()
+    video = connect({
+      store,
+      Component: Video,
+      componentListeners: {
+        errors: 'onError',
+        responses: 'onSuccess',
+      },
+    })({
+      /**
+       * Events at this level will always be global so there's no need
+       * for a namespace.
+       */
+      namespace: '',
+      eventChannel: 'video.rooms',
+      store: store,
+      emitter: new EventEmitter(),
+    })
+    video.execute = jest.fn()
+  })
+
+  it('should not invoke execute without event listeners', async () => {
+    await video.run()
+    expect(video.execute).not.toHaveBeenCalled()
+  })
+
+  it('should invoke execute with event listeners', async () => {
+    video.on('event.here', jest.fn)
+    await video.run()
+    expect(video.execute).toHaveBeenCalledWith({
+      method: 'signalwire.subscribe',
+      params: {
+        get_initial_state: true,
+        event_channel: 'video.rooms',
+        events: ['video.event.here'],
+      },
+    })
+  })
+
+  describe('video.room.started event', () => {
+    const eventChannelOne = 'room.<uuid-one>'
+    const firstRoom = JSON.parse(
+      `{"jsonrpc":"2.0","id":"uuid1","method":"signalwire.event","params":{"params":{"room_session_id":"session-one","room_id":"room_id","room":{"room_id":"room_id","room_session_id":"session-one","name":"latest","event_channel":"${eventChannelOne}"}},"timestamp":1630004194.9456,"event_type":"video.room.started","event_channel":"video.rooms.78429ef1-283b-4fa9-8ebc-16b59f95bb1f"}}`
+    )
+    const eventChannelTwo = 'room.<uuid-one>'
+    const secondRoom = JSON.parse(
+      `{"jsonrpc":"2.0","id":"uuid1","method":"signalwire.event","params":{"params":{"room_session_id":"session-two","room_id":"room_id","room":{"room_id":"room_id","room_session_id":"session-two","name":"latest","event_channel":"${eventChannelTwo}"}},"timestamp":1630004194.9456,"event_type":"video.room.started","event_channel":"video.rooms.78429ef1-283b-4fa9-8ebc-16b59f95bb1f"}}`
+    )
+
+    it('should pass a Room obj to the handler', (done) => {
+      video.on('room.started', (room) => {
+        expect(room.videoMute).toBeDefined()
+        expect(room.videoUnmute).toBeDefined()
+        expect(room.getMembers).toBeDefined()
+        expect(room.run).toBeDefined()
+        done()
+      })
+
+      video.run()
+      video.emit('video.room.started', firstRoom.params.params)
+    })
+
+    it('each room object should use its own payload from the Proxy', async () => {
+      const mockExecute = jest.fn()
+      const promise = new Promise((resolve) => {
+        video.on('room.started', (room) => {
+          expect(room.videoMute).toBeDefined()
+          expect(room.videoUnmute).toBeDefined()
+          expect(room.getMembers).toBeDefined()
+          expect(room.run).toBeDefined()
+
+          room.on('event.here', jest.fn)
+          room.execute = mockExecute
+          room.run()
+
+          if (room.roomSessionId === 'session-two') {
+            resolve(undefined)
+          }
+        })
+      })
+
+      video.run()
+      video.emit('video.room.started', firstRoom.params.params)
+
+      video.emit('video.room.started', secondRoom.params.params)
+
+      await promise
+
+      expect(mockExecute).toHaveBeenCalledTimes(2)
+      expect(mockExecute).toHaveBeenNthCalledWith(1, {
+        method: 'signalwire.subscribe',
+        params: {
+          event_channel: eventChannelOne,
+          events: ['video.event.here'],
+        },
+      })
+      expect(mockExecute).toHaveBeenNthCalledWith(2, {
+        method: 'signalwire.subscribe',
+        params: {
+          event_channel: eventChannelTwo,
+          events: ['video.event.here'],
+        },
+      })
+    })
+  })
+})

--- a/packages/realtime-api/src/Video.test.ts
+++ b/packages/realtime-api/src/Video.test.ts
@@ -49,11 +49,11 @@ describe('Member Object', () => {
   describe('video.room.started event', () => {
     const eventChannelOne = 'room.<uuid-one>'
     const firstRoom = JSON.parse(
-      `{"jsonrpc":"2.0","id":"uuid1","method":"signalwire.event","params":{"params":{"room_session_id":"session-one","room_id":"room_id","room":{"room_id":"room_id","room_session_id":"session-one","name":"latest","event_channel":"${eventChannelOne}"}},"timestamp":1630004194.9456,"event_type":"video.room.started","event_channel":"video.rooms.78429ef1-283b-4fa9-8ebc-16b59f95bb1f"}}`
+      `{"jsonrpc":"2.0","id":"uuid1","method":"signalwire.event","params":{"params":{"room_session_id":"session-one","room_id":"room_id","room":{"room_id":"room_id","room_session_id":"session-one","name":"First Room","event_channel":"${eventChannelOne}"}},"timestamp":1630004194.9456,"event_type":"video.room.started","event_channel":"video.rooms.78429ef1-283b-4fa9-8ebc-16b59f95bb1f"}}`
     )
     const eventChannelTwo = 'room.<uuid-one>'
     const secondRoom = JSON.parse(
-      `{"jsonrpc":"2.0","id":"uuid1","method":"signalwire.event","params":{"params":{"room_session_id":"session-two","room_id":"room_id","room":{"room_id":"room_id","room_session_id":"session-two","name":"latest","event_channel":"${eventChannelTwo}"}},"timestamp":1630004194.9456,"event_type":"video.room.started","event_channel":"video.rooms.78429ef1-283b-4fa9-8ebc-16b59f95bb1f"}}`
+      `{"jsonrpc":"2.0","id":"uuid1","method":"signalwire.event","params":{"params":{"room_session_id":"session-two","room_id":"room_id","room":{"room_id":"room_id","room_session_id":"session-two","name":"Second Room","event_channel":"${eventChannelTwo}"}},"timestamp":1630004194.9456,"event_type":"video.room.started","event_channel":"video.rooms.78429ef1-283b-4fa9-8ebc-16b59f95bb1f"}}`
     )
 
     it('should pass a Room obj to the handler', (done) => {
@@ -71,6 +71,7 @@ describe('Member Object', () => {
 
     it('each room object should use its own payload from the Proxy', async () => {
       const mockExecute = jest.fn()
+      const mockNameCheck = jest.fn()
       const promise = new Promise((resolve) => {
         video.on('room.started', (room) => {
           expect(room.videoMute).toBeDefined()
@@ -81,6 +82,7 @@ describe('Member Object', () => {
           room.on('event.here', jest.fn)
           room.execute = mockExecute
           room.run()
+          mockNameCheck(room.name)
 
           if (room.roomSessionId === 'session-two') {
             resolve(undefined)
@@ -110,6 +112,11 @@ describe('Member Object', () => {
           events: ['video.event.here'],
         },
       })
+
+      // Check room.name exposed
+      expect(mockNameCheck).toHaveBeenCalledTimes(2)
+      expect(mockNameCheck).toHaveBeenNthCalledWith(1, 'First Room')
+      expect(mockNameCheck).toHaveBeenNthCalledWith(2, 'Second Room')
     })
   })
 })

--- a/packages/realtime-api/src/Video.ts
+++ b/packages/realtime-api/src/Video.ts
@@ -51,6 +51,12 @@ class Video extends BaseConsumer {
           payloadTransform: (payload: any) => {
             return toExternalJSON(payload)
           },
+          getInstanceEventNamespace: (payload: any) => {
+            return payload.room_session_id
+          },
+          getInstanceEventChannel: (payload: any) => {
+            return payload.room.event_channel
+          },
         },
       ],
     ])

--- a/packages/realtime-api/src/Video.ts
+++ b/packages/realtime-api/src/Video.ts
@@ -49,7 +49,7 @@ class Video extends BaseConsumer {
             return room
           },
           payloadTransform: (payload: any) => {
-            return toExternalJSON(payload)
+            return toExternalJSON(payload.room)
           },
           getInstanceEventNamespace: (payload: any) => {
             return payload.room_session_id

--- a/packages/realtime-api/src/setupTests.ts
+++ b/packages/realtime-api/src/setupTests.ts
@@ -1,0 +1,15 @@
+jest.mock('@signalwire/core', () => {
+  return {
+    ...jest.requireActual('@signalwire/core'),
+    logger: {
+      error: jest.fn(),
+      warn: jest.fn(),
+      log: jest.fn(),
+      info: jest.fn(),
+      debug: jest.fn(),
+      trace: jest.fn(),
+      levels: jest.fn(),
+      setLevel: jest.fn(),
+    },
+  }
+})

--- a/packages/realtime-api/src/testUtils.ts
+++ b/packages/realtime-api/src/testUtils.ts
@@ -1,0 +1,23 @@
+import { configureStore } from '@signalwire/core'
+import { Session } from './Session'
+
+const PROJECT_ID = '8f0a119a-cda7-4497-a47d-c81493b824d4'
+const TOKEN = '<VRT>'
+
+/**
+ * Helper method to configure a Store w/o Saga middleware.
+ * Useful to test slices and reducers logic.
+ *
+ * @returns Redux Store
+ */
+export const configureJestStore = () => {
+  return configureStore({
+    userOptions: {
+      project: PROJECT_ID,
+      token: TOKEN,
+      devTools: false,
+    },
+    SessionConstructor: Session,
+    runSagaMiddleware: false,
+  })
+}


### PR DESCRIPTION
This PR fixes an issue where, due to the cache logic, we were using _previous/old_ data for subsequent Room events. This affects Node.js only.