### PR TITLE
Cleanup cached transforms

### DIFF
--- a/.changeset/clean-rockets-teach.md
+++ b/.changeset/clean-rockets-teach.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/core': patch
+---
+
+Add cleanup logic for event handler transforms

--- a/package-lock.json
+++ b/package-lock.json
@@ -12475,7 +12475,7 @@
     },
     "packages/core": {
       "name": "@signalwire/core",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "license": "MIT",
       "dependencies": {
         "@reduxjs/toolkit": "^1.6.0",
@@ -12497,11 +12497,11 @@
     },
     "packages/js": {
       "name": "@signalwire/js",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "license": "MIT",
       "dependencies": {
-        "@signalwire/core": "3.1.0",
-        "@signalwire/webrtc": "3.1.0"
+        "@signalwire/core": "3.1.1",
+        "@signalwire/webrtc": "3.1.1"
       },
       "engines": {
         "node": ">=10"
@@ -12524,8 +12524,8 @@
       "version": "0.0.1-beta.4",
       "license": "MIT",
       "dependencies": {
-        "@signalwire/core": "3.1.0",
-        "@signalwire/webrtc": "3.1.0"
+        "@signalwire/core": "3.1.1",
+        "@signalwire/webrtc": "3.1.1"
       },
       "engines": {
         "node": ">=10"
@@ -12536,7 +12536,7 @@
       "version": "0.0.1-beta.4",
       "license": "MIT",
       "dependencies": {
-        "@signalwire/core": "3.1.0",
+        "@signalwire/core": "3.1.1",
         "ws": "^7.4.6"
       },
       "devDependencies": {
@@ -12570,7 +12570,7 @@
       "version": "0.0.1-beta.4",
       "license": "MIT",
       "dependencies": {
-        "@signalwire/core": "3.1.0",
+        "@signalwire/core": "3.1.1",
         "node-abort-controller": "^2.0.0",
         "node-fetch": "^2.6.1"
       },
@@ -12585,10 +12585,10 @@
     },
     "packages/webrtc": {
       "name": "@signalwire/webrtc",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "license": "MIT",
       "dependencies": {
-        "@signalwire/core": "3.1.0"
+        "@signalwire/core": "3.1.1"
       },
       "engines": {
         "node": ">=10"
@@ -14637,8 +14637,8 @@
     "@signalwire/js": {
       "version": "file:packages/js",
       "requires": {
-        "@signalwire/core": "3.1.0",
-        "@signalwire/webrtc": "3.1.0"
+        "@signalwire/core": "3.1.1",
+        "@signalwire/webrtc": "3.1.1"
       }
     },
     "@signalwire/node": {
@@ -14651,14 +14651,14 @@
     "@signalwire/react-native": {
       "version": "file:packages/react-native",
       "requires": {
-        "@signalwire/core": "3.1.0",
-        "@signalwire/webrtc": "3.1.0"
+        "@signalwire/core": "3.1.1",
+        "@signalwire/webrtc": "3.1.1"
       }
     },
     "@signalwire/realtime-api": {
       "version": "file:packages/realtime-api",
       "requires": {
-        "@signalwire/core": "3.1.0",
+        "@signalwire/core": "3.1.1",
         "@types/ws": "^7.4.4",
         "ts-node": "^10.0.0",
         "ws": "^7.4.6"
@@ -14667,7 +14667,7 @@
     "@signalwire/web-api": {
       "version": "file:packages/web-api",
       "requires": {
-        "@signalwire/core": "3.1.0",
+        "@signalwire/core": "3.1.1",
         "@types/node-fetch": "^2.5.10",
         "msw": "^0.28.2",
         "node-abort-controller": "^2.0.0",
@@ -14678,7 +14678,7 @@
     "@signalwire/webrtc": {
       "version": "file:packages/webrtc",
       "requires": {
-        "@signalwire/core": "3.1.0"
+        "@signalwire/core": "3.1.1"
       }
     },
     "@sindresorhus/is": {

--- a/packages/core/src/BaseComponent.ts
+++ b/packages/core/src/BaseComponent.ts
@@ -169,6 +169,22 @@ export class BaseComponent implements Emitter {
     return this._eventsTransformsCache.get(transformCacheKey)
   }
 
+  /** @internal */
+  private cleanupEventHandlerTransformCache(event: string | symbol) {
+    const transformCacheKey = this.getEventHandlerTransformCacheKey(event)
+    const instance = this._eventsTransformsCache.get(transformCacheKey)
+
+    if (instance) {
+      instance.destroy()
+      return this._eventsTransformsCache.delete(event)
+    }
+
+    logger.debug(
+      `[cleanupEventHandlerTransformCache] Key wasn't cached`, event
+    )
+    return false
+  }
+
   /**
    * Creates the event handler to be attached to the `EventEmitter`.
    * It contains the logic for applying any custom transforms for
@@ -286,6 +302,7 @@ export class BaseComponent implements Emitter {
     const [event, fn, context, once] = this._getOptionsFromParams(params)
     const handler = this.getAndRemoveStableEventHandler(fn)
     const namespacedEvent = this._getNamespacedEvent(event)
+    this.cleanupEventHandlerTransformCache(event)
     logger.trace('Removing event listener', namespacedEvent)
     return this.emitter.off(namespacedEvent, handler, context, once)
   }

--- a/packages/core/src/utils/interfaces.ts
+++ b/packages/core/src/utils/interfaces.ts
@@ -12,7 +12,7 @@ import {
  */
 export type Emitter = Pick<
   EventEmitter,
-  'on' | 'off' | 'once' | 'emit' | 'removeAllListeners' | 'eventNames'
+  'on' | 'off' | 'once' | 'emit' | 'removeAllListeners' | 'eventNames' | 'listenerCount'
 >
 
 type JSONRPCParams = Record<string, any>

--- a/packages/realtime-api/src/Video.test.ts
+++ b/packages/realtime-api/src/Video.test.ts
@@ -69,6 +69,51 @@ describe('Member Object', () => {
       video.emit('video.room.started', firstRoom.params.params)
     })
 
+    it('should destroy the cached obj when an event has no longer handlers attached', () => {
+      const destroyer = jest.fn()
+      const h = (room: any) => {
+        room._destroyer = destroyer
+      }
+      video.on('room.started', h)
+
+      video.run()
+      video.emit('video.room.started', firstRoom.params.params)
+
+      video.off('room.started', h)
+      expect(destroyer).toHaveBeenCalled()
+    })
+
+    it('should *not* destroy the cached obj when there are existing listeners attached', () => {
+      const destroyer = jest.fn()
+      const h = (room: any) => {
+        room._destroyer = destroyer
+      }
+      video.on('room.started', h)
+      video.on('room.started', () => {})
+
+      video.run()
+      video.emit('video.room.started', firstRoom.params.params)
+
+      video.off('room.started', h)
+      expect(destroyer).not.toHaveBeenCalled()
+    })
+
+    it('should destroy the cached obj when .off is called with no handler', () => {
+      const destroyer = jest.fn()
+      const h = (room: any) => {
+        room._destroyer = destroyer
+      }
+      video.on('room.started', h)
+      video.on('room.started', () => {})
+      video.on('room.started', () => {})
+
+      video.run()
+      video.emit('video.room.started', firstRoom.params.params)
+
+      video.off('room.started')
+      expect(destroyer).toHaveBeenCalled()
+    })
+
     it('each room object should use its own payload from the Proxy', async () => {
       const mockExecute = jest.fn()
       const mockNameCheck = jest.fn()


### PR DESCRIPTION
The code in this changeset includes the cleanup logic for `destroying` our cached instances once the user call `.off()`. 

### Scenarios covered:
**_Premise**: we're caching instances per event_

1. When `.off('event', handler)` is called and there's only 1 listener attached to that event the cached will be destroyed.
2. When `.off('event', handler)` is called and there are other listeners attached the cached instance won't be destroyed.
3. When `.off('event')` is called with no handler the cache instance will be destroyed. 