### PR TITLE
Update TypeDoc

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "concurrently": "^6.2.0",
         "jest": "^27.0.6",
         "prettier": "^2.3.2",
-        "typedoc": "^0.21.2",
+        "typedoc": "^0.21.9",
         "typescript": "^4.2.3",
         "yarn": "^1.22.11"
       }
@@ -9243,14 +9243,14 @@
       }
     },
     "node_modules/marked": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-2.1.3.tgz",
-      "integrity": "sha512-/Q+7MGzaETqifOMWYEA7HVMaZb4XbcRfaOzcSsHZEith83KGlvaSG33u0SKu89Mj5h+T8V2hM+8O45Qc5XTgwA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-3.0.2.tgz",
+      "integrity": "sha512-TMJQQ79Z0e3rJYazY0tIoMsFzteUGw9fB3FD+gzuIT3zLuG9L9ckIvUfF51apdJkcqc208jJN2KbtPbOvXtbjA==",
       "bin": {
         "marked": "bin/marked"
       },
       "engines": {
-        "node": ">= 10"
+        "node": ">= 12"
       }
     },
     "node_modules/meow": {
@@ -11027,12 +11027,13 @@
       }
     },
     "node_modules/shiki": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.9.3.tgz",
-      "integrity": "sha512-NEjg1mVbAUrzRv2eIcUt3TG7X9svX7l3n3F5/3OdFq+/BxUdmBOeKGiH4icZJBLHy354Shnj6sfBTemea2e7XA==",
+      "version": "0.9.10",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.9.10.tgz",
+      "integrity": "sha512-xeM7Oc6hY+6iW5O/T5hor8ul7mEprzyl5y4r5zthEHToQNw7MIhREMgU3r2gKDB0NaMLNrkcEQagudCdzE13Lg==",
       "dependencies": {
+        "json5": "^2.2.0",
         "onigasm": "^2.2.5",
-        "vscode-textmate": "^5.2.0"
+        "vscode-textmate": "5.2.0"
       }
     },
     "node_modules/signal-exit": {
@@ -11863,28 +11864,27 @@
       }
     },
     "node_modules/typedoc": {
-      "version": "0.21.2",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.21.2.tgz",
-      "integrity": "sha512-SR1ByJB3USg+jxoxwzMRP07g/0f/cQUE5t7gOh1iTUyjTPyJohu9YSKRlK+MSXXqlhIq+m0jkEHEG5HoY7/Adg==",
+      "version": "0.21.9",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.21.9.tgz",
+      "integrity": "sha512-VRo7aII4bnYaBBM1lhw4bQFmUcDQV8m8tqgjtc7oXl87jc1Slbhfw2X5MccfcR2YnEClHDWgsiQGgNB8KJXocA==",
       "dependencies": {
         "glob": "^7.1.7",
         "handlebars": "^4.7.7",
-        "lodash": "^4.17.21",
         "lunr": "^2.3.9",
-        "marked": "^2.1.1",
+        "marked": "^3.0.2",
         "minimatch": "^3.0.0",
         "progress": "^2.0.3",
-        "shiki": "^0.9.3",
+        "shiki": "^0.9.8",
         "typedoc-default-themes": "^0.12.10"
       },
       "bin": {
         "typedoc": "bin/typedoc"
       },
       "engines": {
-        "node": ">= 12.20.0"
+        "node": ">= 12.10.0"
       },
       "peerDependencies": {
-        "typescript": "4.0.x || 4.1.x || 4.2.x || 4.3.x"
+        "typescript": "4.0.x || 4.1.x || 4.2.x || 4.3.x || 4.4.x"
       }
     },
     "node_modules/typedoc-default-themes": {
@@ -12140,9 +12140,9 @@
       }
     },
     "node_modules/vscode-textmate": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.4.0.tgz",
-      "integrity": "sha512-c0Q4zYZkcLizeYJ3hNyaVUM2AA8KDhNCA3JvXY8CeZSJuBdAy3bAvSbv46RClC4P3dSO9BdwhnKEx2zOo6vP/w=="
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.2.0.tgz",
+      "integrity": "sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ=="
     },
     "node_modules/w3c-hr-time": {
       "version": "1.0.2",
@@ -19230,9 +19230,9 @@
       }
     },
     "marked": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-2.1.3.tgz",
-      "integrity": "sha512-/Q+7MGzaETqifOMWYEA7HVMaZb4XbcRfaOzcSsHZEith83KGlvaSG33u0SKu89Mj5h+T8V2hM+8O45Qc5XTgwA=="
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-3.0.2.tgz",
+      "integrity": "sha512-TMJQQ79Z0e3rJYazY0tIoMsFzteUGw9fB3FD+gzuIT3zLuG9L9ckIvUfF51apdJkcqc208jJN2KbtPbOvXtbjA=="
     },
     "meow": {
       "version": "6.1.1",
@@ -20413,12 +20413,13 @@
       "version": "1.0.0"
     },
     "shiki": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.9.3.tgz",
-      "integrity": "sha512-NEjg1mVbAUrzRv2eIcUt3TG7X9svX7l3n3F5/3OdFq+/BxUdmBOeKGiH4icZJBLHy354Shnj6sfBTemea2e7XA==",
+      "version": "0.9.10",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.9.10.tgz",
+      "integrity": "sha512-xeM7Oc6hY+6iW5O/T5hor8ul7mEprzyl5y4r5zthEHToQNw7MIhREMgU3r2gKDB0NaMLNrkcEQagudCdzE13Lg==",
       "requires": {
+        "json5": "^2.2.0",
         "onigasm": "^2.2.5",
-        "vscode-textmate": "^5.2.0"
+        "vscode-textmate": "5.2.0"
       }
     },
     "signal-exit": {
@@ -20990,18 +20991,17 @@
       }
     },
     "typedoc": {
-      "version": "0.21.2",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.21.2.tgz",
-      "integrity": "sha512-SR1ByJB3USg+jxoxwzMRP07g/0f/cQUE5t7gOh1iTUyjTPyJohu9YSKRlK+MSXXqlhIq+m0jkEHEG5HoY7/Adg==",
+      "version": "0.21.9",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.21.9.tgz",
+      "integrity": "sha512-VRo7aII4bnYaBBM1lhw4bQFmUcDQV8m8tqgjtc7oXl87jc1Slbhfw2X5MccfcR2YnEClHDWgsiQGgNB8KJXocA==",
       "requires": {
         "glob": "^7.1.7",
         "handlebars": "^4.7.7",
-        "lodash": "^4.17.21",
         "lunr": "^2.3.9",
-        "marked": "^2.1.1",
+        "marked": "^3.0.2",
         "minimatch": "^3.0.0",
         "progress": "^2.0.3",
-        "shiki": "^0.9.3",
+        "shiki": "^0.9.8",
         "typedoc-default-themes": "^0.12.10"
       }
     },
@@ -21187,9 +21187,9 @@
       }
     },
     "vscode-textmate": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.4.0.tgz",
-      "integrity": "sha512-c0Q4zYZkcLizeYJ3hNyaVUM2AA8KDhNCA3JvXY8CeZSJuBdAy3bAvSbv46RClC4P3dSO9BdwhnKEx2zOo6vP/w=="
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.2.0.tgz",
+      "integrity": "sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ=="
     },
     "w3c-hr-time": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "concurrently": "^6.2.0",
     "jest": "^27.0.6",
     "prettier": "^2.3.2",
-    "typedoc": "^0.21.2",
+    "typedoc": "^0.21.9",
     "typescript": "^4.2.3",
     "yarn": "^1.22.11"
   }

--- a/packages/core/src/BaseComponent.ts
+++ b/packages/core/src/BaseComponent.ts
@@ -165,7 +165,7 @@ export class BaseComponent implements Emitter {
       return instance
     }
 
-    // @ts-expect-error
+    // @ts-ignore
     return this._eventsTransformsCache.get(transformCacheKey)
   }
 


### PR DESCRIPTION
Minor change since i found out a weird behaviour for TypeDoc. While running `npm run docs` for a package, TypeDoc complains about

```
Error: ../core/src/BaseComponent.ts:168:5 - error TS2578: Unused '@ts-expect-error' directive.
```

But the directive it's use because of the `Map().get`. 
The latest version didn't fix it, so i changed it to be `ts-ignore`. 