### PR TITLE
Rename `getParam` and change signature for `BaseComponent`

### DIFF
--- a/.changeset/friendly-zoos-eat.md
+++ b/.changeset/friendly-zoos-eat.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/core': patch
+---
+
+Rename getParam to getStateProperty and make BaseComponent a generic

--- a/packages/core/src/BaseComponent.ts
+++ b/packages/core/src/BaseComponent.ts
@@ -14,6 +14,7 @@ import {
 import { EventEmitter, getNamespacedEvent } from './utils/EventEmitter'
 import { SDKState } from './redux/interfaces'
 import { makeCustomSagaAction } from './redux/actions'
+import { OnlyStateProperties } from './types'
 
 type EventRegisterHandlers =
   | {
@@ -35,7 +36,7 @@ type EventRegisterHandlers =
 
 const identity: ExecuteTransform<any, any> = (payload) => payload
 
-export class BaseComponent implements Emitter {
+export class BaseComponent<T = Record<string, unknown>> implements Emitter {
   /** @internal */
   private readonly uuid = uuid()
 
@@ -470,7 +471,7 @@ export class BaseComponent implements Emitter {
   }
 
   /** @internal */
-  getParam<T extends string>(param: T) {
+  getParam(param: keyof OnlyStateProperties<T>) {
     // @ts-expect-error
     return this[param]
   }

--- a/packages/core/src/BaseComponent.ts
+++ b/packages/core/src/BaseComponent.ts
@@ -471,7 +471,7 @@ export class BaseComponent<T = Record<string, unknown>> implements Emitter {
   }
 
   /** @internal */
-  getParam(param: keyof OnlyStateProperties<T>) {
+  getStateProperty(param: keyof OnlyStateProperties<T>) {
     // @ts-expect-error
     return this[param]
   }

--- a/packages/core/src/rooms/RoomSessionRecording.ts
+++ b/packages/core/src/rooms/RoomSessionRecording.ts
@@ -23,8 +23,8 @@ export class RoomSessionRecordingAPI
     await this.execute({
       method: 'video.recording.pause',
       params: {
-        room_session_id: this.getParam('roomSessionId'),
-        recording_id: this.getParam('id'),
+        room_session_id: this.getStateProperty('roomSessionId'),
+        recording_id: this.getStateProperty('id'),
       },
     })
   }
@@ -33,8 +33,8 @@ export class RoomSessionRecordingAPI
     await this.execute({
       method: 'video.recording.resume',
       params: {
-        room_session_id: this.getParam('roomSessionId'),
-        recording_id: this.getParam('id'),
+        room_session_id: this.getStateProperty('roomSessionId'),
+        recording_id: this.getStateProperty('id'),
       },
     })
   }
@@ -43,8 +43,8 @@ export class RoomSessionRecordingAPI
     await this.execute({
       method: 'video.recording.stop',
       params: {
-        room_session_id: this.getParam('roomSessionId'),
-        recording_id: this.getParam('id'),
+        room_session_id: this.getStateProperty('roomSessionId'),
+        recording_id: this.getStateProperty('id'),
       },
     })
   }

--- a/packages/core/src/rooms/RoomSessionRecording.ts
+++ b/packages/core/src/rooms/RoomSessionRecording.ts
@@ -15,18 +15,16 @@ export interface RoomSessionRecording {
   stop(): Promise<void>
 }
 
-type AllowedParams = 'roomSessionId' | 'id'
-
 export class RoomSessionRecordingAPI
-  extends BaseComponent
+  extends BaseComponent<RoomSessionRecording>
   implements OnlyFunctionProperties<RoomSessionRecording>
 {
   async pause() {
     await this.execute({
       method: 'video.recording.pause',
       params: {
-        room_session_id: this.getParam<AllowedParams>('roomSessionId'),
-        recording_id: this.getParam<AllowedParams>('id'),
+        room_session_id: this.getParam('roomSessionId'),
+        recording_id: this.getParam('id'),
       },
     })
   }
@@ -35,8 +33,8 @@ export class RoomSessionRecordingAPI
     await this.execute({
       method: 'video.recording.resume',
       params: {
-        room_session_id: this.getParam<AllowedParams>('roomSessionId'),
-        recording_id: this.getParam<AllowedParams>('id'),
+        room_session_id: this.getParam('roomSessionId'),
+        recording_id: this.getParam('id'),
       },
     })
   }
@@ -45,8 +43,8 @@ export class RoomSessionRecordingAPI
     await this.execute({
       method: 'video.recording.stop',
       params: {
-        room_session_id: this.getParam<AllowedParams>('roomSessionId'),
-        recording_id: this.getParam<AllowedParams>('id'),
+        room_session_id: this.getParam('roomSessionId'),
+        recording_id: this.getParam('id'),
       },
     })
   }

--- a/packages/core/src/types/utils.ts
+++ b/packages/core/src/types/utils.ts
@@ -21,4 +21,10 @@ type OnlyFunctionPropertyNames<T> = {
   [K in keyof T]: T[K] extends Function ? K : never
 }[keyof T]
 
+type OnlyStatePropertyNames<T> = {
+  [K in keyof T]: T[K] extends Function ? never : K
+}[keyof T]
+
 export type OnlyFunctionProperties<T> = Pick<T, OnlyFunctionPropertyNames<T>>
+
+export type OnlyStateProperties<T> = Pick<T, OnlyStatePropertyNames<T>>


### PR DESCRIPTION
The code in this changeset includes:

1. Rename `getParam` to `getStateProperty`
2. Make `BaseComponent` a generic to avoid having to specify the type every time we call `getStateProperty`