### PR TITLE
Convert events before adding to the EventEmitter

### DIFF
--- a/.changeset/loud-guests-sniff.md
+++ b/.changeset/loud-guests-sniff.md
@@ -1,5 +1,0 @@
----
-'@signalwire/js': patch
----
-
-Rename an internal event to be lowercase.

--- a/.changeset/loud-guests-sniff.md
+++ b/.changeset/loud-guests-sniff.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/js': patch
+---
+
+Rename an internal event to be lowercase.

--- a/.changeset/olive-pumpkins-deny.md
+++ b/.changeset/olive-pumpkins-deny.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/core': patch
+---
+
+Bugfix on the internal EventEmitter where, in a specific case, the `.off()` method did not remove the listener. Improved test coverage.

--- a/packages/core/src/BaseComponent.test.ts
+++ b/packages/core/src/BaseComponent.test.ts
@@ -1,0 +1,43 @@
+import { BaseComponent } from './BaseComponent'
+import { configureJestStore } from './testUtils'
+import { EventEmitter } from './utils/EventEmitter'
+
+describe('BaseComponent', () => {
+  describe('as an event emitter', () => {
+    let instance: BaseComponent
+    const serverEvent = 'jest.event.server_side'
+
+    beforeEach(() => {
+      instance = new BaseComponent({
+        store: configureJestStore(),
+        emitter: new EventEmitter(),
+      })
+      // @ts-expect-error
+      instance._eventsPrefix = 'jest'
+      // @ts-expect-error
+      instance._attachListeners('')
+    })
+
+    it('should handle snake_case events', (done) => {
+      const payload = { test: 1 }
+      instance.on(serverEvent, (data) => {
+        expect(data).toStrictEqual(payload)
+
+        done()
+      })
+
+      instance.emit(serverEvent, payload)
+    })
+
+    it('should handle camelCase events', (done) => {
+      const payload = { test: 1 }
+      instance.on('event.serverSide', (data) => {
+        expect(data).toStrictEqual(payload)
+
+        done()
+      })
+
+      instance.emit(serverEvent, payload)
+    })
+  })
+})

--- a/packages/core/src/BaseComponent.test.ts
+++ b/packages/core/src/BaseComponent.test.ts
@@ -23,6 +23,83 @@ describe('BaseComponent', () => {
       instance = new JestComponent()
     })
 
+    it('should transform the event name to the internal format', () => {
+      instance.on('test.event_one', () => {})
+      instance.on('test.eventOne', () => {})
+      instance.once('video.test.eventOne', () => {})
+
+      instance.once('video.test.eventTwo', () => {})
+
+      expect(instance.listenerCount('video.test.event_one')).toEqual(3)
+      expect(instance.listenerCount('video.test.event_two')).toEqual(1)
+    })
+
+    it('should transform the event name to the internal format with namespace', () => {
+      const customInstance = new JestComponent('custom')
+      customInstance.on('test.event_one', () => {})
+      customInstance.on('test.eventOne', () => {})
+      customInstance.once('video.test.eventOne', () => {})
+
+      customInstance.once('video.test.eventTwo', () => {})
+
+      expect(
+        customInstance.listenerCount('custom:video.test.event_one')
+      ).toEqual(3)
+      expect(
+        customInstance.listenerCount('custom:video.test.event_two')
+      ).toEqual(1)
+    })
+
+    it('should keep track of the original events with the _eventsPrefix', () => {
+      const firstInstance = new JestComponent('first')
+      firstInstance.on('first.event_one', () => {})
+      firstInstance.once('video.first.eventOne', () => {})
+      firstInstance.on('first.event_two', () => {})
+      firstInstance.once('video.first.eventTwo', () => {})
+
+      const secondInstance = new JestComponent('second')
+      secondInstance.on('second.event_one', () => {})
+      secondInstance.once('video.second.eventOne', () => {})
+      secondInstance.on('second.event_two', () => {})
+      secondInstance.once('video.second.eventTwo', () => {})
+
+      expect(firstInstance.eventNames()).toStrictEqual([
+        'video.first.event_one',
+        'video.first.eventOne',
+        'video.first.event_two',
+        'video.first.eventTwo',
+      ])
+      expect(secondInstance.eventNames()).toStrictEqual([
+        'video.second.event_one',
+        'video.second.eventOne',
+        'video.second.event_two',
+        'video.second.eventTwo',
+      ])
+    })
+
+    it('should remove the listeners with .off', () => {
+      const instance = new JestComponent('custom')
+      const mockOne = jest.fn()
+      instance.on('test.eventOne', mockOne)
+      instance.once('test.eventOne', mockOne)
+      const mockTwo = jest.fn()
+      instance.on('test.eventTwo', mockTwo)
+      instance.once('test.eventTwo', mockTwo)
+
+      expect(instance.listenerCount('custom:video.test.event_one')).toEqual(2)
+      expect(instance.listenerCount('custom:video.test.event_two')).toEqual(2)
+
+      // No-op
+      instance.off('test.eventOne', () => {})
+      expect(instance.listenerCount('custom:video.test.event_one')).toEqual(2)
+
+      instance.off('test.eventOne', mockOne)
+      expect(instance.listenerCount('custom:video.test.event_one')).toEqual(0)
+
+      instance.off('test.eventTwo', mockTwo)
+      expect(instance.listenerCount('custom:video.test.event_two')).toEqual(0)
+    })
+
     it('should handle snake_case events', (done) => {
       const serverEvent = 'video.event.server_side'
       const payload = { test: 1 }

--- a/packages/core/src/BaseComponent.test.ts
+++ b/packages/core/src/BaseComponent.test.ts
@@ -4,23 +4,29 @@ import { EventEmitter } from './utils/EventEmitter'
 
 describe('BaseComponent', () => {
   describe('as an event emitter', () => {
+    class JestComponent extends BaseComponent {
+      protected _eventsPrefix = 'video' as const
+
+      constructor(namespace = '') {
+        super({
+          store: configureJestStore(),
+          emitter: new EventEmitter(),
+        })
+
+        this._attachListeners(namespace)
+      }
+    }
+
     let instance: BaseComponent
-    const serverEvent = 'jest.event.server_side'
 
     beforeEach(() => {
-      instance = new BaseComponent({
-        store: configureJestStore(),
-        emitter: new EventEmitter(),
-      })
-      // @ts-expect-error
-      instance._eventsPrefix = 'jest'
-      // @ts-expect-error
-      instance._attachListeners('')
+      instance = new JestComponent()
     })
 
     it('should handle snake_case events', (done) => {
+      const serverEvent = 'video.event.server_side'
       const payload = { test: 1 }
-      instance.on(serverEvent, (data) => {
+      instance.on('event.server_side', (data) => {
         expect(data).toStrictEqual(payload)
 
         done()
@@ -30,6 +36,7 @@ describe('BaseComponent', () => {
     })
 
     it('should handle camelCase events', (done) => {
+      const serverEvent = 'video.event.server_side'
       const payload = { test: 1 }
       instance.on('event.serverSide', (data) => {
         expect(data).toStrictEqual(payload)

--- a/packages/core/src/BaseComponent.test.ts
+++ b/packages/core/src/BaseComponent.test.ts
@@ -89,6 +89,12 @@ describe('BaseComponent', () => {
       expect(instance.listenerCount('custom:video.test.event_one')).toEqual(2)
       expect(instance.listenerCount('custom:video.test.event_two')).toEqual(2)
 
+      // _trackedEvents contains raw-prefixed event names
+      expect(instance.eventNames()).toStrictEqual([
+        'video.test.eventOne',
+        'video.test.eventTwo',
+      ])
+
       // No-op
       instance.off('test.eventOne', () => {})
       expect(instance.listenerCount('custom:video.test.event_one')).toEqual(2)
@@ -98,6 +104,33 @@ describe('BaseComponent', () => {
 
       instance.off('test.eventTwo', mockTwo)
       expect(instance.listenerCount('custom:video.test.event_two')).toEqual(0)
+
+      expect(instance.eventNames()).toStrictEqual([])
+    })
+
+    it('should remove all the listeners with .removeAllListeners', () => {
+      const instance = new JestComponent('custom')
+      const mockOne = jest.fn()
+      instance.on('test.eventOne', mockOne)
+      instance.once('test.eventOne', mockOne)
+      const mockTwo = jest.fn()
+      instance.on('test.eventTwo', mockTwo)
+      instance.once('test.eventTwo', mockTwo)
+
+      expect(instance.listenerCount('custom:video.test.event_one')).toEqual(2)
+      expect(instance.listenerCount('custom:video.test.event_two')).toEqual(2)
+
+      // _trackedEvents contains raw-prefixed event names
+      expect(instance.eventNames()).toStrictEqual([
+        'video.test.eventOne',
+        'video.test.eventTwo',
+      ])
+
+      instance.removeAllListeners()
+
+      expect(instance.listenerCount('custom:video.test.event_one')).toEqual(0)
+      expect(instance.listenerCount('custom:video.test.event_two')).toEqual(0)
+      expect(instance.eventNames()).toStrictEqual([])
     })
 
     it('should handle snake_case events', (done) => {

--- a/packages/core/src/BaseComponent.ts
+++ b/packages/core/src/BaseComponent.ts
@@ -15,6 +15,7 @@ import { EventEmitter, getNamespacedEvent } from './utils/EventEmitter'
 import { SDKState } from './redux/interfaces'
 import { makeCustomSagaAction } from './redux/actions'
 import { OnlyStateProperties } from './types'
+import { toInternalEventName } from './utils/toInternalEventName'
 
 type EventRegisterHandlers =
   | {
@@ -284,9 +285,10 @@ export class BaseComponent<T = Record<string, unknown>> implements Emitter {
     const [event, fn, context] = this._getOptionsFromParams(params)
     const handler = this.applyEventHandlerTransform(event, fn)
     const namespacedEvent = this._getNamespacedEvent(event)
-    logger.trace('Registering event', namespacedEvent)
+    const internalEvent = toInternalEventName(namespacedEvent)
+    logger.trace('Registering event', internalEvent)
     this.trackEvent(event)
-    return this.emitter.on(namespacedEvent, handler, context)
+    return this.emitter.on(internalEvent, handler, context)
   }
 
   once(...params: Parameters<Emitter['once']>) {
@@ -298,9 +300,10 @@ export class BaseComponent<T = Record<string, unknown>> implements Emitter {
     const [event, fn, context] = this._getOptionsFromParams(params)
     const handler = this.applyEventHandlerTransform(event, fn)
     const namespacedEvent = this._getNamespacedEvent(event)
-    logger.trace('Registering event', namespacedEvent)
+    const internalEvent = toInternalEventName(namespacedEvent)
+    logger.trace('Registering event', internalEvent)
     this.trackEvent(event)
-    return this.emitter.once(namespacedEvent, handler, context)
+    return this.emitter.once(internalEvent, handler, context)
   }
 
   off(...params: Parameters<Emitter['off']>) {

--- a/packages/core/src/BaseComponent.ts
+++ b/packages/core/src/BaseComponent.ts
@@ -293,6 +293,10 @@ export class BaseComponent<T = Record<string, unknown>> implements Emitter {
     this._trackedEvents = Array.from(new Set(this._trackedEvents.concat(event)))
   }
 
+  private untrackEvent(event: string | symbol) {
+    this._trackedEvents = this._trackedEvents.filter((evt) => evt !== event)
+  }
+
   private _getOptionsFromParams<T extends any[]>(params: T): typeof params {
     const [event, ...rest] = params
 
@@ -346,6 +350,7 @@ export class BaseComponent<T = Record<string, unknown>> implements Emitter {
       force: !handler,
     })
     logger.trace('Removing event listener', internalEvent)
+    this.untrackEvent(event)
     return this.emitter.off(internalEvent, handler, context, once)
   }
 

--- a/packages/core/src/BaseComponent.ts
+++ b/packages/core/src/BaseComponent.ts
@@ -65,14 +65,6 @@ export class BaseComponent<T = Record<string, unknown>> implements Emitter {
       event,
       namespace: this._eventsNamespace,
     })
-    // if (typeof event === 'string' && this._eventsNamespace !== undefined) {
-    //   return getNamespacedEvent({
-    //     namespace: this._eventsNamespace,
-    //     event,
-    //   })
-    // }
-
-    // return event
   }
   /**
    * A prefix is a product, like `video` or `chat`.
@@ -203,9 +195,9 @@ export class BaseComponent<T = Record<string, unknown>> implements Emitter {
   }
 
   /**
-   * Transforms are mapped using the "raw" event name (i.e
-   * non-namespaced sent by the server) and then mapped again
-   * using the end-user `fn` reference.
+   * Transforms are mapped using the "prefixed" event name (i.e
+   * non-namespaced sent by the server with the _eventPrefix) and
+   * then mapped again using the end-user `fn` reference.
    * @internal
    */
   private getEmitterListenersMapByEventName(event: string | symbol) {

--- a/packages/core/src/redux/features/pubSub/pubSubSaga.ts
+++ b/packages/core/src/redux/features/pubSub/pubSubSaga.ts
@@ -1,8 +1,11 @@
 import { SagaIterator } from 'redux-saga'
 import { take } from '@redux-saga/core/effects'
-import { logger, isInternalGlobalEvent } from '../../../utils'
+import {
+  logger,
+  isInternalGlobalEvent,
+  toInternalEventName,
+} from '../../../utils'
 import type { Emitter } from '../../../utils/interfaces'
-import { getNamespacedEvent } from '../../../utils/EventEmitter'
 import { PubSubChannel, PubSubAction } from '../../interfaces'
 
 type PubSubSagaParams = {
@@ -39,7 +42,7 @@ export function* pubSubSaga({
         emitter.emit(type, payload)
       }
 
-      emitter.emit(getNamespacedEvent({ namespace, event: type }), payload)
+      emitter.emit(toInternalEventName({ namespace, event: type }), payload)
     } catch (error) {
       logger.error(error)
     }

--- a/packages/core/src/rooms/methods.ts
+++ b/packages/core/src/rooms/methods.ts
@@ -115,7 +115,7 @@ export const startRecording: RoomMethodDescriptor<any> = {
         resolve(instance)
       }
 
-      this.on('video._INTERNAL_.recording.start', handler)
+      this.on('video.__internal__.recording.start', handler)
 
       try {
         const payload = await this.execute({
@@ -124,9 +124,9 @@ export const startRecording: RoomMethodDescriptor<any> = {
             room_session_id: this.roomSessionId,
           },
         })
-        this.emit('video._INTERNAL_.recording.start', payload)
+        this.emit('video.__internal__.recording.start', payload)
       } catch (error) {
-        this.off('video._INTERNAL_.recording.start', handler)
+        this.off('video.__internal__.recording.start', handler)
         throw error
       }
     })

--- a/packages/core/src/utils/EventEmitter.ts
+++ b/packages/core/src/utils/EventEmitter.ts
@@ -41,23 +41,4 @@ const getEventEmitter = <T>(userOptions: UserOptions) => {
   )
 }
 
-const getNamespacedEvent = ({
-  namespace,
-  event,
-}: {
-  namespace: string
-  event: string
-}) => {
-  /**
-   * If getNamespacedEvent is called with the `namespace` already
-   * present in the `event` or with a falsy namespace we'll return it
-   * as is
-   */
-  if (!namespace || event.startsWith(namespace)) {
-    return event
-  }
-
-  return `${namespace}:${event}`
-}
-
-export { assertEventEmitter, EventEmitter, getEventEmitter, getNamespacedEvent }
+export { assertEventEmitter, EventEmitter, getEventEmitter }

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -8,6 +8,7 @@ export { v4 as uuid } from 'uuid'
 export { logger } from './logger'
 export * from './parseRPCResponse'
 export * from './toExternalJSON'
+export * from './toInternalEventName'
 
 export const mutateStorageKey = (key: string) => `${STORAGE_PREFIX}${key}`
 

--- a/packages/core/src/utils/toInternalEventName.test.ts
+++ b/packages/core/src/utils/toInternalEventName.test.ts
@@ -1,0 +1,32 @@
+import { toInternalEventName } from './toInternalEventName'
+
+describe('toInternalEventName', () => {
+  it('should transform public events into internal', () => {
+    expect(toInternalEventName('video.room.started')).toEqual(
+      'video.room.started'
+    )
+    expect(toInternalEventName('video.member.updated')).toEqual(
+      'video.member.updated'
+    )
+    expect(toInternalEventName('video.member.updated.video_muted')).toEqual(
+      'video.member.updated.video_muted'
+    )
+    expect(
+      toInternalEventName('video.member.updated.other_snake_case')
+    ).toEqual('video.member.updated.other_snake_case')
+
+    expect(toInternalEventName('video.member.updated.videoMuted')).toEqual(
+      'video.member.updated.video_muted'
+    )
+    expect(toInternalEventName('video.member.updated.otherSnakeCase')).toEqual(
+      'video.member.updated.other_snake_case'
+    )
+
+    expect(toInternalEventName('video.recording.started')).toEqual(
+      'video.recording.started'
+    )
+    expect(toInternalEventName('video.recording.exampleHere')).toEqual(
+      'video.recording.example_here'
+    )
+  })
+})

--- a/packages/core/src/utils/toInternalEventName.test.ts
+++ b/packages/core/src/utils/toInternalEventName.test.ts
@@ -1,32 +1,32 @@
 import { toInternalEventName } from './toInternalEventName'
 
 describe('toInternalEventName', () => {
-  it('should transform public events into internal', () => {
-    expect(toInternalEventName('video.room.started')).toEqual(
-      'video.room.started'
-    )
-    expect(toInternalEventName('video.member.updated')).toEqual(
-      'video.member.updated'
-    )
-    expect(toInternalEventName('video.member.updated.video_muted')).toEqual(
-      'video.member.updated.video_muted'
-    )
-    expect(
-      toInternalEventName('video.member.updated.other_snake_case')
-    ).toEqual('video.member.updated.other_snake_case')
+  it('should transform public events into internal without namespace', () => {
+    const events = [
+      // no-op
+      ['video.room.started', 'video.room.started'],
+      ['video.member.updated', 'video.member.updated'],
+      ['video.member.updated.video_muted', 'video.member.updated.video_muted'],
+      ['video.other_snake_case', 'video.other_snake_case'],
+      // camel to snake
+      ['video.member.updated.videoMuted', 'video.member.updated.video_muted'],
+      ['video.member.otherSnakeCase', 'video.member.other_snake_case'],
+      ['video.recording.exampleHere', 'video.recording.example_here'],
+    ]
+    const namespace = 'random-uuid'
 
-    expect(toInternalEventName('video.member.updated.videoMuted')).toEqual(
-      'video.member.updated.video_muted'
-    )
-    expect(toInternalEventName('video.member.updated.otherSnakeCase')).toEqual(
-      'video.member.updated.other_snake_case'
-    )
-
-    expect(toInternalEventName('video.recording.started')).toEqual(
-      'video.recording.started'
-    )
-    expect(toInternalEventName('video.recording.exampleHere')).toEqual(
-      'video.recording.example_here'
-    )
+    events.forEach(([input, output]) => {
+      expect(toInternalEventName({ event: input })).toEqual(output)
+      // @ts-ignore
+      expect(toInternalEventName({ event: input, namespace: null })).toEqual(
+        output
+      )
+      expect(toInternalEventName({ event: input, namespace: '' })).toEqual(
+        output
+      )
+      expect(toInternalEventName({ event: input, namespace })).toEqual(
+        `${namespace}:${output}`
+      )
+    })
   })
 })

--- a/packages/core/src/utils/toInternalEventName.ts
+++ b/packages/core/src/utils/toInternalEventName.ts
@@ -1,0 +1,19 @@
+export const toInternalEventName = (event: string | symbol) => {
+  if (typeof event === 'string') {
+    // other transforms here..
+    event = fromCamelToSnakeCase(event)
+  }
+
+  return event
+}
+
+const UPPERCASE_REGEX = /[A-Z]/g
+/**
+ * Converts values from camelCase to snake_case
+ * @internal
+ */
+const fromCamelToSnakeCase = (event: string) => {
+  return event.replace(UPPERCASE_REGEX, (letter) => {
+    return `_${letter.toLowerCase()}`
+  })
+}

--- a/packages/core/src/utils/toInternalEventName.ts
+++ b/packages/core/src/utils/toInternalEventName.ts
@@ -1,6 +1,15 @@
-export const toInternalEventName = (event: string | symbol) => {
+type ToInternalEventNameParams = {
+  event: string | symbol
+  namespace?: string
+}
+
+export const toInternalEventName = ({
+  event,
+  namespace,
+}: ToInternalEventNameParams) => {
   if (typeof event === 'string') {
     // other transforms here..
+    event = getNamespacedEvent({ event, namespace })
     event = fromCamelToSnakeCase(event)
   }
 
@@ -16,4 +25,23 @@ const fromCamelToSnakeCase = (event: string) => {
   return event.replace(UPPERCASE_REGEX, (letter) => {
     return `_${letter.toLowerCase()}`
   })
+}
+
+const getNamespacedEvent = ({
+  namespace,
+  event,
+}: {
+  event: string
+  namespace?: string
+}) => {
+  /**
+   * If getNamespacedEvent is called with the `namespace` already
+   * present in the `event` or with a falsy namespace we'll return it
+   * as is
+   */
+  if (!namespace || event.startsWith(namespace)) {
+    return event
+  }
+
+  return `${namespace}:${event}`
 }

--- a/packages/js/src/Room.ts
+++ b/packages/js/src/Room.ts
@@ -47,7 +47,7 @@ class Room extends BaseConnection implements BaseRoomInterface {
     return new Map<string | string[], EventTransform>([
       [
         [
-          'video._INTERNAL_.recording.start',
+          'video.__internal__.recording.start',
           'video.recording.started',
           'video.recording.updated',
           'video.recording.ended',


### PR DESCRIPTION
This PR update the way BaseComponent attach events to the EE transforming them to the _internal_ format (snake_case). This allow end-users to attach camelCase events and match those with the ones sent from the server. 