### PR TITLE
Rename `talking` events

### DIFF
--- a/.changeset/ten-candles-hang.md
+++ b/.changeset/ten-candles-hang.md
@@ -1,0 +1,6 @@
+---
+'@signalwire/core': patch
+'@signalwire/js': patch
+---
+
+Added `member.talking.started`, `member.talking.ended` and deprecated `member.talking.start` and `member.talking.stop` for consistency.

--- a/packages/core/src/redux/features/session/sessionSaga.test.ts
+++ b/packages/core/src/redux/features/session/sessionSaga.test.ts
@@ -160,6 +160,10 @@ describe('sessionChannelWatcher', () => {
           },
         ])
         .put(pubSubChannel, {
+          type: 'video.member.talking.started',
+          payload,
+        })
+        .put(pubSubChannel, {
           type: 'video.member.talking.start',
           payload,
         })
@@ -169,7 +173,7 @@ describe('sessionChannelWatcher', () => {
         })
         .run()
         .finally(() => {
-          expect(dispatchedActions).toHaveLength(2)
+          expect(dispatchedActions).toHaveLength(3)
         })
     })
 
@@ -212,6 +216,10 @@ describe('sessionChannelWatcher', () => {
           },
         ])
         .put(pubSubChannel, {
+          type: 'video.member.talking.ended',
+          payload,
+        })
+        .put(pubSubChannel, {
           type: 'video.member.talking.stop',
           payload,
         })
@@ -221,7 +229,7 @@ describe('sessionChannelWatcher', () => {
         })
         .run()
         .finally(() => {
-          expect(dispatchedActions).toHaveLength(2)
+          expect(dispatchedActions).toHaveLength(3)
         })
     })
 

--- a/packages/core/src/redux/features/session/sessionSaga.ts
+++ b/packages/core/src/redux/features/session/sessionSaga.ts
@@ -264,10 +264,15 @@ export function* sessionChannelWatcher({
       case 'video.member.talking': {
         const { member } = params.params
         if ('talking' in member) {
-          const suffix = member.talking ? 'start' : 'stop'
-          const type = `video.member.talking.${suffix}` as const
+          const suffix = member.talking ? 'started' : 'ended'
           yield put(pubSubChannel, {
-            type,
+            type: `video.member.talking.${suffix}` as const,
+            payload: params.params,
+          })
+          // Keep for backwards compat.
+          const deprecatedSuffix = member.talking ? 'start' : 'stop'
+          yield put(pubSubChannel, {
+            type: `video.member.talking.${deprecatedSuffix}` as const,
             payload: params.params,
           })
         }

--- a/packages/core/src/types/videoMember.ts
+++ b/packages/core/src/types/videoMember.ts
@@ -63,11 +63,23 @@ export type MemberTalking = 'member.talking'
  * See {@link MEMBER_UPDATED_EVENTS} for the full list of events.
  */
 export type MemberUpdatedEventNames = typeof MEMBER_UPDATED_EVENTS[number]
+export type MemberTalkingStarted = 'member.talking.started'
+export type MemberTalkingEnded = 'member.talking.ended'
+/**
+ * Use `member.talking.started` instead
+ * @deprecated
+ */
 export type MemberTalkingStart = 'member.talking.start'
+/**
+ * Use `member.talking.ended` instead
+ * @deprecated
+ */
 export type MemberTalkingStop = 'member.talking.stop'
 
 export type MemberTalkingEventNames =
   | MemberTalking
+  | MemberTalkingStarted
+  | MemberTalkingEnded
   | MemberTalkingStart
   | MemberTalkingStop
 

--- a/packages/js/src/testUtils.ts
+++ b/packages/js/src/testUtils.ts
@@ -23,10 +23,11 @@ export const configureJestStore = () => {
 }
 
 /**
- * Helper method to configure a Store w/o Saga middleware.
- * Useful to test slices and reducers logic.
+ * Helper method to configure a Store with a rootSaga
+ * and a mocked Session object.
+ * This allow to write integration tests.
  *
- * @returns Redux Store
+ * @returns { store, session, emitter, destroy }
  */
 export const configureFullStack = () => {
   const session = {

--- a/packages/js/src/testUtils.ts
+++ b/packages/js/src/testUtils.ts
@@ -1,4 +1,4 @@
-import { configureStore } from '@signalwire/core'
+import { configureStore, EventEmitter, actions } from '@signalwire/core'
 import { JWTSession } from './JWTSession'
 
 const PROJECT_ID = '8f0a119a-cda7-4497-a47d-c81493b824d4'
@@ -20,4 +20,39 @@ export const configureJestStore = () => {
     SessionConstructor: JWTSession,
     runSagaMiddleware: false,
   })
+}
+
+/**
+ * Helper method to configure a Store w/o Saga middleware.
+ * Useful to test slices and reducers logic.
+ *
+ * @returns Redux Store
+ */
+export const configureFullStack = () => {
+  const session = {
+    dispatch: console.log,
+    connect: jest.fn(),
+  }
+  const emitter = new EventEmitter()
+  const store = configureStore({
+    userOptions: {
+      project: PROJECT_ID,
+      token: TOKEN,
+      devTools: false,
+      emitter,
+    },
+    SessionConstructor: jest.fn().mockImplementation(() => {
+      return session
+    }),
+  })
+
+  store.dispatch(actions.initAction())
+  store.dispatch(actions.authSuccessAction())
+
+  return {
+    store,
+    session,
+    emitter,
+    destroy: () => store.dispatch(actions.destroyAction()),
+  }
 }


### PR DESCRIPTION
This PR adds new talking events like `member.talking.started` and `member.talking.ended` for consistency with other names. It's backward compatible since it keeps the old ones.

I also added an API in `js` to start writing integration tests covering all the Session/rootSaga logic. 