### PR TITLE
Fix EventEmitter interface for all emitter-objects + Upgrade to TS 4.4.2 + more

### DIFF
--- a/.changeset/eleven-shoes-love.md
+++ b/.changeset/eleven-shoes-love.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/core': patch
+---
+
+Improve way of creating strictly typed EventEmitter instances.

--- a/.changeset/poor-hounds-hide.md
+++ b/.changeset/poor-hounds-hide.md
@@ -1,0 +1,7 @@
+---
+'@signalwire/js': patch
+'@signalwire/realtime-api': patch
+'@signalwire/webrtc': patch
+---
+
+Removed option for passing a custom event emitter when creating a client.

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "jest": "^27.0.6",
         "prettier": "^2.3.2",
         "typedoc": "^0.21.9",
-        "typescript": "^4.2.3",
+        "typescript": "^4.4.2",
         "yarn": "^1.22.11"
       }
     },
@@ -12057,9 +12057,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.4.tgz",
-      "integrity": "sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.2.tgz",
+      "integrity": "sha512-gzP+t5W4hdy4c+68bfcv0t400HVJMMd2+H9B7gae1nQlBzCqvrXX+6GL/b3GAgyTH966pzrZ70/fRjwAtZksSQ==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -21301,9 +21301,9 @@
       "integrity": "sha512-fIS001cAYHkyQPidWXmHuhs8usjP5XVJjWB8oZGqkTowZaz3v7g3KDZeeqE82FBrmkAnIBOY3jgy7lnPnqATbA=="
     },
     "typescript": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.4.tgz",
-      "integrity": "sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg=="
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.2.tgz",
+      "integrity": "sha512-gzP+t5W4hdy4c+68bfcv0t400HVJMMd2+H9B7gae1nQlBzCqvrXX+6GL/b3GAgyTH966pzrZ70/fRjwAtZksSQ=="
     },
     "typescript-compare": {
       "version": "0.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11537,11 +11537,6 @@
         "events": "^3.3.0"
       }
     },
-    "node_modules/strict-event-emitter-types": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strict-event-emitter-types/-/strict-event-emitter-types-2.0.0.tgz",
-      "integrity": "sha512-Nk/brWYpD85WlOgzw5h173aci0Teyv8YdIAEtV+N88nDB0dLlazZyJMIsN6eo1/AR61l+p6CJTG1JIyFaoNEEA=="
-    },
     "node_modules/string-length": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
@@ -12645,7 +12640,6 @@
         "loglevel": "^1.7.1",
         "redux-saga": "^1.1.3",
         "redux-saga-test-plan": "^4.0.1",
-        "strict-event-emitter-types": "^2.0.0",
         "uuid": "^8.3.2"
       },
       "devDependencies": {
@@ -14791,7 +14785,6 @@
         "mock-socket": "^9.0.3",
         "redux-saga": "^1.1.3",
         "redux-saga-test-plan": "^4.0.1",
-        "strict-event-emitter-types": "^2.0.0",
         "uuid": "^8.3.2"
       }
     },
@@ -20972,11 +20965,6 @@
       "requires": {
         "events": "^3.3.0"
       }
-    },
-    "strict-event-emitter-types": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strict-event-emitter-types/-/strict-event-emitter-types-2.0.0.tgz",
-      "integrity": "sha512-Nk/brWYpD85WlOgzw5h173aci0Teyv8YdIAEtV+N88nDB0dLlazZyJMIsN6eo1/AR61l+p6CJTG1JIyFaoNEEA=="
     },
     "string-length": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "jest": "^27.0.6",
     "prettier": "^2.3.2",
     "typedoc": "^0.21.9",
-    "typescript": "^4.2.3",
+    "typescript": "^4.4.2",
     "yarn": "^1.22.11"
   }
 }

--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,0 +1,885 @@
+{
+  "name": "@signalwire/core",
+  "version": "3.1.2",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@signalwire/core",
+      "version": "3.1.2",
+      "license": "MIT",
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.6.0",
+        "@types/uuid": "^8.3.0",
+        "eventemitter3": "4.0.7",
+        "loglevel": "^1.7.1",
+        "redux-saga": "^1.1.3",
+        "redux-saga-test-plan": "^4.0.1",
+        "uuid": "^8.3.2"
+      },
+      "devDependencies": {
+        "jest-websocket-mock": "^2.2.1",
+        "mock-socket": "^9.0.3"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.15.4.tgz",
+      "integrity": "sha512-99catp6bHCaxr4sJ/DbTGgHS4+Rs2RVd2g7iOap6SLGPDknRK9ztKNsE/Fg6QhSeh1FGE5f6gHGQmvvn3I3xhw==",
+      "dependencies": {
+        "regenerator-runtime": "^0.13.4"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@jest/types": {
+      "version": "27.1.1",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.1.tgz",
+      "integrity": "sha512-yqJPDDseb0mXgKqmNqypCsb85C22K1aY5+LUxh7syIM9n/b0AsaltxNy+o6tt29VcfGDpYEve175bm3uOhcehA==",
+      "dev": true,
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^16.0.0",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/@redux-saga/core": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@redux-saga/core/-/core-1.1.3.tgz",
+      "integrity": "sha512-8tInBftak8TPzE6X13ABmEtRJGjtK17w7VUs7qV17S8hCO5S3+aUTWZ/DBsBJPdE8Z5jOPwYALyvofgq1Ws+kg==",
+      "dependencies": {
+        "@babel/runtime": "^7.6.3",
+        "@redux-saga/deferred": "^1.1.2",
+        "@redux-saga/delay-p": "^1.1.2",
+        "@redux-saga/is": "^1.1.2",
+        "@redux-saga/symbols": "^1.1.2",
+        "@redux-saga/types": "^1.1.0",
+        "redux": "^4.0.4",
+        "typescript-tuple": "^2.2.1"
+      }
+    },
+    "node_modules/@redux-saga/deferred": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@redux-saga/deferred/-/deferred-1.1.2.tgz",
+      "integrity": "sha512-908rDLHFN2UUzt2jb4uOzj6afpjgJe3MjICaUNO3bvkV/kN/cNeI9PMr8BsFXB/MR8WTAZQq/PlTq8Kww3TBSQ=="
+    },
+    "node_modules/@redux-saga/delay-p": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@redux-saga/delay-p/-/delay-p-1.1.2.tgz",
+      "integrity": "sha512-ojc+1IoC6OP65Ts5+ZHbEYdrohmIw1j9P7HS9MOJezqMYtCDgpkoqB5enAAZrNtnbSL6gVCWPHaoaTY5KeO0/g==",
+      "dependencies": {
+        "@redux-saga/symbols": "^1.1.2"
+      }
+    },
+    "node_modules/@redux-saga/is": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@redux-saga/is/-/is-1.1.2.tgz",
+      "integrity": "sha512-OLbunKVsCVNTKEf2cH4TYyNbbPgvmZ52iaxBD4I1fTif4+MTXMa4/Z07L83zW/hTCXwpSZvXogqMqLfex2Tg6w==",
+      "dependencies": {
+        "@redux-saga/symbols": "^1.1.2",
+        "@redux-saga/types": "^1.1.0"
+      }
+    },
+    "node_modules/@redux-saga/symbols": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@redux-saga/symbols/-/symbols-1.1.2.tgz",
+      "integrity": "sha512-EfdGnF423glv3uMwLsGAtE6bg+R9MdqlHEzExnfagXPrIiuxwr3bdiAwz3gi+PsrQ3yBlaBpfGLtDG8rf3LgQQ=="
+    },
+    "node_modules/@redux-saga/types": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@redux-saga/types/-/types-1.1.0.tgz",
+      "integrity": "sha512-afmTuJrylUU/0OtqzaRkbyYFFNgCF73Bvel/sw90pvGrWIZ+vyoIJqA6eMSoA6+nb443kTmulmBtC9NerXboNg=="
+    },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.6.1.tgz",
+      "integrity": "sha512-pa3nqclCJaZPAyBhruQtiRwtTjottRrVJqziVZcWzI73i6L3miLTtUyWfauwv08HWtiXLx1xGyGt+yLFfW/d0A==",
+      "dependencies": {
+        "immer": "^9.0.1",
+        "redux": "^4.1.0",
+        "redux-thunk": "^2.3.0",
+        "reselect": "^4.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0 || ^17.0.0",
+        "react-redux": "^7.2.1"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@types/istanbul-lib-coverage": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
+      "integrity": "sha512-sz7iLqvVUg1gIedBOvlkxPlc8/uVzyS5OwGz1cKjXzkl3FpL3al0crU8YGU1WoHkxn0Wxbw5tyi6hvzJKNzFsw==",
+      "dev": true
+    },
+    "node_modules/@types/istanbul-lib-report": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
+      "integrity": "sha512-plGgXAPfVKFoYfa9NpYDAkseG+g6Jr294RqeqcqDixSbU34MZVJRi/P+7Y8GDpzkEwLaGZZOpKIEmeVZNtKsrg==",
+      "dev": true,
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "*"
+      }
+    },
+    "node_modules/@types/istanbul-reports": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.1.tgz",
+      "integrity": "sha512-c3mAZEuK0lvBp8tmuL74XRKn1+y2dcwOUpH7x4WrF6gk1GIgiluDRgMYQtw2OFcBvAJWlt6ASU3tSqxp0Uu0Aw==",
+      "dev": true,
+      "dependencies": {
+        "@types/istanbul-lib-report": "*"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "16.9.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.9.1.tgz",
+      "integrity": "sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g==",
+      "dev": true
+    },
+    "node_modules/@types/uuid": {
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.1.tgz",
+      "integrity": "sha512-Y2mHTRAbqfFkpjldbkHGY8JIzRN6XqYRliG8/24FcHm2D2PwW24fl5xMRTVGdrb7iMrwCaIEbLWerGIkXuFWVg=="
+    },
+    "node_modules/@types/yargs": {
+      "version": "16.0.4",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
+      "integrity": "sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==",
+      "dev": true,
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/@types/yargs-parser": {
+      "version": "20.2.1",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-20.2.1.tgz",
+      "integrity": "sha512-7tFImggNeNBVMsn0vLrpn1H1uPrUBdnARPTpZoitY37ZrdJREzf7I16tMrlK3hen349gr1NYh8CmZQa7CTG6Aw==",
+      "dev": true
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/core-js": {
+      "version": "2.6.12",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
+      "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
+      "deprecated": "core-js@<3.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Please, upgrade your dependencies to the actual version of core-js.",
+      "hasInstallScript": true
+    },
+    "node_modules/diff-sequences": {
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-27.0.6.tgz",
+      "integrity": "sha512-ag6wfpBFyNXZ0p8pcuIDS//D8H062ZQJ3fzYxjpmeKjnz8W4pekL3AI8VohmyZmsWW2PWaHgjsmqR6L13101VQ==",
+      "dev": true,
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
+    },
+    "node_modules/fsm-iterator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fsm-iterator/-/fsm-iterator-1.1.0.tgz",
+      "integrity": "sha1-M33kXeGesgV4jPAuOpVewgZ2Dew="
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/immer": {
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.6.tgz",
+      "integrity": "sha512-G95ivKpy+EvVAnAab4fVa4YGYn24J1SpEktnJX7JJ45Bd7xqME/SCplFzYFmTbrkwZbQ4xJK1xMTUYBkN6pWsQ==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
+    "node_modules/jest-diff": {
+      "version": "27.1.1",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-27.1.1.tgz",
+      "integrity": "sha512-m/6n5158rqEriTazqHtBpOa2B/gGgXJijX6nsEgZfbJ/3pxQcdpVXBe+FP39b1dxWHyLVVmuVXddmAwtqFO4Lg==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "^27.0.6",
+        "jest-get-type": "^27.0.6",
+        "pretty-format": "^27.1.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/jest-get-type": {
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-27.0.6.tgz",
+      "integrity": "sha512-XTkK5exIeUbbveehcSR8w0bhH+c0yloW/Wpl+9vZrjzztCPWrxhHwkIFpZzCt71oRBsgxmuUfxEqOYoZI2macg==",
+      "dev": true,
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/jest-websocket-mock": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/jest-websocket-mock/-/jest-websocket-mock-2.2.1.tgz",
+      "integrity": "sha512-fhsGLXrPfs06PhHoxqOSA9yZ6Rb4qYrf4Wcm7/nfRzjlrf1gIeuhYUkzMRjjE0TMQ37SwkmeLanwrZY4ZaNp8g==",
+      "dev": true,
+      "dependencies": {
+        "jest-diff": "^27.0.2"
+      },
+      "peerDependencies": {
+        "mock-socket": "^8||^9"
+      }
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
+    },
+    "node_modules/lodash.ismatch": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz",
+      "integrity": "sha1-dWy1FQyjum8RCFp4hJZF8Yj4Xzc="
+    },
+    "node_modules/loglevel": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.7.1.tgz",
+      "integrity": "sha512-Hesni4s5UkWkwCGJMQGAh71PaLUmKFM60dHvq0zi/vDhhrzuk+4GgNbTXJ12YYQJn6ZKBDNIjYcuQGKudvqrIw==",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "funding": {
+        "type": "tidelift",
+        "url": "https://tidelift.com/funding/github/npm/loglevel"
+      }
+    },
+    "node_modules/mock-socket": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/mock-socket/-/mock-socket-9.0.3.tgz",
+      "integrity": "sha512-SxIiD2yE/By79p3cNAAXyLQWTvEFNEzcAO7PH+DzRqKSFaplAPFjiQLmw8ofmpCsZf+Rhfn2/xCJagpdGmYdTw==",
+      "dev": true,
+      "dependencies": {
+        "url-parse": "^1.4.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.1.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.1.1.tgz",
+      "integrity": "sha512-zdBi/xlstKJL42UH7goQti5Hip/B415w1Mfj+WWWYMBylAYtKESnXGUtVVcMVid9ReVjypCotUV6CEevYPHv2g==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "^27.1.1",
+        "ansi-regex": "^5.0.0",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "dev": true
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true
+    },
+    "node_modules/redux": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.1.1.tgz",
+      "integrity": "sha512-hZQZdDEM25UY2P493kPYuKqviVwZ58lEmGQNeQ+gXa+U0gYPUBf7NKYazbe3m+bs/DzM/ahN12DbF+NG8i0CWw==",
+      "dependencies": {
+        "@babel/runtime": "^7.9.2"
+      }
+    },
+    "node_modules/redux-saga": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/redux-saga/-/redux-saga-1.1.3.tgz",
+      "integrity": "sha512-RkSn/z0mwaSa5/xH/hQLo8gNf4tlvT18qXDNvedihLcfzh+jMchDgaariQoehCpgRltEm4zHKJyINEz6aqswTw==",
+      "dependencies": {
+        "@redux-saga/core": "^1.1.3"
+      }
+    },
+    "node_modules/redux-saga-test-plan": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/redux-saga-test-plan/-/redux-saga-test-plan-4.0.3.tgz",
+      "integrity": "sha512-bhiWnwb3Gvsu1iUh8A4jUvDxhf1AU/ZfjTspDMWf2fRFUCBeKBnTBm+UcKAPRJxKro5h1ypS/jaFNb7kJaf5yw==",
+      "dependencies": {
+        "core-js": "^2.4.1",
+        "fsm-iterator": "^1.1.0",
+        "lodash.isequal": "^4.5.0",
+        "lodash.ismatch": "^4.4.0",
+        "object-assign": "^4.1.0"
+      },
+      "peerDependencies": {
+        "@redux-saga/is": "^1.0.1",
+        "@redux-saga/symbols": "^1.0.1",
+        "redux-saga": "^1.0.1"
+      }
+    },
+    "node_modules/redux-thunk": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.3.0.tgz",
+      "integrity": "sha512-km6dclyFnmcvxhAcrQV2AkZmPQjzPDjgVlQtR0EQjxZPyJ0BnMf3in1ryuR8A2qU0HldVRfxYXbFSKlI3N7Slw=="
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.9",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
+      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
+      "dev": true
+    },
+    "node_modules/reselect": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.0.0.tgz",
+      "integrity": "sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA=="
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/typescript-compare": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/typescript-compare/-/typescript-compare-0.0.2.tgz",
+      "integrity": "sha512-8ja4j7pMHkfLJQO2/8tut7ub+J3Lw2S3061eJLFQcvs3tsmJKp8KG5NtpLn7KcY2w08edF74BSVN7qJS0U6oHA==",
+      "dependencies": {
+        "typescript-logic": "^0.0.0"
+      }
+    },
+    "node_modules/typescript-logic": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/typescript-logic/-/typescript-logic-0.0.0.tgz",
+      "integrity": "sha512-zXFars5LUkI3zP492ls0VskH3TtdeHCqu0i7/duGt60i5IGPIpAHE/DWo5FqJ6EjQ15YKXrt+AETjv60Dat34Q=="
+    },
+    "node_modules/typescript-tuple": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/typescript-tuple/-/typescript-tuple-2.2.1.tgz",
+      "integrity": "sha512-Zcr0lbt8z5ZdEzERHAMAniTiIKerFCMgd7yjq1fPnDJ43et/k9twIFQMUYff9k5oXcsQ0WpvFcgzK2ZKASoW6Q==",
+      "dependencies": {
+        "typescript-compare": "^0.0.2"
+      }
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.3.tgz",
+      "integrity": "sha512-IIORyIQD9rvj0A4CLWsHkBBJuNqWpFQe224b6j9t/ABmquIS0qDU2pY6kl6AuOrL5OkCXHMCFNe1jBcuAggjvQ==",
+      "dev": true,
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    }
+  },
+  "dependencies": {
+    "@babel/runtime": {
+      "version": "7.15.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.15.4.tgz",
+      "integrity": "sha512-99catp6bHCaxr4sJ/DbTGgHS4+Rs2RVd2g7iOap6SLGPDknRK9ztKNsE/Fg6QhSeh1FGE5f6gHGQmvvn3I3xhw==",
+      "requires": {
+        "regenerator-runtime": "^0.13.4"
+      }
+    },
+    "@jest/types": {
+      "version": "27.1.1",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.1.tgz",
+      "integrity": "sha512-yqJPDDseb0mXgKqmNqypCsb85C22K1aY5+LUxh7syIM9n/b0AsaltxNy+o6tt29VcfGDpYEve175bm3uOhcehA==",
+      "dev": true,
+      "requires": {
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^16.0.0",
+        "chalk": "^4.0.0"
+      }
+    },
+    "@redux-saga/core": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@redux-saga/core/-/core-1.1.3.tgz",
+      "integrity": "sha512-8tInBftak8TPzE6X13ABmEtRJGjtK17w7VUs7qV17S8hCO5S3+aUTWZ/DBsBJPdE8Z5jOPwYALyvofgq1Ws+kg==",
+      "requires": {
+        "@babel/runtime": "^7.6.3",
+        "@redux-saga/deferred": "^1.1.2",
+        "@redux-saga/delay-p": "^1.1.2",
+        "@redux-saga/is": "^1.1.2",
+        "@redux-saga/symbols": "^1.1.2",
+        "@redux-saga/types": "^1.1.0",
+        "redux": "^4.0.4",
+        "typescript-tuple": "^2.2.1"
+      }
+    },
+    "@redux-saga/deferred": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@redux-saga/deferred/-/deferred-1.1.2.tgz",
+      "integrity": "sha512-908rDLHFN2UUzt2jb4uOzj6afpjgJe3MjICaUNO3bvkV/kN/cNeI9PMr8BsFXB/MR8WTAZQq/PlTq8Kww3TBSQ=="
+    },
+    "@redux-saga/delay-p": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@redux-saga/delay-p/-/delay-p-1.1.2.tgz",
+      "integrity": "sha512-ojc+1IoC6OP65Ts5+ZHbEYdrohmIw1j9P7HS9MOJezqMYtCDgpkoqB5enAAZrNtnbSL6gVCWPHaoaTY5KeO0/g==",
+      "requires": {
+        "@redux-saga/symbols": "^1.1.2"
+      }
+    },
+    "@redux-saga/is": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@redux-saga/is/-/is-1.1.2.tgz",
+      "integrity": "sha512-OLbunKVsCVNTKEf2cH4TYyNbbPgvmZ52iaxBD4I1fTif4+MTXMa4/Z07L83zW/hTCXwpSZvXogqMqLfex2Tg6w==",
+      "requires": {
+        "@redux-saga/symbols": "^1.1.2",
+        "@redux-saga/types": "^1.1.0"
+      }
+    },
+    "@redux-saga/symbols": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@redux-saga/symbols/-/symbols-1.1.2.tgz",
+      "integrity": "sha512-EfdGnF423glv3uMwLsGAtE6bg+R9MdqlHEzExnfagXPrIiuxwr3bdiAwz3gi+PsrQ3yBlaBpfGLtDG8rf3LgQQ=="
+    },
+    "@redux-saga/types": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@redux-saga/types/-/types-1.1.0.tgz",
+      "integrity": "sha512-afmTuJrylUU/0OtqzaRkbyYFFNgCF73Bvel/sw90pvGrWIZ+vyoIJqA6eMSoA6+nb443kTmulmBtC9NerXboNg=="
+    },
+    "@reduxjs/toolkit": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.6.1.tgz",
+      "integrity": "sha512-pa3nqclCJaZPAyBhruQtiRwtTjottRrVJqziVZcWzI73i6L3miLTtUyWfauwv08HWtiXLx1xGyGt+yLFfW/d0A==",
+      "requires": {
+        "immer": "^9.0.1",
+        "redux": "^4.1.0",
+        "redux-thunk": "^2.3.0",
+        "reselect": "^4.0.0"
+      }
+    },
+    "@types/istanbul-lib-coverage": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
+      "integrity": "sha512-sz7iLqvVUg1gIedBOvlkxPlc8/uVzyS5OwGz1cKjXzkl3FpL3al0crU8YGU1WoHkxn0Wxbw5tyi6hvzJKNzFsw==",
+      "dev": true
+    },
+    "@types/istanbul-lib-report": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
+      "integrity": "sha512-plGgXAPfVKFoYfa9NpYDAkseG+g6Jr294RqeqcqDixSbU34MZVJRi/P+7Y8GDpzkEwLaGZZOpKIEmeVZNtKsrg==",
+      "dev": true,
+      "requires": {
+        "@types/istanbul-lib-coverage": "*"
+      }
+    },
+    "@types/istanbul-reports": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.1.tgz",
+      "integrity": "sha512-c3mAZEuK0lvBp8tmuL74XRKn1+y2dcwOUpH7x4WrF6gk1GIgiluDRgMYQtw2OFcBvAJWlt6ASU3tSqxp0Uu0Aw==",
+      "dev": true,
+      "requires": {
+        "@types/istanbul-lib-report": "*"
+      }
+    },
+    "@types/node": {
+      "version": "16.9.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.9.1.tgz",
+      "integrity": "sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g==",
+      "dev": true
+    },
+    "@types/uuid": {
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.1.tgz",
+      "integrity": "sha512-Y2mHTRAbqfFkpjldbkHGY8JIzRN6XqYRliG8/24FcHm2D2PwW24fl5xMRTVGdrb7iMrwCaIEbLWerGIkXuFWVg=="
+    },
+    "@types/yargs": {
+      "version": "16.0.4",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.4.tgz",
+      "integrity": "sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==",
+      "dev": true,
+      "requires": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "@types/yargs-parser": {
+      "version": "20.2.1",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-20.2.1.tgz",
+      "integrity": "sha512-7tFImggNeNBVMsn0vLrpn1H1uPrUBdnARPTpZoitY37ZrdJREzf7I16tMrlK3hen349gr1NYh8CmZQa7CTG6Aw==",
+      "dev": true
+    },
+    "ansi-regex": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "requires": {
+        "color-convert": "^2.0.1"
+      }
+    },
+    "chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      }
+    },
+    "color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "requires": {
+        "color-name": "~1.1.4"
+      }
+    },
+    "color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "core-js": {
+      "version": "2.6.12",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
+      "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="
+    },
+    "diff-sequences": {
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-27.0.6.tgz",
+      "integrity": "sha512-ag6wfpBFyNXZ0p8pcuIDS//D8H062ZQJ3fzYxjpmeKjnz8W4pekL3AI8VohmyZmsWW2PWaHgjsmqR6L13101VQ==",
+      "dev": true
+    },
+    "eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
+    },
+    "fsm-iterator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fsm-iterator/-/fsm-iterator-1.1.0.tgz",
+      "integrity": "sha1-M33kXeGesgV4jPAuOpVewgZ2Dew="
+    },
+    "has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true
+    },
+    "immer": {
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.6.tgz",
+      "integrity": "sha512-G95ivKpy+EvVAnAab4fVa4YGYn24J1SpEktnJX7JJ45Bd7xqME/SCplFzYFmTbrkwZbQ4xJK1xMTUYBkN6pWsQ=="
+    },
+    "jest-diff": {
+      "version": "27.1.1",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-27.1.1.tgz",
+      "integrity": "sha512-m/6n5158rqEriTazqHtBpOa2B/gGgXJijX6nsEgZfbJ/3pxQcdpVXBe+FP39b1dxWHyLVVmuVXddmAwtqFO4Lg==",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "^27.0.6",
+        "jest-get-type": "^27.0.6",
+        "pretty-format": "^27.1.1"
+      }
+    },
+    "jest-get-type": {
+      "version": "27.0.6",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-27.0.6.tgz",
+      "integrity": "sha512-XTkK5exIeUbbveehcSR8w0bhH+c0yloW/Wpl+9vZrjzztCPWrxhHwkIFpZzCt71oRBsgxmuUfxEqOYoZI2macg==",
+      "dev": true
+    },
+    "jest-websocket-mock": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/jest-websocket-mock/-/jest-websocket-mock-2.2.1.tgz",
+      "integrity": "sha512-fhsGLXrPfs06PhHoxqOSA9yZ6Rb4qYrf4Wcm7/nfRzjlrf1gIeuhYUkzMRjjE0TMQ37SwkmeLanwrZY4ZaNp8g==",
+      "dev": true,
+      "requires": {
+        "jest-diff": "^27.0.2"
+      }
+    },
+    "lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
+    },
+    "lodash.ismatch": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz",
+      "integrity": "sha1-dWy1FQyjum8RCFp4hJZF8Yj4Xzc="
+    },
+    "loglevel": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.7.1.tgz",
+      "integrity": "sha512-Hesni4s5UkWkwCGJMQGAh71PaLUmKFM60dHvq0zi/vDhhrzuk+4GgNbTXJ12YYQJn6ZKBDNIjYcuQGKudvqrIw=="
+    },
+    "mock-socket": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/mock-socket/-/mock-socket-9.0.3.tgz",
+      "integrity": "sha512-SxIiD2yE/By79p3cNAAXyLQWTvEFNEzcAO7PH+DzRqKSFaplAPFjiQLmw8ofmpCsZf+Rhfn2/xCJagpdGmYdTw==",
+      "dev": true,
+      "requires": {
+        "url-parse": "^1.4.4"
+      }
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+    },
+    "pretty-format": {
+      "version": "27.1.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.1.1.tgz",
+      "integrity": "sha512-zdBi/xlstKJL42UH7goQti5Hip/B415w1Mfj+WWWYMBylAYtKESnXGUtVVcMVid9ReVjypCotUV6CEevYPHv2g==",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^27.1.1",
+        "ansi-regex": "^5.0.0",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+          "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+          "dev": true
+        }
+      }
+    },
+    "querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "dev": true
+    },
+    "react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true
+    },
+    "redux": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.1.1.tgz",
+      "integrity": "sha512-hZQZdDEM25UY2P493kPYuKqviVwZ58lEmGQNeQ+gXa+U0gYPUBf7NKYazbe3m+bs/DzM/ahN12DbF+NG8i0CWw==",
+      "requires": {
+        "@babel/runtime": "^7.9.2"
+      }
+    },
+    "redux-saga": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/redux-saga/-/redux-saga-1.1.3.tgz",
+      "integrity": "sha512-RkSn/z0mwaSa5/xH/hQLo8gNf4tlvT18qXDNvedihLcfzh+jMchDgaariQoehCpgRltEm4zHKJyINEz6aqswTw==",
+      "requires": {
+        "@redux-saga/core": "^1.1.3"
+      }
+    },
+    "redux-saga-test-plan": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/redux-saga-test-plan/-/redux-saga-test-plan-4.0.3.tgz",
+      "integrity": "sha512-bhiWnwb3Gvsu1iUh8A4jUvDxhf1AU/ZfjTspDMWf2fRFUCBeKBnTBm+UcKAPRJxKro5h1ypS/jaFNb7kJaf5yw==",
+      "requires": {
+        "core-js": "^2.4.1",
+        "fsm-iterator": "^1.1.0",
+        "lodash.isequal": "^4.5.0",
+        "lodash.ismatch": "^4.4.0",
+        "object-assign": "^4.1.0"
+      }
+    },
+    "redux-thunk": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.3.0.tgz",
+      "integrity": "sha512-km6dclyFnmcvxhAcrQV2AkZmPQjzPDjgVlQtR0EQjxZPyJ0BnMf3in1ryuR8A2qU0HldVRfxYXbFSKlI3N7Slw=="
+    },
+    "regenerator-runtime": {
+      "version": "0.13.9",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
+      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
+    },
+    "requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
+      "dev": true
+    },
+    "reselect": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.0.0.tgz",
+      "integrity": "sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA=="
+    },
+    "supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "requires": {
+        "has-flag": "^4.0.0"
+      }
+    },
+    "typescript-compare": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/typescript-compare/-/typescript-compare-0.0.2.tgz",
+      "integrity": "sha512-8ja4j7pMHkfLJQO2/8tut7ub+J3Lw2S3061eJLFQcvs3tsmJKp8KG5NtpLn7KcY2w08edF74BSVN7qJS0U6oHA==",
+      "requires": {
+        "typescript-logic": "^0.0.0"
+      }
+    },
+    "typescript-logic": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/typescript-logic/-/typescript-logic-0.0.0.tgz",
+      "integrity": "sha512-zXFars5LUkI3zP492ls0VskH3TtdeHCqu0i7/duGt60i5IGPIpAHE/DWo5FqJ6EjQ15YKXrt+AETjv60Dat34Q=="
+    },
+    "typescript-tuple": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/typescript-tuple/-/typescript-tuple-2.2.1.tgz",
+      "integrity": "sha512-Zcr0lbt8z5ZdEzERHAMAniTiIKerFCMgd7yjq1fPnDJ43et/k9twIFQMUYff9k5oXcsQ0WpvFcgzK2ZKASoW6Q==",
+      "requires": {
+        "typescript-compare": "^0.0.2"
+      }
+    },
+    "url-parse": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.3.tgz",
+      "integrity": "sha512-IIORyIQD9rvj0A4CLWsHkBBJuNqWpFQe224b6j9t/ABmquIS0qDU2pY6kl6AuOrL5OkCXHMCFNe1jBcuAggjvQ==",
+      "dev": true,
+      "requires": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    },
+    "uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+    }
+  }
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -43,7 +43,6 @@
     "loglevel": "^1.7.1",
     "redux-saga": "^1.1.3",
     "redux-saga-test-plan": "^4.0.1",
-    "strict-event-emitter-types": "^2.0.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/packages/core/src/BaseClient.ts
+++ b/packages/core/src/BaseClient.ts
@@ -2,9 +2,12 @@ import { AuthError } from './CustomErrors'
 import { destroyAction, initAction } from './redux'
 import { BaseClientOptions } from './utils/interfaces'
 import { BaseComponent } from './BaseComponent'
+import { EventEmitter } from './utils/EventEmitter'
 
-export class BaseClient extends BaseComponent {
-  constructor(public options: BaseClientOptions) {
+export class BaseClient<
+  EventTypes extends EventEmitter.ValidEventTypes
+> extends BaseComponent<EventTypes> {
+  constructor(public options: BaseClientOptions<EventTypes>) {
     super(options)
   }
 

--- a/packages/core/src/BaseComponent.test.ts
+++ b/packages/core/src/BaseComponent.test.ts
@@ -4,7 +4,7 @@ import { EventEmitter } from './utils/EventEmitter'
 
 describe('BaseComponent', () => {
   describe('as an event emitter', () => {
-    class JestComponent extends BaseComponent {
+    class JestComponent extends BaseComponent<any> {
       protected _eventsPrefix = 'video' as const
 
       constructor(namespace = '') {
@@ -17,7 +17,7 @@ describe('BaseComponent', () => {
       }
     }
 
-    let instance: BaseComponent
+    let instance: BaseComponent<any>
 
     beforeEach(() => {
       instance = new JestComponent()

--- a/packages/core/src/BaseComponent.ts
+++ b/packages/core/src/BaseComponent.ts
@@ -283,7 +283,7 @@ export class BaseComponent<
       const internalNotNamespacedEvent = toInternalEventName({ event })
       const transform = this._emitterTransforms.get(internalNotNamespacedEvent)
       if (!transform) {
-        // @ts-ignore
+        // @ts-expect-error
         return fn(payload)
       }
 
@@ -314,7 +314,7 @@ export class BaseComponent<
         },
       })
 
-      // @ts-ignore
+      // @ts-expect-error
       return fn(proxiedObj)
     }
     return wrapperHandler as EventEmitter.EventListener<
@@ -360,7 +360,7 @@ export class BaseComponent<
     return [
       this._getPrefixedEvent(event) as EventEmitter.EventNames<EventTypes>,
       ...rest,
-    ] as any as T
+    ] as T
   }
 
   on<T extends EventEmitter.EventNames<EventTypes>>(
@@ -649,11 +649,17 @@ export class BaseComponent<
   protected applyEmitterTransforms() {
     this.getEmitterTransforms().forEach((handlersObj, key) => {
       if (Array.isArray(key)) {
-        // @ts-ignore
-        key.forEach((k) => this._emitterTransforms.set(k, handlersObj))
+        key.forEach((k) =>
+          this._emitterTransforms.set(
+            k as EventEmitter.EventNames<EventTypes>,
+            handlersObj
+          )
+        )
       } else {
-        // @ts-ignore
-        this._emitterTransforms.set(key, handlersObj)
+        this._emitterTransforms.set(
+          key as EventEmitter.EventNames<EventTypes>,
+          handlersObj
+        )
       }
     })
   }

--- a/packages/core/src/BaseComponent.ts
+++ b/packages/core/src/BaseComponent.ts
@@ -146,7 +146,7 @@ export class BaseComponent<
       type: options.type,
       params: options.params,
     })
-    return this.emitter as any as EventEmitter<EventTypes>
+    return this.emitter as EventEmitter<EventTypes>
   }
 
   /** @internal */

--- a/packages/core/src/redux/connect.ts
+++ b/packages/core/src/redux/connect.ts
@@ -20,7 +20,6 @@ interface Connect<T> {
 type ReduxComponentKeys = keyof ReduxComponent
 type ReduxSessionKeys = keyof SessionState
 
-// TODO: check generic
 export const connect = <
   EventTypes extends EventEmitter.ValidEventTypes,
   T extends BaseComponent<EventTypes>

--- a/packages/core/src/redux/connect.ts
+++ b/packages/core/src/redux/connect.ts
@@ -19,7 +19,8 @@ interface Connect<T> {
 type ReduxComponentKeys = keyof ReduxComponent
 type ReduxSessionKeys = keyof SessionState
 
-export const connect = <T extends BaseComponent>(options: Connect<T>) => {
+// TODO: check generic
+export const connect = <T extends BaseComponent<{}>>(options: Connect<T>) => {
   const {
     componentListeners = {},
     sessionListeners = {},

--- a/packages/core/src/redux/connect.ts
+++ b/packages/core/src/redux/connect.ts
@@ -4,6 +4,7 @@ import { componentActions } from './features'
 import { getComponent } from './features/component/componentSelectors'
 import { getSession } from './features/session/sessionSelectors'
 import type { BaseComponent } from '../BaseComponent'
+import { EventEmitter } from '../utils/EventEmitter'
 
 type ComponentEventHandler = (component: ReduxComponent) => unknown
 type SessionEventHandler = (session: SessionState) => unknown
@@ -20,7 +21,12 @@ type ReduxComponentKeys = keyof ReduxComponent
 type ReduxSessionKeys = keyof SessionState
 
 // TODO: check generic
-export const connect = <T extends BaseComponent<{}>>(options: Connect<T>) => {
+export const connect = <
+  EventTypes extends EventEmitter.ValidEventTypes,
+  T extends BaseComponent<EventTypes>
+>(
+  options: Connect<T>
+) => {
   const {
     componentListeners = {},
     sessionListeners = {},

--- a/packages/core/src/redux/features/pubSub/pubSubSaga.test.ts
+++ b/packages/core/src/redux/features/pubSub/pubSubSaga.test.ts
@@ -39,7 +39,7 @@ describe('sessionChannelWatcher', () => {
 
   it('should be resilient to the end-user errors', () => {
     let runSagaCounter = 0
-    const emitter = new EventEmitter()
+    const emitter = new EventEmitter<string>()
     const mockFn = jest.fn()
     emitter.on('exception', () => {
       throw 'Jest Error'
@@ -49,7 +49,6 @@ describe('sessionChannelWatcher', () => {
 
     return expectSaga(pubSubSaga, {
       pubSubChannel,
-      // @ts-expect-error
       emitter,
     })
       .provide([

--- a/packages/core/src/redux/features/pubSub/pubSubSaga.test.ts
+++ b/packages/core/src/redux/features/pubSub/pubSubSaga.test.ts
@@ -7,14 +7,13 @@ import { createPubSubChannel } from '../../../testUtils'
 describe('sessionChannelWatcher', () => {
   it('should take from pubSubChannel and emit through the EventEmitter', () => {
     let runSaga = true
-    const emitter = new EventEmitter()
+    const emitter = new EventEmitter<string>()
     const mockFn = jest.fn()
     emitter.on('event.name', mockFn)
     const pubSubChannel = createPubSubChannel()
 
     return expectSaga(pubSubSaga, {
       pubSubChannel,
-      // @ts-expect-error
       emitter,
     })
       .provide([

--- a/packages/core/src/redux/features/pubSub/pubSubSaga.test.ts
+++ b/packages/core/src/redux/features/pubSub/pubSubSaga.test.ts
@@ -14,6 +14,7 @@ describe('sessionChannelWatcher', () => {
 
     return expectSaga(pubSubSaga, {
       pubSubChannel,
+      // @ts-expect-error
       emitter,
     })
       .provide([
@@ -48,6 +49,7 @@ describe('sessionChannelWatcher', () => {
 
     return expectSaga(pubSubSaga, {
       pubSubChannel,
+      // @ts-expect-error
       emitter,
     })
       .provide([

--- a/packages/core/src/redux/features/pubSub/pubSubSaga.ts
+++ b/packages/core/src/redux/features/pubSub/pubSubSaga.ts
@@ -42,8 +42,10 @@ export function* pubSubSaga({
         emitter.emit(type, payload)
       }
 
-      // @ts-expect-error
-      emitter.emit(toInternalEventName<{}>({ namespace, event: type }), payload)
+      emitter.emit(
+        toInternalEventName<string>({ namespace, event: type }),
+        payload
+      )
     } catch (error) {
       logger.error(error)
     }

--- a/packages/core/src/redux/features/pubSub/pubSubSaga.ts
+++ b/packages/core/src/redux/features/pubSub/pubSubSaga.ts
@@ -10,7 +10,8 @@ import { PubSubChannel, PubSubAction } from '../../interfaces'
 
 type PubSubSagaParams = {
   pubSubChannel: PubSubChannel
-  emitter: Emitter
+  // TODO: check generic
+  emitter: Emitter<{}>
 }
 const findNamespaceInPayload = (payload?: any): string => {
   /**
@@ -39,10 +40,12 @@ export function* pubSubSaga({
        * event twice to reach everyone.
        */
       if (isInternalGlobalEvent(type)) {
+        // @ts-expect-error
         emitter.emit(type, payload)
       }
 
-      emitter.emit(toInternalEventName({ namespace, event: type }), payload)
+      // @ts-expect-error
+      emitter.emit(toInternalEventName<{}>({ namespace, event: type }), payload)
     } catch (error) {
       logger.error(error)
     }

--- a/packages/core/src/redux/features/pubSub/pubSubSaga.ts
+++ b/packages/core/src/redux/features/pubSub/pubSubSaga.ts
@@ -6,7 +6,7 @@ import {
   toInternalEventName,
 } from '../../../utils'
 import type { Emitter } from '../../../utils/interfaces'
-import { PubSubChannel, PubSubAction } from '../../interfaces'
+import type { PubSubChannel, PubSubAction } from '../../interfaces'
 
 type PubSubSagaParams = {
   pubSubChannel: PubSubChannel

--- a/packages/core/src/redux/features/pubSub/pubSubSaga.ts
+++ b/packages/core/src/redux/features/pubSub/pubSubSaga.ts
@@ -10,8 +10,7 @@ import { PubSubChannel, PubSubAction } from '../../interfaces'
 
 type PubSubSagaParams = {
   pubSubChannel: PubSubChannel
-  // TODO: check generic
-  emitter: Emitter<{}>
+  emitter: Emitter<string>
 }
 const findNamespaceInPayload = (payload?: any): string => {
   /**
@@ -40,7 +39,6 @@ export function* pubSubSaga({
        * event twice to reach everyone.
        */
       if (isInternalGlobalEvent(type)) {
-        // @ts-expect-error
         emitter.emit(type, payload)
       }
 

--- a/packages/core/src/redux/features/session/sessionSaga.test.ts
+++ b/packages/core/src/redux/features/session/sessionSaga.test.ts
@@ -762,6 +762,7 @@ describe('sessionChannelWatcher', () => {
             componentActions.upsert({
               id: '05274260-163b-43b7-805e-b4b14f92baaf',
               audioConstraints: {
+                // @ts-expect-error
                 autoGainControl: false,
                 echoCancellation: false,
                 noiseSuppression: false,

--- a/packages/core/src/redux/index.ts
+++ b/packages/core/src/redux/index.ts
@@ -7,7 +7,8 @@ import { connect } from './connect'
 import { UserOptions, SessionConstructor } from '../utils/interfaces'
 
 interface ConfigureStoreOptions {
-  userOptions: UserOptions
+  // TODO: check generic
+  userOptions: UserOptions<Record<string, any>>
   SessionConstructor: SessionConstructor
   runSagaMiddleware?: boolean
   preloadedState?: Partial<SDKState>

--- a/packages/core/src/redux/index.ts
+++ b/packages/core/src/redux/index.ts
@@ -4,11 +4,10 @@ import { rootReducer } from './rootReducer'
 import rootSaga from './rootSaga'
 import { SDKState } from './interfaces'
 import { connect } from './connect'
-import { UserOptions, SessionConstructor } from '../utils/interfaces'
+import { InternalUserOptions, SessionConstructor } from '../utils/interfaces'
 
 interface ConfigureStoreOptions {
-  // TODO: check generic
-  userOptions: UserOptions<Record<string, any>>
+  userOptions: InternalUserOptions
   SessionConstructor: SessionConstructor
   runSagaMiddleware?: boolean
   preloadedState?: Partial<SDKState>

--- a/packages/core/src/redux/rootSaga.test.ts
+++ b/packages/core/src/redux/rootSaga.test.ts
@@ -85,6 +85,7 @@ describe('sessionStatusWatcher', () => {
   const sessionChannel = eventChannel(() => () => {})
   const userOptions = {
     token: '',
+    emitter: jest.fn() as any,
   }
   const options = {
     session,
@@ -135,6 +136,7 @@ describe('initSessionSaga', () => {
   })
   const userOptions = {
     token: '',
+    emitter: jest.fn() as any,
   }
 
   beforeEach(() => {
@@ -225,7 +227,7 @@ describe('rootSaga', () => {
     const SessionConstructor = jest.fn().mockImplementation(() => {
       return session
     })
-    const userOptions = { token: '' }
+    const userOptions = { token: '', emitter: jest.fn() as any }
     const saga = testSaga(
       rootSaga({
         SessionConstructor,

--- a/packages/core/src/redux/rootSaga.ts
+++ b/packages/core/src/redux/rootSaga.ts
@@ -35,12 +35,14 @@ type StartSagaOptions = {
   session: BaseSession
   sessionChannel: EventChannel<unknown>
   pubSubChannel: PubSubChannel
-  userOptions: UserOptions
+  // TODO: check generic
+  userOptions: UserOptions<{}>
 }
 
 export function* initSessionSaga(
   SessionConstructor: SessionConstructor,
-  userOptions: UserOptions
+  // TODO: check generic
+  userOptions: UserOptions<{}>
 ): SagaIterator {
   const session = new SessionConstructor(userOptions)
 
@@ -168,7 +170,8 @@ interface RootSagaOptions {
 }
 
 export default (options: RootSagaOptions) => {
-  return function* root(userOptions: UserOptions): SagaIterator {
+  // TODO: check generic
+  return function* root(userOptions: UserOptions<{}>): SagaIterator {
     yield fork(executeQueueWatcher)
 
     /**

--- a/packages/core/src/redux/rootSaga.ts
+++ b/packages/core/src/redux/rootSaga.ts
@@ -1,7 +1,8 @@
 import { Task, SagaIterator } from '@redux-saga/types'
 import { channel, EventChannel } from 'redux-saga'
 import { fork, call, take, put, delay } from '@redux-saga/core/effects'
-import { UserOptions, SessionConstructor } from '../utils/interfaces'
+import { SessionConstructor, InternalUserOptions } from '../utils/interfaces'
+import { BaseSession } from '../BaseSession'
 import {
   executeActionWatcher,
   sessionChannelWatcher,
@@ -21,7 +22,6 @@ import {
   sessionConnectedAction,
 } from './actions'
 import { sessionActions } from './features'
-import { BaseSession } from '..'
 import {
   authErrorAction,
   authSuccessAction,
@@ -31,18 +31,16 @@ import {
 import { AuthError } from '../CustomErrors'
 import { PubSubChannel } from './interfaces'
 
-type StartSagaOptions = {
+interface StartSagaOptions {
   session: BaseSession
   sessionChannel: EventChannel<unknown>
   pubSubChannel: PubSubChannel
-  // TODO: check generic
-  userOptions: UserOptions<{}>
+  userOptions: InternalUserOptions
 }
 
 export function* initSessionSaga(
   SessionConstructor: SessionConstructor,
-  // TODO: check generic
-  userOptions: UserOptions<{}>
+  userOptions: InternalUserOptions
 ): SagaIterator {
   const session = new SessionConstructor(userOptions)
 
@@ -170,8 +168,7 @@ interface RootSagaOptions {
 }
 
 export default (options: RootSagaOptions) => {
-  // TODO: check generic
-  return function* root(userOptions: UserOptions<{}>): SagaIterator {
+  return function* root(userOptions: InternalUserOptions): SagaIterator {
     yield fork(executeQueueWatcher)
 
     /**

--- a/packages/core/src/rooms/RoomSessionRecording.test.ts
+++ b/packages/core/src/rooms/RoomSessionRecording.test.ts
@@ -3,6 +3,7 @@ import { EventEmitter } from '../utils/EventEmitter'
 import {
   createRoomSessionRecordingObject,
   RoomSessionRecordingAPI,
+  RoomSessionRecordingEvents,
 } from './RoomSessionRecording'
 
 describe('RoomSessionRecording', () => {
@@ -11,7 +12,7 @@ describe('RoomSessionRecording', () => {
     beforeEach(() => {
       instance = createRoomSessionRecordingObject({
         store: configureJestStore(),
-        emitter: new EventEmitter(),
+        emitter: new EventEmitter<RoomSessionRecordingEvents>(),
       })
       instance.execute = jest.fn()
     })

--- a/packages/core/src/rooms/RoomSessionRecording.ts
+++ b/packages/core/src/rooms/RoomSessionRecording.ts
@@ -51,10 +51,12 @@ export class RoomSessionRecordingAPI
 
 // TODO: move to its own file
 export const createRoomSessionRecordingObject = (
-  params: BaseComponentOptions
+  // TODO: check generic
+  params: BaseComponentOptions<{}>
 ) => {
-  const recording: RoomSessionRecordingAPI = connect({
+  const recording = connect({
     store: params.store,
+    // @ts-expect-error
     Component: RoomSessionRecordingAPI,
     componentListeners: {
       errors: 'onError',
@@ -62,5 +64,5 @@ export const createRoomSessionRecordingObject = (
     },
   })(params)
 
-  return recording
+  return recording as any as RoomSessionRecordingAPI
 }

--- a/packages/core/src/rooms/RoomSessionRecording.ts
+++ b/packages/core/src/rooms/RoomSessionRecording.ts
@@ -2,6 +2,7 @@ import { connect } from '../redux'
 import { BaseComponent } from '../BaseComponent'
 import { BaseComponentOptions } from '../utils/interfaces'
 import { OnlyFunctionProperties } from '../types'
+import type { VideoRecordingEventNames } from '../types/videoRecording'
 
 export interface RoomSessionRecording {
   id: string
@@ -14,8 +15,13 @@ export interface RoomSessionRecording {
   stop(): Promise<void>
 }
 
+type RoomSessionRecordingEvents = Record<
+  VideoRecordingEventNames,
+  (recording: RoomSessionRecording) => void
+>
+
 export class RoomSessionRecordingAPI
-  extends BaseComponent<RoomSessionRecording>
+  extends BaseComponent<RoomSessionRecordingEvents>
   implements OnlyFunctionProperties<RoomSessionRecording>
 {
   async pause() {
@@ -51,8 +57,7 @@ export class RoomSessionRecordingAPI
 
 // TODO: move to its own file
 export const createRoomSessionRecordingObject = (
-  // TODO: check generic
-  params: BaseComponentOptions<{}>
+  params: BaseComponentOptions<RoomSessionRecordingEvents>
 ) => {
   const recording = connect({
     store: params.store,

--- a/packages/core/src/rooms/RoomSessionRecording.ts
+++ b/packages/core/src/rooms/RoomSessionRecording.ts
@@ -15,7 +15,7 @@ export interface RoomSessionRecording {
   stop(): Promise<void>
 }
 
-type RoomSessionRecordingEvents = Record<
+export type RoomSessionRecordingEvents = Record<
   VideoRecordingEventNames,
   (recording: RoomSessionRecording) => void
 >

--- a/packages/core/src/rooms/RoomSessionRecording.ts
+++ b/packages/core/src/rooms/RoomSessionRecording.ts
@@ -58,10 +58,12 @@ export class RoomSessionRecordingAPI
 // TODO: move to its own file
 export const createRoomSessionRecordingObject = (
   params: BaseComponentOptions<RoomSessionRecordingEvents>
-) => {
-  const recording = connect({
+): RoomSessionRecordingAPI => {
+  const recording = connect<
+    RoomSessionRecordingEvents,
+    RoomSessionRecordingAPI
+  >({
     store: params.store,
-    // @ts-expect-error
     Component: RoomSessionRecordingAPI,
     componentListeners: {
       errors: 'onError',
@@ -69,5 +71,5 @@ export const createRoomSessionRecordingObject = (
     },
   })(params)
 
-  return recording as any as RoomSessionRecordingAPI
+  return recording
 }

--- a/packages/core/src/rooms/index.ts
+++ b/packages/core/src/rooms/index.ts
@@ -1,7 +1,8 @@
-import { BaseComponent } from '..'
+import { BaseComponent, EventEmitter } from '..'
 
-// TODO: check generic
-export interface BaseRoomInterface extends BaseComponent<{}> {
+export interface BaseRoomInterface<
+  EventTypes extends EventEmitter.ValidEventTypes
+> extends BaseComponent<EventTypes> {
   roomId: string
   roomSessionId: string
   memberId: string

--- a/packages/core/src/rooms/index.ts
+++ b/packages/core/src/rooms/index.ts
@@ -1,6 +1,7 @@
 import { BaseComponent } from '..'
 
-export interface BaseRoomInterface extends BaseComponent {
+// TODO: check generic
+export interface BaseRoomInterface extends BaseComponent<{}> {
   roomId: string
   roomSessionId: string
   memberId: string

--- a/packages/core/src/rooms/methods.ts
+++ b/packages/core/src/rooms/methods.ts
@@ -115,6 +115,7 @@ export const startRecording: RoomMethodDescriptor<any> = {
         resolve(instance)
       }
 
+      // @ts-ignore
       this.on('video.__internal__.recording.start', handler)
 
       try {
@@ -124,8 +125,10 @@ export const startRecording: RoomMethodDescriptor<any> = {
             room_session_id: this.roomSessionId,
           },
         })
+        // @ts-ignore
         this.emit('video.__internal__.recording.start', payload)
       } catch (error) {
+        // @ts-ignore
         this.off('video.__internal__.recording.start', handler)
         throw error
       }

--- a/packages/core/src/rooms/methods.ts
+++ b/packages/core/src/rooms/methods.ts
@@ -6,7 +6,7 @@ interface RoomMethodPropertyDescriptor<T> extends PropertyDescriptor {
   value: (params: RoomMethodParams) => Promise<T>
 }
 type RoomMethodDescriptor<T = unknown> = RoomMethodPropertyDescriptor<T> &
-  // TODO: is string enough here?
+  // TODO: Replace string with a tighter type
   ThisType<BaseRoomInterface<string>>
 type RoomMethodParams = Record<string, unknown>
 interface BaseRPCResult {
@@ -115,8 +115,6 @@ export const startRecording: RoomMethodDescriptor<any> = {
       const handler = (instance: any) => {
         resolve(instance)
       }
-
-      // @ts-ignore
       this.on('video.__internal__.recording.start', handler)
 
       try {
@@ -126,10 +124,8 @@ export const startRecording: RoomMethodDescriptor<any> = {
             room_session_id: this.roomSessionId,
           },
         })
-        // @ts-ignore
         this.emit('video.__internal__.recording.start', payload)
       } catch (error) {
-        // @ts-ignore
         this.off('video.__internal__.recording.start', handler)
         throw error
       }

--- a/packages/core/src/rooms/methods.ts
+++ b/packages/core/src/rooms/methods.ts
@@ -6,7 +6,8 @@ interface RoomMethodPropertyDescriptor<T> extends PropertyDescriptor {
   value: (params: RoomMethodParams) => Promise<T>
 }
 type RoomMethodDescriptor<T = unknown> = RoomMethodPropertyDescriptor<T> &
-  ThisType<BaseRoomInterface>
+  // TODO: is string enough here?
+  ThisType<BaseRoomInterface<string>>
 type RoomMethodParams = Record<string, unknown>
 interface BaseRPCResult {
   code: string

--- a/packages/core/src/setupTests.ts
+++ b/packages/core/src/setupTests.ts
@@ -1,6 +1,6 @@
 jest.mock('./utils', () => {
   return {
-    ...jest.requireActual('./utils'),
+    ...(jest.requireActual('./utils') as any),
     logger: {
       error: jest.fn(),
       warn: jest.fn(),

--- a/packages/core/src/testUtils.ts
+++ b/packages/core/src/testUtils.ts
@@ -3,6 +3,7 @@ import { configureStore } from './redux'
 import { PubSubChannel } from './redux/interfaces'
 import { BaseSession } from './BaseSession'
 import { RPCConnectResult } from './utils/interfaces'
+import { EventEmitter } from './utils/EventEmitter'
 
 const PROJECT_ID = '8f0a119a-cda7-4497-a47d-c81493b824d4'
 const TOKEN = '<VRT>'
@@ -19,6 +20,7 @@ export const configureJestStore = () => {
       project: PROJECT_ID,
       token: TOKEN,
       devTools: false,
+      emitter: new EventEmitter(),
     },
     SessionConstructor: BaseSession,
     runSagaMiddleware: false,

--- a/packages/core/src/utils/EventEmitter.ts
+++ b/packages/core/src/utils/EventEmitter.ts
@@ -26,7 +26,9 @@ const assertEventEmitter = (emitter: unknown): emitter is EventEmitter => {
   return false
 }
 
-const getEventEmitter = <T>(userOptions: UserOptions) => {
+const getEventEmitter = <T extends EventEmitter.ValidEventTypes>(
+  userOptions: UserOptions<T>
+) => {
   if (!userOptions.emitter) {
     const emitter = new EventEmitter()
     return emitter as StrictEventEmitter<EventEmitter, T>

--- a/packages/core/src/utils/EventEmitter.ts
+++ b/packages/core/src/utils/EventEmitter.ts
@@ -1,6 +1,4 @@
 import EventEmitter from 'eventemitter3'
-import StrictEventEmitter from 'strict-event-emitter-types'
-import { UserOptions } from './interfaces'
 
 const REQUIRED_EMITTER_METHODS = [
   'on',
@@ -26,21 +24,8 @@ const assertEventEmitter = (emitter: unknown): emitter is EventEmitter => {
   return false
 }
 
-const getEventEmitter = <T extends EventEmitter.ValidEventTypes>(
-  userOptions: UserOptions<T>
-) => {
-  if (!userOptions.emitter) {
-    const emitter = new EventEmitter()
-    return emitter as StrictEventEmitter<EventEmitter, T>
-  } else if (assertEventEmitter(userOptions.emitter)) {
-    return userOptions.emitter as unknown as StrictEventEmitter<EventEmitter, T>
-  }
-  // TODO: In future versions we can narrow this error a bit more and
-  // give the user more info about which method they are missing as
-  // well
-  throw new Error(
-    "The passed `emitter` doesn't expose the correct interface. Please check that your custom `emitter` comply with the `Emitter` interface."
-  )
+const getEventEmitter = <T extends EventEmitter.ValidEventTypes>() => {
+  return new EventEmitter<T>()
 }
 
 export { assertEventEmitter, EventEmitter, getEventEmitter }

--- a/packages/core/src/utils/interfaces.ts
+++ b/packages/core/src/utils/interfaces.ts
@@ -81,10 +81,13 @@ export interface SessionOptions {
   logLevel?: 'trace' | 'debug' | 'info' | 'warn' | 'error' | 'silent'
 }
 
-export interface UserOptions<EventTypes extends EventEmitter.ValidEventTypes>
-  extends SessionOptions {
+export interface UserOptions extends SessionOptions {
   devTools?: boolean
-  emitter?: Emitter<EventTypes>
+}
+
+export interface InternalUserOptions extends UserOptions {
+  // TODO: check if we need to make InternalUserOptions a generic
+  emitter: Emitter<any>
 }
 
 /**
@@ -93,8 +96,9 @@ export interface UserOptions<EventTypes extends EventEmitter.ValidEventTypes>
  * @internal
  */
 export interface BaseClientOptions<
-  EventTypes extends EventEmitter.ValidEventTypes
-> extends UserOptions<EventTypes> {
+  // TODO: review if having a default makes sense.
+  EventTypes extends EventEmitter.ValidEventTypes = any
+> extends UserOptions {
   store: SDKStore
   emitter: Emitter<EventTypes>
 }

--- a/packages/core/src/utils/interfaces.ts
+++ b/packages/core/src/utils/interfaces.ts
@@ -10,9 +10,15 @@ import {
 /**
  * Minimal interface the emitter must fulfill
  */
-export type Emitter = Pick<
-  EventEmitter,
-  'on' | 'off' | 'once' | 'emit' | 'removeAllListeners' | 'eventNames' | 'listenerCount'
+export type Emitter<T extends EventEmitter.ValidEventTypes> = Pick<
+  EventEmitter<T>,
+  | 'on'
+  | 'off'
+  | 'once'
+  | 'emit'
+  | 'removeAllListeners'
+  | 'eventNames'
+  | 'listenerCount'
 >
 
 type JSONRPCParams = Record<string, any>
@@ -75,9 +81,10 @@ export interface SessionOptions {
   logLevel?: 'trace' | 'debug' | 'info' | 'warn' | 'error' | 'silent'
 }
 
-export interface UserOptions extends SessionOptions {
+export interface UserOptions<EventTypes extends EventEmitter.ValidEventTypes>
+  extends SessionOptions {
   devTools?: boolean
-  emitter?: Emitter
+  emitter?: Emitter<EventTypes>
 }
 
 /**
@@ -85,14 +92,18 @@ export interface UserOptions extends SessionOptions {
  * the interface we use internally that extends the options provided.
  * @internal
  */
-export interface BaseClientOptions extends UserOptions {
+export interface BaseClientOptions<
+  EventTypes extends EventEmitter.ValidEventTypes
+> extends UserOptions<EventTypes> {
   store: SDKStore
-  emitter: Emitter
+  emitter: Emitter<EventTypes>
 }
 
-export interface BaseComponentOptions {
+export interface BaseComponentOptions<
+  EventTypes extends EventEmitter.ValidEventTypes
+> {
   store: SDKStore
-  emitter: Emitter
+  emitter: Emitter<EventTypes>
 }
 
 export interface SessionRequestObject {

--- a/packages/core/src/utils/interfaces.ts
+++ b/packages/core/src/utils/interfaces.ts
@@ -86,7 +86,10 @@ export interface UserOptions extends SessionOptions {
 }
 
 export interface InternalUserOptions extends UserOptions {
-  // TODO: check if we need to make InternalUserOptions a generic
+  /**
+   * TODO: Create type containing all the possible types the
+   * emitter should be allowed to handle
+   */
   emitter: Emitter<any>
 }
 

--- a/packages/core/src/utils/toExternalJSON.test.ts
+++ b/packages/core/src/utils/toExternalJSON.test.ts
@@ -58,4 +58,60 @@ describe('toExternalJSON', () => {
       })
     ).toStrictEqual(output)
   })
+
+  it('converts the layout `layers` key to be camelCase', () => {
+    const input = {
+      layers: [
+        {
+          y: 25,
+          x: 0,
+          layer_index: 0,
+          height: 50,
+          z_index: 0,
+          reservation: 'focus-1',
+          width: 50,
+        },
+        {
+          y: 25,
+          x: 50,
+          layer_index: 1,
+          height: 50,
+          z_index: 1,
+          reservation: 'focus-2',
+          width: 50,
+        },
+      ],
+      room_session_id: '688d9de2-09ac-4dd9-89c6-59e44fa9cd44',
+      room_id: '24c86438-8cd7-4315-9cf4-e3ac0b8cb588',
+      name: '2x1',
+    }
+
+    const output = {
+      layers: [
+        {
+          y: 25,
+          x: 0,
+          layerIndex: 0,
+          height: 50,
+          zIndex: 0,
+          reservation: 'focus-1',
+          width: 50,
+        },
+        {
+          y: 25,
+          x: 50,
+          layerIndex: 1,
+          height: 50,
+          zIndex: 1,
+          reservation: 'focus-2',
+          width: 50,
+        },
+      ],
+      roomSessionId: '688d9de2-09ac-4dd9-89c6-59e44fa9cd44',
+      roomId: '24c86438-8cd7-4315-9cf4-e3ac0b8cb588',
+      name: '2x1',
+    }
+
+    expect(toExternalJSON(input)).toStrictEqual(output)
+  })
 })

--- a/packages/core/src/utils/toExternalJSON.ts
+++ b/packages/core/src/utils/toExternalJSON.ts
@@ -3,7 +3,7 @@ const DEFAULT_OPTIONS = {
    * Properties coming from the server where their value will be
    * converted to camelCase
    */
-  propsToUpdateValue: ['updated'],
+  propsToUpdateValue: ['updated', 'layers'],
 }
 
 /**
@@ -36,7 +36,12 @@ export const toExternalJSON = <T>(
      */
     if (propType === 'object' && value) {
       if (Array.isArray(value) && options.propsToUpdateValue.includes(key)) {
-        reducer[prop] = value.map((v) => v && fromSnakeToCamelCase(v))
+        reducer[prop] = value.map((v) => {
+          if (typeof v === 'string') {
+            return fromSnakeToCamelCase(v)
+          }
+          return toExternalJSON(v)
+        })
       } else {
         reducer[prop] = toExternalJSON(value as T)
       }

--- a/packages/core/src/utils/toInternalEventName.ts
+++ b/packages/core/src/utils/toInternalEventName.ts
@@ -1,16 +1,26 @@
-type ToInternalEventNameParams = {
-  event: string | symbol
+import { EventEmitter } from './EventEmitter'
+
+type ToInternalEventNameParams<
+  EventTypes extends EventEmitter.ValidEventTypes
+> = {
+  event: EventEmitter.EventNames<EventTypes>
   namespace?: string
 }
 
-export const toInternalEventName = ({
+export const toInternalEventName = <
+  EventTypes extends EventEmitter.ValidEventTypes
+>({
   event,
   namespace,
-}: ToInternalEventNameParams) => {
+}: ToInternalEventNameParams<EventTypes>) => {
+  // TODO: improve types of getNamespacedEvent and fromCamelToSnakeCase
   if (typeof event === 'string') {
     // other transforms here..
-    event = getNamespacedEvent({ event, namespace })
-    event = fromCamelToSnakeCase(event)
+    event = getNamespacedEvent({
+      event,
+      namespace,
+    }) as EventEmitter.EventNames<EventTypes>
+    event = fromCamelToSnakeCase<EventEmitter.EventNames<EventTypes>>(event)
   }
 
   return event
@@ -21,10 +31,11 @@ const UPPERCASE_REGEX = /[A-Z]/g
  * Converts values from camelCase to snake_case
  * @internal
  */
-const fromCamelToSnakeCase = (event: string) => {
+const fromCamelToSnakeCase = <T>(event: T): T => {
+  // @ts-ignore
   return event.replace(UPPERCASE_REGEX, (letter) => {
     return `_${letter.toLowerCase()}`
-  })
+  }) as T
 }
 
 const getNamespacedEvent = ({

--- a/packages/js/src/Client.ts
+++ b/packages/js/src/Client.ts
@@ -42,7 +42,7 @@ export class Client extends BaseClient<ClientEvents> {
         }
 
         // @ts-expect-error
-        const room: Room = connect<RoomObjectEvents, Room>({
+        const room = connect<RoomObjectEvents, Room>({
           store: this.store,
           Component: Room,
           customSagas,
@@ -56,7 +56,6 @@ export class Client extends BaseClient<ClientEvents> {
          * Stop and Restore outbound audio on audio_muted event
          */
         if (stopMicrophoneWhileMuted) {
-          // @ts-expect-error
           room.on('member.updated.audio_muted', ({ member }) => {
             try {
               if (member.id === room.memberId && 'audio_muted' in member) {
@@ -74,7 +73,6 @@ export class Client extends BaseClient<ClientEvents> {
          * Stop and Restore outbound video on video_muted event
          */
         if (stopCameraWhileMuted) {
-          // @ts-expect-error
           room.on('member.updated.video_muted', ({ member }) => {
             try {
               if (member.id === room.memberId && 'video_muted' in member) {

--- a/packages/js/src/Client.ts
+++ b/packages/js/src/Client.ts
@@ -42,7 +42,7 @@ export class Client extends BaseClient<ClientEvents> {
         }
 
         // @ts-expect-error
-        const room = connect<RoomObjectEvents, Room>({
+        const room: Room = connect<RoomObjectEvents, Room>({
           store: this.store,
           Component: Room,
           customSagas,

--- a/packages/js/src/Client.ts
+++ b/packages/js/src/Client.ts
@@ -1,4 +1,4 @@
-import { logger, connect, BaseClient } from '@signalwire/core'
+import { logger, connect, BaseClient, ClientEvents } from '@signalwire/core'
 import type { CustomSaga } from '@signalwire/core'
 import { ConnectionOptions } from '@signalwire/webrtc'
 import { makeMediaElementsSaga } from './features/mediaElements/mediaElementsSagas'
@@ -13,7 +13,7 @@ export interface MakeRoomOptions extends ConnectionOptions {
   stopMicrophoneWhileMuted?: boolean
 }
 
-export class Client extends BaseClient {
+export class Client extends BaseClient<ClientEvents> {
   get rooms() {
     return {
       makeRoomObject: (makeRoomOptions: MakeRoomOptions) => {

--- a/packages/js/src/Client.ts
+++ b/packages/js/src/Client.ts
@@ -2,7 +2,7 @@ import { logger, connect, BaseClient, ClientEvents } from '@signalwire/core'
 import type { CustomSaga } from '@signalwire/core'
 import { ConnectionOptions } from '@signalwire/webrtc'
 import { makeMediaElementsSaga } from './features/mediaElements/mediaElementsSagas'
-import type { RoomObject } from './utils/interfaces'
+import type { RoomObjectEvents } from './utils/interfaces'
 import { ROOM_COMPONENT_LISTENERS } from './utils/constants'
 import { Room } from './Room'
 
@@ -41,7 +41,8 @@ export class Client extends BaseClient<ClientEvents> {
           )
         }
 
-        const room: RoomObject = connect({
+        // @ts-expect-error
+        const room = connect<RoomObjectEvents, Room>({
           store: this.store,
           Component: Room,
           customSagas,
@@ -55,6 +56,7 @@ export class Client extends BaseClient<ClientEvents> {
          * Stop and Restore outbound audio on audio_muted event
          */
         if (stopMicrophoneWhileMuted) {
+          // @ts-expect-error
           room.on('member.updated.audio_muted', ({ member }) => {
             try {
               if (member.id === room.memberId && 'audio_muted' in member) {
@@ -72,6 +74,7 @@ export class Client extends BaseClient<ClientEvents> {
          * Stop and Restore outbound video on video_muted event
          */
         if (stopCameraWhileMuted) {
+          // @ts-expect-error
           room.on('member.updated.video_muted', ({ member }) => {
             try {
               if (member.id === room.memberId && 'video_muted' in member) {

--- a/packages/js/src/Room.ts
+++ b/packages/js/src/Room.ts
@@ -2,8 +2,8 @@ import {
   logger,
   connect,
   Rooms,
-  RoomCustomMethods,
   EventTransform,
+  extendComponent,
 } from '@signalwire/core'
 import {
   getDisplayMedia,
@@ -27,9 +27,12 @@ import { audioSetSpeakerAction } from './features/actions'
 import { RoomScreenShare } from './RoomScreenShare'
 import { RoomDevice } from './RoomDevice'
 
-interface Room extends RoomMethods {}
+interface Room extends RoomMethods, BaseConnection<RoomObjectEvents> {
+  join(): Promise<Room>
+  leave(): Promise<void>
+}
 
-class Room
+class RoomConnection
   extends BaseConnection<RoomObjectEvents>
   implements BaseRoomInterface
 {
@@ -101,7 +104,7 @@ class Room
       },
     }
 
-    const screenShare: RoomScreenShare = connect<
+    const screenShare = connect<
       RoomObjectEvents,
       // @ts-expect-error
       RoomScreenShare
@@ -247,6 +250,7 @@ class Room
    * be removed in v3.0.0
    */
   getLayoutList() {
+    // @ts-expect-error
     return this.getLayouts()
   }
 
@@ -255,11 +259,12 @@ class Room
    * be removed in v3.0.0
    */
   getMemberList() {
+    // @ts-expect-error
     return this.getMembers()
   }
 }
 
-const customMethods: RoomCustomMethods<RoomMethods> = {
+const Room = extendComponent<Room, RoomMethods>(RoomConnection, {
   audioMute: Rooms.audioMuteMember,
   audioUnmute: Rooms.audioUnmuteMember,
   videoMute: Rooms.videoMuteMember,
@@ -275,10 +280,8 @@ const customMethods: RoomCustomMethods<RoomMethods> = {
   setLayout: Rooms.setLayout,
   hideVideoMuted: Rooms.hideVideoMuted,
   showVideoMuted: Rooms.showVideoMuted,
-  // TODO: Add these to the spec list
   getRecordings: Rooms.getRecordings,
   startRecording: Rooms.startRecording,
-}
-Object.defineProperties(Room.prototype, customMethods)
+})
 
 export { Room }

--- a/packages/js/src/Room.ts
+++ b/packages/js/src/Room.ts
@@ -29,7 +29,10 @@ import { RoomDevice } from './RoomDevice'
 
 interface Room extends RoomMethods {}
 
-class Room extends BaseConnection implements BaseRoomInterface {
+class Room
+  extends BaseConnection<RoomObjectEvents>
+  implements BaseRoomInterface
+{
   private _screenShareList = new Set<RoomScreenShare>()
   private _deviceList = new Set<RoomDevice>()
 
@@ -85,7 +88,7 @@ class Room extends BaseConnection implements BaseRoomInterface {
       audio: audio === true ? SCREENSHARE_AUDIO_CONSTRAINTS : audio,
       video,
     })
-    const options: BaseConnectionOptions = {
+    const options: BaseConnectionOptions<RoomObjectEvents> = {
       ...this.options,
       screenShare: true,
       recoverCall: false,
@@ -169,7 +172,7 @@ class Room extends BaseConnection implements BaseRoomInterface {
       )
     }
 
-    const options: BaseConnectionOptions = {
+    const options: BaseConnectionOptions<RoomObjectEvents> = {
       ...this.options,
       localStream: undefined,
       remoteStream: undefined,

--- a/packages/js/src/Room.ts
+++ b/packages/js/src/Room.ts
@@ -11,8 +11,7 @@ import {
   BaseConnectionOptions,
 } from '@signalwire/webrtc'
 import {
-  RoomScreenShareObject,
-  RoomDeviceObject,
+  RoomObjectEvents,
   CreateScreenShareObjectOptions,
   AddDeviceOptions,
   AddCameraOptions,
@@ -31,8 +30,8 @@ import { RoomDevice } from './RoomDevice'
 interface Room extends RoomMethods {}
 
 class Room extends BaseConnection implements BaseRoomInterface {
-  private _screenShareList = new Set<RoomScreenShareObject>()
-  private _deviceList = new Set<RoomDeviceObject>()
+  private _screenShareList = new Set<RoomScreenShare>()
+  private _deviceList = new Set<RoomDevice>()
 
   get screenShareList() {
     return Array.from(this._screenShareList)
@@ -56,6 +55,7 @@ class Room extends BaseConnection implements BaseRoomInterface {
           instanceFactory: (_payload: any) => {
             return Rooms.createRoomSessionRecordingObject({
               store: this.store,
+              // @ts-expect-error
               emitter: this.emitter,
             })
           },
@@ -98,7 +98,11 @@ class Room extends BaseConnection implements BaseRoomInterface {
       },
     }
 
-    const screenShare: RoomScreenShareObject = connect({
+    const screenShare: RoomScreenShare = connect<
+      RoomObjectEvents,
+      // @ts-expect-error
+      RoomScreenShare
+    >({
       store: this.store,
       Component: RoomScreenShare,
       componentListeners: ROOM_COMPONENT_LISTENERS,
@@ -180,7 +184,8 @@ class Room extends BaseConnection implements BaseRoomInterface {
       },
     }
 
-    const roomDevice: RoomDeviceObject = connect({
+    // @ts-expect-error
+    const roomDevice = connect<RoomObjectEvents, RoomDevice>({
       store: this.store,
       Component: RoomDevice,
       componentListeners: ROOM_COMPONENT_LISTENERS,

--- a/packages/js/src/RoomDevice.ts
+++ b/packages/js/src/RoomDevice.ts
@@ -1,10 +1,15 @@
-import { Rooms, RoomCustomMethods } from '@signalwire/core'
+import { Rooms, extendComponent } from '@signalwire/core'
 import { BaseConnection } from '@signalwire/webrtc'
 import { RoomDeviceMethods, RoomObjectEvents } from './utils/interfaces'
 
-interface RoomDevice extends RoomDeviceMethods {}
+interface RoomDevice
+  extends RoomDeviceMethods,
+    BaseConnection<RoomObjectEvents> {
+  join(): Promise<void>
+  leave(): Promise<void>
+}
 
-class RoomDevice extends BaseConnection<RoomObjectEvents> {
+class RoomDeviceConnection extends BaseConnection<RoomObjectEvents> {
   join() {
     return super.invite()
   }
@@ -14,14 +19,16 @@ class RoomDevice extends BaseConnection<RoomObjectEvents> {
   }
 }
 
-const customMethods: RoomCustomMethods<RoomDeviceMethods> = {
-  audioMute: Rooms.audioMuteMember,
-  audioUnmute: Rooms.audioUnmuteMember,
-  videoMute: Rooms.videoMuteMember,
-  videoUnmute: Rooms.videoUnmuteMember,
-  setMicrophoneVolume: Rooms.setInputVolumeMember,
-  setInputSensitivity: Rooms.setInputSensitivityMember,
-}
-Object.defineProperties(RoomDevice.prototype, customMethods)
+const RoomDevice = extendComponent<RoomDevice, RoomDeviceMethods>(
+  RoomDeviceConnection,
+  {
+    audioMute: Rooms.audioMuteMember,
+    audioUnmute: Rooms.audioUnmuteMember,
+    videoMute: Rooms.videoMuteMember,
+    videoUnmute: Rooms.videoUnmuteMember,
+    setMicrophoneVolume: Rooms.setInputVolumeMember,
+    setInputSensitivity: Rooms.setInputSensitivityMember,
+  }
+)
 
 export { RoomDevice }

--- a/packages/js/src/RoomDevice.ts
+++ b/packages/js/src/RoomDevice.ts
@@ -1,10 +1,10 @@
 import { Rooms, RoomCustomMethods } from '@signalwire/core'
 import { BaseConnection } from '@signalwire/webrtc'
-import { RoomDeviceMethods } from './utils/interfaces'
+import { RoomDeviceMethods, RoomObjectEvents } from './utils/interfaces'
 
 interface RoomDevice extends RoomDeviceMethods {}
 
-class RoomDevice extends BaseConnection {
+class RoomDevice extends BaseConnection<RoomObjectEvents> {
   join() {
     return super.invite()
   }

--- a/packages/js/src/RoomScreenShare.ts
+++ b/packages/js/src/RoomScreenShare.ts
@@ -1,10 +1,15 @@
-import { Rooms, RoomCustomMethods } from '@signalwire/core'
+import { Rooms, extendComponent } from '@signalwire/core'
 import { BaseConnection } from '@signalwire/webrtc'
 import { RoomScreenShareMethods, RoomObjectEvents } from './utils/interfaces'
 
-interface RoomScreenShare extends RoomScreenShareMethods {}
+interface RoomScreenShare
+  extends RoomScreenShareMethods,
+    BaseConnection<RoomObjectEvents> {
+  join(): Promise<void>
+  leave(): Promise<void>
+}
 
-class RoomScreenShare extends BaseConnection<RoomObjectEvents> {
+class RoomScreenShareConnection extends BaseConnection<RoomObjectEvents> {
   join() {
     return super.invite()
   }
@@ -14,14 +19,16 @@ class RoomScreenShare extends BaseConnection<RoomObjectEvents> {
   }
 }
 
-const customMethods: RoomCustomMethods<RoomScreenShareMethods> = {
+const RoomScreenShare = extendComponent<
+  RoomScreenShare,
+  RoomScreenShareMethods
+>(RoomScreenShareConnection, {
   audioMute: Rooms.audioMuteMember,
   audioUnmute: Rooms.audioUnmuteMember,
   videoMute: Rooms.videoMuteMember,
   videoUnmute: Rooms.videoUnmuteMember,
   setMicrophoneVolume: Rooms.setInputVolumeMember,
   setInputSensitivity: Rooms.setInputSensitivityMember,
-}
-Object.defineProperties(RoomScreenShare.prototype, customMethods)
+})
 
 export { RoomScreenShare }

--- a/packages/js/src/RoomScreenShare.ts
+++ b/packages/js/src/RoomScreenShare.ts
@@ -1,10 +1,10 @@
 import { Rooms, RoomCustomMethods } from '@signalwire/core'
 import { BaseConnection } from '@signalwire/webrtc'
-import { RoomScreenShareMethods } from './utils/interfaces'
+import { RoomScreenShareMethods, RoomObjectEvents } from './utils/interfaces'
 
 interface RoomScreenShare extends RoomScreenShareMethods {}
 
-class RoomScreenShare extends BaseConnection {
+class RoomScreenShare extends BaseConnection<RoomObjectEvents> {
   join() {
     return super.invite()
   }

--- a/packages/js/src/createClient.ts
+++ b/packages/js/src/createClient.ts
@@ -5,7 +5,6 @@ import {
   getEventEmitter,
   UserOptions,
 } from '@signalwire/core'
-import StrictEventEmitter from 'strict-event-emitter-types'
 import { Client } from './Client'
 import { JWTSession } from './JWTSession'
 

--- a/packages/js/src/createClient.ts
+++ b/packages/js/src/createClient.ts
@@ -54,13 +54,13 @@ import { JWTSession } from './JWTSession'
 export const createClient = async (userOptions: UserOptions) => {
   const baseUserOptions = {
     ...userOptions,
-    emitter: getEventEmitter<ClientEvents>(userOptions),
+    emitter: getEventEmitter<ClientEvents>(),
   }
   const store = configureStore({
     userOptions: baseUserOptions,
     SessionConstructor: JWTSession,
   })
-  const client: StrictEventEmitter<Client, ClientEvents> = connect({
+  const client = connect<ClientEvents, Client>({
     store,
     Component: Client,
     componentListeners: {

--- a/packages/js/src/createRoomObject.ts
+++ b/packages/js/src/createRoomObject.ts
@@ -1,7 +1,7 @@
 import { UserOptions } from '@signalwire/core'
-import { RoomObject } from './utils/interfaces'
 import { createClient } from './createClient'
 import { MakeRoomOptions } from './Client'
+import type { Room } from './Room'
 
 export interface CreateRoomObjectOptions extends UserOptions, MakeRoomOptions {
   autoJoin?: boolean
@@ -36,7 +36,7 @@ const VIDEO_CONSTRAINTS: MediaTrackConstraints = {
  */
 export const createRoomObject = (
   roomOptions: CreateRoomObjectOptions
-): Promise<RoomObject> => {
+): Promise<Room> => {
   return new Promise(async (resolve, reject) => {
     const {
       audio = true,

--- a/packages/js/src/features/mediaElements/mediaElementsSagas.ts
+++ b/packages/js/src/features/mediaElements/mediaElementsSagas.ts
@@ -52,6 +52,7 @@ export const makeMediaElementsSaga = ({
       room.on('layout.changed', (params) => {
         if (room.peer.hasVideoSender && room.localStream) {
           layoutChangedHandler({
+            // @ts-expect-error
             layout: params.layout,
             localStream: room.localStream,
             myMemberId: room.memberId,
@@ -62,6 +63,7 @@ export const makeMediaElementsSaga = ({
       // @ts-expect-error
       room.on('member.updated.video_muted', (params) => {
         try {
+          // @ts-expect-error
           const { member } = params
           if (member.id === room.memberId && 'video_muted' in member) {
             member.video_muted ? hideOverlay(member.id) : showOverlay(member.id)

--- a/packages/js/src/features/mediaElements/mediaElementsSagas.ts
+++ b/packages/js/src/features/mediaElements/mediaElementsSagas.ts
@@ -48,6 +48,7 @@ export const makeMediaElementsSaga = ({
         )
       }
 
+      // @ts-expect-error
       room.on('layout.changed', (params) => {
         if (room.peer.hasVideoSender && room.localStream) {
           layoutChangedHandler({
@@ -58,6 +59,7 @@ export const makeMediaElementsSaga = ({
         }
       })
 
+      // @ts-expect-error
       room.on('member.updated.video_muted', (params) => {
         try {
           const { member } = params
@@ -72,6 +74,7 @@ export const makeMediaElementsSaga = ({
       let audioTask: Task | undefined
       let videoTask: Task | undefined
 
+      // @ts-expect-error
       room.on('track', function (event: RTCTrackEvent) {
         switch (event.track.kind) {
           case 'audio':

--- a/packages/js/src/features/mediaElements/mediaElementsSagas.ts
+++ b/packages/js/src/features/mediaElements/mediaElementsSagas.ts
@@ -48,7 +48,6 @@ export const makeMediaElementsSaga = ({
         )
       }
 
-      // @ts-expect-error
       room.on('layout.changed', (params) => {
         if (room.peer.hasVideoSender && room.localStream) {
           layoutChangedHandler({
@@ -60,10 +59,8 @@ export const makeMediaElementsSaga = ({
         }
       })
 
-      // @ts-expect-error
       room.on('member.updated.video_muted', (params) => {
         try {
-          // @ts-expect-error
           const { member } = params
           if (member.id === room.memberId && 'video_muted' in member) {
             member.video_muted ? hideOverlay(member.id) : showOverlay(member.id)
@@ -76,7 +73,6 @@ export const makeMediaElementsSaga = ({
       let audioTask: Task | undefined
       let videoTask: Task | undefined
 
-      // @ts-expect-error
       room.on('track', function (event: RTCTrackEvent) {
         switch (event.track.kind) {
           case 'audio':

--- a/packages/js/src/testUtils.ts
+++ b/packages/js/src/testUtils.ts
@@ -16,6 +16,7 @@ export const configureJestStore = () => {
       project: PROJECT_ID,
       token: TOKEN,
       devTools: false,
+      emitter: new EventEmitter(),
     },
     SessionConstructor: JWTSession,
     runSagaMiddleware: false,

--- a/packages/js/src/utils/constants.ts
+++ b/packages/js/src/utils/constants.ts
@@ -10,8 +10,8 @@ export const ROOM_COMPONENT_LISTENERS = {
 
 export const SCREENSHARE_AUDIO_CONSTRAINTS: MediaTrackConstraints = {
   echoCancellation: false,
+  // @ts-expect-error
   noiseSuppression: false,
   autoGainControl: false,
-  // @ts-expect-error
   googAutoGainControl: false,
 }

--- a/packages/js/src/utils/interfaces.ts
+++ b/packages/js/src/utils/interfaces.ts
@@ -1,4 +1,3 @@
-import StrictEventEmitter from 'strict-event-emitter-types'
 import type {
   Rooms,
   BaseConnectionState,
@@ -18,8 +17,6 @@ import type {
 } from '@signalwire/core'
 import { INTERNAL_MEMBER_UPDATABLE_PROPS } from '@signalwire/core'
 import type { Room } from '../Room'
-import type { RoomScreenShare } from '../RoomScreenShare'
-import type { RoomDevice } from '../RoomDevice'
 
 const INTERNAL_MEMBER_UPDATED_EVENTS = Object.keys(
   INTERNAL_MEMBER_UPDATABLE_PROPS
@@ -56,13 +53,6 @@ export type RoomObjectEventsHandlerMap = Record<
 export type RoomObjectEvents = {
   [k in keyof RoomObjectEventsHandlerMap]: RoomObjectEventsHandlerMap[k]
 }
-
-export type RoomObject = StrictEventEmitter<Room, RoomObjectEvents>
-export type RoomScreenShareObject = StrictEventEmitter<
-  RoomScreenShare,
-  RoomObjectEvents
->
-export type RoomDeviceObject = StrictEventEmitter<RoomDevice, RoomObjectEvents>
 
 export type CreateScreenShareObjectOptions = {
   autoJoin?: boolean

--- a/packages/js/src/video.ts
+++ b/packages/js/src/video.ts
@@ -9,7 +9,6 @@ export { Client, createRoomObject, joinRoom, Room, RoomScreenShare, RoomDevice }
 
 export type { MakeRoomOptions }
 export type {
-  RoomObject,
   MemberCommandParams,
   MemberCommandWithVolumeParams,
   MemberCommandWithValueParams,

--- a/packages/realtime-api/examples/ts-vanilla-websockets/index.ts
+++ b/packages/realtime-api/examples/ts-vanilla-websockets/index.ts
@@ -4,8 +4,8 @@ async function run() {
   try {
     const client = await createClient({
       host: 'relay.swire.io',
-      project: '<project-id>',
-      token: '<project-token>',
+      project: process.env.PROJECT as string,
+      token: process.env.TOKEN as string,
     })
 
     client.video.on('room.started', async (room) => {
@@ -50,7 +50,7 @@ async function run() {
     })
 
     client.video.on('room.ended', (room) => {
-      console.log('🔴 ROOOM ENDED 🔴', room.name, room)
+      console.log('🔴 ROOOM ENDED 🔴', room)
     })
 
     await client.connect()

--- a/packages/realtime-api/package.json
+++ b/packages/realtime-api/package.json
@@ -36,7 +36,7 @@
     "build": "tsc --project tsconfig.build.json && sw-build --node",
     "test": "NODE_ENV=test jest",
     "prepublishOnly": "npm run build",
-    "docs": "typedoc --options typedoc.js --readme README.md",
+    "docs": "typedoc --options typedoc.js",
     "docs:watch": "npm run docs -- --watch"
   },
   "dependencies": {

--- a/packages/realtime-api/src/BaseConsumer.ts
+++ b/packages/realtime-api/src/BaseConsumer.ts
@@ -3,6 +3,7 @@ import {
   ExecuteParams,
   logger,
   validateEventsToSubscribe,
+  EventEmitter,
 } from '@signalwire/core'
 
 /**
@@ -12,7 +13,9 @@ import {
  * and the `eventChannel`
  * @internal
  */
-export class BaseConsumer extends BaseComponent {
+export class BaseConsumer<
+  EventTypes extends EventEmitter.ValidEventTypes
+> extends BaseComponent<EventTypes> {
   protected subscribeParams?: Record<string, any> = {}
 
   protected getSubscriptions(): (string | symbol)[] {

--- a/packages/realtime-api/src/Client.ts
+++ b/packages/realtime-api/src/Client.ts
@@ -7,17 +7,14 @@ import {
 } from '@signalwire/core'
 import { createVideoObject, Video } from './Video'
 
-// interface Consumer {
-//   on: (event: GlobalVideoEvents, handler: any) => void
-//   run: () => Promise<unknown>
-// }
-
 export interface RealtimeClient extends Emitter<ClientEvents> {
   video: Video
 }
 
-export class Client extends BaseClient<{}> {
-  private _consumers: Map<EventsPrefix, any> = new Map()
+type ClientNamespaces = Video
+
+export class Client extends BaseClient<ClientEvents> {
+  private _consumers: Map<EventsPrefix, ClientNamespaces> = new Map()
 
   async onAuth(session: SessionState) {
     if (session.authStatus === 'authorized') {
@@ -33,8 +30,10 @@ export class Client extends BaseClient<{}> {
     }
     const video = createVideoObject({
       store: this.store,
-      // TODO:
-      emitter: this.options.emitter as any,
+      // Emitter is now typed but we share it across objects
+      // so types won't match
+      // @ts-expect-error
+      emitter: this.options.emitter,
     })
     this._consumers.set('video', video)
     return video

--- a/packages/realtime-api/src/Client.ts
+++ b/packages/realtime-api/src/Client.ts
@@ -1,20 +1,23 @@
 import {
   BaseClient,
   EventsPrefix,
-  GlobalVideoEvents,
   SessionState,
+  Emitter,
+  ClientEvents,
 } from '@signalwire/core'
-import StrictEventEmitter from 'strict-event-emitter-types'
-import { RealTimeVideoApiEvents } from './types/video'
 import { createVideoObject, Video } from './Video'
 
-interface Consumer {
-  on: (event: GlobalVideoEvents, handler: any) => void
-  run: () => Promise<unknown>
+// interface Consumer {
+//   on: (event: GlobalVideoEvents, handler: any) => void
+//   run: () => Promise<unknown>
+// }
+
+export interface RealtimeClient extends Emitter<ClientEvents> {
+  video: Video
 }
 
-export class Client extends BaseClient {
-  private _consumers: Map<EventsPrefix, Consumer> = new Map()
+export class Client extends BaseClient<{}> {
+  private _consumers: Map<EventsPrefix, any> = new Map()
 
   async onAuth(session: SessionState) {
     if (session.authStatus === 'authorized') {
@@ -24,13 +27,14 @@ export class Client extends BaseClient {
     }
   }
 
-  get video(): StrictEventEmitter<Video, RealTimeVideoApiEvents> {
+  get video(): Video {
     if (this._consumers.has('video')) {
       return this._consumers.get('video') as Video
     }
     const video = createVideoObject({
       store: this.store,
-      emitter: this.options.emitter,
+      // TODO:
+      emitter: this.options.emitter as any,
     })
     this._consumers.set('video', video)
     return video

--- a/packages/realtime-api/src/Video.ts
+++ b/packages/realtime-api/src/Video.ts
@@ -15,7 +15,7 @@ type TransformEvent = Extract<
   'video.room.started' | 'video.room.ended'
 >
 
-export interface VideoObject extends Emitter<RealTimeVideoApiEvents> {}
+interface VideoObject extends Emitter<RealTimeVideoApiEvents> {}
 
 export class Video
   extends BaseConsumer<RealTimeVideoApiEvents>

--- a/packages/realtime-api/src/Video.ts
+++ b/packages/realtime-api/src/Video.ts
@@ -1,7 +1,7 @@
 import {
   BaseComponentOptions,
   connect,
-  EventEmitter,
+  Emitter,
   EventTransform,
   InternalVideoRoomEventNames,
   toExternalJSON,
@@ -15,9 +15,8 @@ type TransformEvent = Extract<
   'video.room.started' | 'video.room.ended'
 >
 
-export interface VideoObject extends EventEmitter<RealTimeVideoApiEvents> {}
+export interface VideoObject extends Emitter<RealTimeVideoApiEvents> {}
 
-// @ts-ignore
 export class Video
   extends BaseConsumer<RealTimeVideoApiEvents>
   implements VideoObject
@@ -62,10 +61,8 @@ export class Video
 export const createVideoObject = (
   params: BaseComponentOptions<RealTimeVideoApiEvents>
 ): Video => {
-  const video = connect({
+  const video = connect<RealTimeVideoApiEvents, Video>({
     store: params.store,
-    // TODO:
-    // @ts-expect-error
     Component: Video,
     componentListeners: {
       errors: 'onError',
@@ -73,7 +70,7 @@ export const createVideoObject = (
     },
   })(params)
 
-  const proxy = new Proxy(video, {
+  const proxy = new Proxy<Video>(video, {
     get(target: any, prop: any, receiver: any) {
       if (prop === '_eventsNamespace') {
         /**
@@ -87,7 +84,7 @@ export const createVideoObject = (
 
       return Reflect.get(target, prop, receiver)
     },
-  }) as any as Video
+  })
 
   return proxy
 }

--- a/packages/realtime-api/src/Video.ts
+++ b/packages/realtime-api/src/Video.ts
@@ -39,6 +39,7 @@ export class Video
           instanceFactory: () => {
             return createRoomSessionObject({
               store: this.store,
+              // Emitter is now typed.
               // @ts-expect-error
               emitter: this.options.emitter,
             })

--- a/packages/realtime-api/src/createClient.ts
+++ b/packages/realtime-api/src/createClient.ts
@@ -36,7 +36,7 @@ export const createClient = async (
     SessionConstructor: Session,
   })
 
-  const client = connect({
+  const client = connect<ClientEvents, Client>({
     store,
     Component: Client,
     componentListeners: {

--- a/packages/realtime-api/src/createClient.ts
+++ b/packages/realtime-api/src/createClient.ts
@@ -5,23 +5,38 @@ import {
   getEventEmitter,
   UserOptions,
 } from '@signalwire/core'
-import StrictEventEmitter from 'strict-event-emitter-types'
+// import StrictEventEmitter from 'strict-event-emitter-types'
 import { Client } from './Client'
 import { Session } from './Session'
+// import { VideoObject } from './Video'
 
-type CreateClientOptions = Omit<UserOptions, 'autoConnect'>
+type CreateClientOptions = Omit<UserOptions<ClientEvents>, 'autoConnect'>
 
-export const createClient = async (userOptions: CreateClientOptions) => {
+// interface IRealtimeClient extends Emitter<ClientEvents> {
+//   video: VideoObject
+//   connect: () => any
+//   destroy: () => any
+// }
+
+// export interface RealtimeClient
+//   extends StrictEventEmitter<Client, ClientEvents> {}
+// export interface RealtimeClient
+//   extends StrictEventEmitter<IRealtimeClient, ClientEvents> {}
+
+export const createClient = async (
+  userOptions: CreateClientOptions
+): Promise<Client> => {
   const baseUserOptions = {
     ...userOptions,
     emitter: getEventEmitter<ClientEvents>(userOptions),
   }
   const store = configureStore({
+    // @ts-expect-error
     userOptions: baseUserOptions,
     SessionConstructor: Session,
   })
 
-  const client: StrictEventEmitter<Client, ClientEvents> = connect({
+  const client = connect({
     store,
     Component: Client,
     componentListeners: {

--- a/packages/realtime-api/src/createClient.ts
+++ b/packages/realtime-api/src/createClient.ts
@@ -4,13 +4,14 @@ import {
   connect,
   getEventEmitter,
   UserOptions,
+  InternalUserOptions,
 } from '@signalwire/core'
 // import StrictEventEmitter from 'strict-event-emitter-types'
 import { Client } from './Client'
 import { Session } from './Session'
 // import { VideoObject } from './Video'
 
-type CreateClientOptions = Omit<UserOptions<ClientEvents>, 'autoConnect'>
+type CreateClientOptions = Omit<UserOptions, 'autoConnect'>
 
 // interface IRealtimeClient extends Emitter<ClientEvents> {
 //   video: VideoObject
@@ -26,12 +27,11 @@ type CreateClientOptions = Omit<UserOptions<ClientEvents>, 'autoConnect'>
 export const createClient = async (
   userOptions: CreateClientOptions
 ): Promise<Client> => {
-  const baseUserOptions = {
+  const baseUserOptions: InternalUserOptions = {
     ...userOptions,
-    emitter: getEventEmitter<ClientEvents>(userOptions),
+    emitter: getEventEmitter<ClientEvents>(),
   }
   const store = configureStore({
-    // @ts-expect-error
     userOptions: baseUserOptions,
     SessionConstructor: Session,
   })

--- a/packages/realtime-api/src/createClient.ts
+++ b/packages/realtime-api/src/createClient.ts
@@ -6,23 +6,10 @@ import {
   UserOptions,
   InternalUserOptions,
 } from '@signalwire/core'
-// import StrictEventEmitter from 'strict-event-emitter-types'
 import { Client } from './Client'
 import { Session } from './Session'
-// import { VideoObject } from './Video'
 
 type CreateClientOptions = Omit<UserOptions, 'autoConnect'>
-
-// interface IRealtimeClient extends Emitter<ClientEvents> {
-//   video: VideoObject
-//   connect: () => any
-//   destroy: () => any
-// }
-
-// export interface RealtimeClient
-//   extends StrictEventEmitter<Client, ClientEvents> {}
-// export interface RealtimeClient
-//   extends StrictEventEmitter<IRealtimeClient, ClientEvents> {}
 
 export const createClient = async (
   userOptions: CreateClientOptions

--- a/packages/realtime-api/src/index.ts
+++ b/packages/realtime-api/src/index.ts
@@ -1,3 +1,3 @@
-import { createClient } from './createClient'
-
-export { createClient }
+export * from './createClient'
+export * from './Video'
+export type { EventEmitter } from '@signalwire/core'

--- a/packages/realtime-api/src/index.ts
+++ b/packages/realtime-api/src/index.ts
@@ -1,3 +1,2 @@
 export * from './createClient'
 export * from './Video'
-export type { EventEmitter } from '@signalwire/core'

--- a/packages/realtime-api/src/setupTests.ts
+++ b/packages/realtime-api/src/setupTests.ts
@@ -1,6 +1,5 @@
 jest.mock('@signalwire/core', () => {
   return {
-    // @ts-ignore
     ...jest.requireActual('@signalwire/core'),
     logger: {
       error: jest.fn(),

--- a/packages/realtime-api/src/setupTests.ts
+++ b/packages/realtime-api/src/setupTests.ts
@@ -1,6 +1,6 @@
 jest.mock('@signalwire/core', () => {
   return {
-    ...jest.requireActual('@signalwire/core'),
+    ...(jest.requireActual('@signalwire/core') as any),
     logger: {
       error: jest.fn(),
       warn: jest.fn(),

--- a/packages/realtime-api/src/setupTests.ts
+++ b/packages/realtime-api/src/setupTests.ts
@@ -1,5 +1,6 @@
 jest.mock('@signalwire/core', () => {
   return {
+    // @ts-ignore
     ...jest.requireActual('@signalwire/core'),
     logger: {
       error: jest.fn(),

--- a/packages/realtime-api/src/testUtils.ts
+++ b/packages/realtime-api/src/testUtils.ts
@@ -1,4 +1,4 @@
-import { configureStore } from '@signalwire/core'
+import { configureStore, EventEmitter } from '@signalwire/core'
 import { Session } from './Session'
 
 const PROJECT_ID = '8f0a119a-cda7-4497-a47d-c81493b824d4'
@@ -16,6 +16,7 @@ export const configureJestStore = () => {
       project: PROJECT_ID,
       token: TOKEN,
       devTools: false,
+      emitter: new EventEmitter(),
     },
     SessionConstructor: Session,
     runSagaMiddleware: false,

--- a/packages/realtime-api/src/types/video.ts
+++ b/packages/realtime-api/src/types/video.ts
@@ -1,4 +1,3 @@
-import StrictEventEmitter from 'strict-event-emitter-types'
 import type {
   GlobalVideoEvents,
   VideoMemberEventNames,
@@ -16,7 +15,7 @@ export type RealTimeVideoApiGlobalEvents = GlobalVideoEvents
 
 export type RealTimeVideoApiEventsHandlerMapping = Record<
   RealTimeVideoApiGlobalEvents,
-  (room: StrictEventEmitter<RoomSession, RealTimeRoomApiEvents>) => void
+  (room: RoomSession) => void
 >
 
 export type RealTimeVideoApiEvents = {
@@ -30,15 +29,9 @@ export type RealTimeRoomApiEventsHandlerMapping = Record<
 > &
   Record<VideoMemberEventNames, (member: RoomSessionMember) => void> &
   Record<MemberTalkingEventNames, (member: RoomSessionMember) => void> &
-  Record<
-    RoomStarted | RoomEnded,
-    (room: StrictEventEmitter<RoomSession, RealTimeRoomApiEvents>) => void
-  > &
+  Record<RoomStarted | RoomEnded, (room: RoomSession) => void> &
   // TODO: we need to tweak the `room` param because it includes `updated` too in this event
-  Record<
-    RoomUpdated,
-    (room: StrictEventEmitter<RoomSession, RealTimeRoomApiEvents>) => void
-  >
+  Record<RoomUpdated, (room: RoomSession) => void>
 
 export type RealTimeRoomApiEvents = {
   [k in keyof RealTimeRoomApiEventsHandlerMapping]: RealTimeRoomApiEventsHandlerMapping[k]

--- a/packages/realtime-api/src/video/RoomSession.ts
+++ b/packages/realtime-api/src/video/RoomSession.ts
@@ -59,9 +59,9 @@ type EmitterTransformsEvents =
 // TODO: update once we do the split between API and Entity interfaces
 export interface RoomSession
   extends RoomSessionMethods,
-    BaseConsumer<MemberEventMap> {}
+    BaseConsumer<EmitterTransformsEvents> {}
 
-class RoomSessionConsumer extends BaseConsumer<MemberEventMap> {
+class RoomSessionConsumer extends BaseConsumer<EmitterTransformsEvents> {
   protected _eventsPrefix = 'video' as const
 
   /** @internal */
@@ -116,6 +116,9 @@ class RoomSessionConsumer extends BaseConsumer<MemberEventMap> {
           instanceFactory: (_payload: VideoMemberEventParams) => {
             return createRoomSessionMemberObject({
               store: this.store,
+              // TODO: the emitter is now typed so types
+              // don't match but internally it doesn't
+              // matter that much.
               // @ts-expect-error
               emitter: this.options.emitter,
             })
@@ -163,11 +166,10 @@ export const RoomSessionAPI = extendComponent<RoomSession, RoomSessionMethods>(
 )
 
 export const createRoomSessionObject = (
-  params: BaseComponentOptions<MemberEventMap>
+  params: BaseComponentOptions<EmitterTransformsEvents>
 ) => {
-  const roomSession = connect({
+  const roomSession = connect<EmitterTransformsEvents, RoomSession>({
     store: params.store,
-    // @ts-expect-error
     Component: RoomSessionAPI,
     componentListeners: {
       errors: 'onError',
@@ -175,5 +177,5 @@ export const createRoomSessionObject = (
     },
   })(params)
 
-  return roomSession as any as RoomSession
+  return roomSession
 }

--- a/packages/realtime-api/src/video/RoomSession.ts
+++ b/packages/realtime-api/src/video/RoomSession.ts
@@ -14,6 +14,7 @@ import {
   VideoLayoutChangedEventParams,
 } from '@signalwire/core'
 import { BaseConsumer } from '../BaseConsumer'
+import { RealTimeRoomApiEvents } from '../types'
 import { createRoomSessionMemberObject } from './RoomSessionMember'
 
 // FIXME: Move these interfaces to core (and use them in JS too)
@@ -59,9 +60,8 @@ type EmitterTransformsEvents =
 // TODO: update once we do the split between API and Entity interfaces
 export interface RoomSession
   extends RoomSessionMethods,
-    BaseConsumer<EmitterTransformsEvents> {}
-
-class RoomSessionConsumer extends BaseConsumer<EmitterTransformsEvents> {
+    BaseConsumer<RealTimeRoomApiEvents> {}
+class RoomSessionConsumer extends BaseConsumer<RealTimeRoomApiEvents> {
   protected _eventsPrefix = 'video' as const
 
   /** @internal */
@@ -167,8 +167,8 @@ export const RoomSessionAPI = extendComponent<RoomSession, RoomSessionMethods>(
 
 export const createRoomSessionObject = (
   params: BaseComponentOptions<EmitterTransformsEvents>
-) => {
-  const roomSession = connect<EmitterTransformsEvents, RoomSession>({
+): RoomSession => {
+  const roomSession = connect<RealTimeRoomApiEvents, RoomSession>({
     store: params.store,
     Component: RoomSessionAPI,
     componentListeners: {

--- a/packages/realtime-api/src/video/RoomSession.ts
+++ b/packages/realtime-api/src/video/RoomSession.ts
@@ -57,9 +57,11 @@ type EmitterTransformsEvents =
   | InternalVideoLayoutEventNames
 
 // TODO: update once we do the split between API and Entity interfaces
-export interface RoomSession extends RoomSessionMethods, BaseConsumer {}
+export interface RoomSession
+  extends RoomSessionMethods,
+    BaseConsumer<MemberEventMap> {}
 
-class RoomSessionConsumer extends BaseConsumer {
+class RoomSessionConsumer extends BaseConsumer<MemberEventMap> {
   protected _eventsPrefix = 'video' as const
 
   /** @internal */
@@ -114,6 +116,7 @@ class RoomSessionConsumer extends BaseConsumer {
           instanceFactory: (_payload: VideoMemberEventParams) => {
             return createRoomSessionMemberObject({
               store: this.store,
+              // @ts-expect-error
               emitter: this.options.emitter,
             })
           },
@@ -159,9 +162,12 @@ export const RoomSessionAPI = extendComponent<RoomSession, RoomSessionMethods>(
   }
 )
 
-export const createRoomSessionObject = (params: BaseComponentOptions) => {
-  const roomSession: RoomSession = connect({
+export const createRoomSessionObject = (
+  params: BaseComponentOptions<MemberEventMap>
+) => {
+  const roomSession = connect({
     store: params.store,
+    // @ts-expect-error
     Component: RoomSessionAPI,
     componentListeners: {
       errors: 'onError',
@@ -169,5 +175,5 @@ export const createRoomSessionObject = (params: BaseComponentOptions) => {
     },
   })(params)
 
-  return roomSession
+  return roomSession as any as RoomSession
 }

--- a/packages/realtime-api/src/video/RoomSession.ts
+++ b/packages/realtime-api/src/video/RoomSession.ts
@@ -124,9 +124,8 @@ class RoomSessionConsumer extends BaseConsumer<RealTimeRoomApiEvents> {
             })
           },
           payloadTransform: (payload: VideoMemberEventParams) => {
-            const { id, ...rest } = payload.member
             return toExternalJSON({
-              ...rest,
+              ...payload.member,
               /**
                * The server is sending the member id as `id`
                * but internally (i.e in CustomMethods) we
@@ -135,7 +134,7 @@ class RoomSessionConsumer extends BaseConsumer<RealTimeRoomApiEvents> {
                * multiple ids at once and having them
                * properly prefixed makes it easier to read.
                */
-              member_id: id,
+              member_id: payload.member.id,
             })
           },
         },

--- a/packages/realtime-api/src/video/RoomSessionMember.ts
+++ b/packages/realtime-api/src/video/RoomSessionMember.ts
@@ -27,7 +27,8 @@ export interface RoomSessionMemberAPI extends RoomSessionMemberMethods {
 
 export type RoomSessionMember = RoomSessionMemberAPI & VideoMember
 
-// TODO: check generic
+// TODO: Extend from a variant of `BaseComponent` that
+// doesn't expose EventEmitter methods
 class RoomSessionMemberComponent extends BaseComponent<{}> {
   async remove() {
     await this.execute({
@@ -55,7 +56,6 @@ const RoomSessionMemberAPI = extendComponent<
   setInputSensitivity: Rooms.setInputSensitivityMember,
 })
 
-// TODO: check generic
 export const createRoomSessionMemberObject = (
   params: BaseComponentOptions<{}>
 ) => {

--- a/packages/realtime-api/src/video/RoomSessionMember.ts
+++ b/packages/realtime-api/src/video/RoomSessionMember.ts
@@ -27,7 +27,8 @@ export interface RoomSessionMemberAPI extends RoomSessionMemberMethods {
 
 export type RoomSessionMember = RoomSessionMemberAPI & VideoMember
 
-class RoomSessionMemberComponent extends BaseComponent {
+// TODO: check generic
+class RoomSessionMemberComponent extends BaseComponent<{}> {
   async remove() {
     await this.execute({
       method: 'video.member.remove',
@@ -54,7 +55,10 @@ const RoomSessionMemberAPI = extendComponent<
   setInputSensitivity: Rooms.setInputSensitivityMember,
 })
 
-export const createRoomSessionMemberObject = (params: BaseComponentOptions) => {
+// TODO: check generic
+export const createRoomSessionMemberObject = (
+  params: BaseComponentOptions<{}>
+) => {
   const member = connect({
     store: params.store,
     // @ts-expect-error

--- a/packages/realtime-api/typedoc.js
+++ b/packages/realtime-api/typedoc.js
@@ -2,8 +2,10 @@ module.exports = {
   out: './docs/',
   entryPoints: ['src/index.ts'],
   excludeExternals: true,
+  excludeInternal: true,
   excludePrivate: true,
   hideGenerator: true,
-  readme: 'none',
-  tsconfig: 'tsconfig.docs.json'
+  readme: 'README.md',
+  tsconfig: 'tsconfig.docs.json',
+  plugin: [],
 }

--- a/packages/webrtc/src/BaseConnection.ts
+++ b/packages/webrtc/src/BaseConnection.ts
@@ -72,14 +72,24 @@ const DEFAULT_CALL_OPTIONS: ConnectionOptions = {
   iceGatheringTimeout: 2 * 1000,
 }
 
-export type BaseConnectionOptions = ConnectionOptions & BaseComponentOptions
+type EventsHandlerMapping = Record<BaseConnectionState, () => void> &
+  Record<string, () => void>
+
+export type EventTypes = {
+  [k in BaseConnectionState]: EventsHandlerMapping[k]
+}
+
+export type BaseConnectionOptions = ConnectionOptions &
+  BaseComponentOptions<EventTypes>
+
 export class BaseConnection
-  extends BaseComponent
+  extends BaseComponent<EventTypes>
   implements Rooms.BaseRoomInterface
 {
   public nodeId = ''
   public direction: 'inbound' | 'outbound'
   public peer: RTCPeer
+  // @ts-expect-error
   public options: BaseConnectionOptions
   /** @internal */
   public cause: string

--- a/packages/webrtc/src/BaseConnection.ts
+++ b/packages/webrtc/src/BaseConnection.ts
@@ -84,12 +84,12 @@ export type BaseConnectionOptions = ConnectionOptions &
 
 export class BaseConnection
   extends BaseComponent<EventTypes>
-  implements Rooms.BaseRoomInterface
+  // TODO: fix types
+  implements Rooms.BaseRoomInterface<any>
 {
   public nodeId = ''
   public direction: 'inbound' | 'outbound'
   public peer: RTCPeer
-  // @ts-expect-error
   public options: BaseConnectionOptions
   /** @internal */
   public cause: string

--- a/packages/webrtc/src/BaseConnection.ts
+++ b/packages/webrtc/src/BaseConnection.ts
@@ -87,7 +87,6 @@ export type BaseConnectionOptions<
 
 export class BaseConnection<EventTypes extends EventEmitter.ValidEventTypes>
   extends BaseComponent<EventTypes & BaseConnectionStateEventTypes>
-  // TODO: fix types
   implements
     Rooms.BaseRoomInterface<EventTypes & BaseConnectionStateEventTypes>
 {

--- a/packages/webrtc/src/RTCPeer.ts
+++ b/packages/webrtc/src/RTCPeer.ts
@@ -408,6 +408,7 @@ export default class RTCPeer {
     }
     if (event.candidate) {
       logger.debug('IceCandidate:', event.candidate)
+      // @ts-expect-error
       this.call.emit('icecandidate', event)
     } else {
       this._sdpReady()
@@ -512,6 +513,7 @@ export default class RTCPeer {
     // })
 
     this.instance.addEventListener('track', (event: RTCTrackEvent) => {
+      // @ts-expect-error
       this.call.emit('track', event)
 
       if (this.isSfu) {

--- a/packages/webrtc/src/RTCPeer.ts
+++ b/packages/webrtc/src/RTCPeer.ts
@@ -1,4 +1,4 @@
-import { logger } from '@signalwire/core'
+import { logger, EventEmitter } from '@signalwire/core'
 import { getUserMedia, getMediaConstraints } from './utils/helpers'
 import {
   sdpStereoHack,
@@ -14,14 +14,17 @@ import {
 } from './utils/webrtcHelpers'
 import { ConnectionOptions } from './utils/interfaces'
 
-export default class RTCPeer {
+export default class RTCPeer<EventTypes extends EventEmitter.ValidEventTypes> {
   public instance: RTCPeerConnection
 
   private options: ConnectionOptions
   private _iceTimeout: any
   private _negotiating = false
 
-  constructor(public call: BaseConnection, public type: RTCSdpType) {
+  constructor(
+    public call: BaseConnection<EventTypes>,
+    public type: RTCSdpType
+  ) {
     this.options = call.options
     logger.debug('New Peer with type:', this.type, 'Options:', this.options)
 

--- a/packages/webrtc/src/utils/deviceHelpers.ts
+++ b/packages/webrtc/src/utils/deviceHelpers.ts
@@ -34,7 +34,8 @@ const _legacyCheckPermissions = async (kind?: MediaDeviceKind) => {
   return devices.every(({ deviceId, label }) => Boolean(deviceId && label))
 }
 
-type DevicePermissionName = DevicePermissionDescriptor['name']
+// DevicePermissionDescriptor['name]
+type DevicePermissionName = 'camera' | 'microphone' | 'speaker'
 
 /**
  * Asynchronously returns whether we have permissions to access the specified
@@ -62,6 +63,7 @@ export const checkPermissions = async (name?: DevicePermissionName) => {
        * valid enumation value for `PermissionName`. As of today, some
        * browsers like Fireforx will throw with `name: "camera"`
        */
+      // @ts-expect-error
       const status = await navigator.permissions.query({ name })
 
       return status.state === 'granted'

--- a/packages/webrtc/src/utils/deviceHelpers.ts
+++ b/packages/webrtc/src/utils/deviceHelpers.ts
@@ -1,5 +1,4 @@
 import { logger, EventEmitter } from '@signalwire/core'
-import StrictEventEmitter from 'strict-event-emitter-types'
 import * as WebRTC from './webrtcHelpers'
 
 /**
@@ -625,23 +624,18 @@ type DeviceWatcherChange<T extends DeviceWatcherEventNames> = {
 }
 
 interface DeviceWatcherEvents {
-  added: DeviceWatcherChange<'added'>
-  removed: DeviceWatcherChange<'removed'>
-  updated: DeviceWatcherChange<'updated'>
-  changed: {
+  added: (params: DeviceWatcherChange<'added'>) => void
+  removed: (params: DeviceWatcherChange<'removed'>) => void
+  updated: (params: DeviceWatcherChange<'updated'>) => void
+  changed: (params: {
     changes: {
       added: DeviceWatcherChangePayload<'added'>[]
       removed: DeviceWatcherChangePayload<'removed'>[]
       updated: DeviceWatcherChangePayload<'updated'>[]
     }
     devices: MediaDeviceInfo[]
-  }
+  }) => void
 }
-
-type DeviceWatcherEventEmitter = StrictEventEmitter<
-  EventEmitter,
-  DeviceWatcherEvents
->
 
 /**
  * Asynchronously returns an event emitter that notifies changes in the devices.
@@ -686,10 +680,9 @@ type DeviceWatcherEventEmitter = StrictEventEmitter<
  */
 export const createDeviceWatcher = async (
   options: CreateDeviceWatcherOptions = {}
-): Promise<DeviceWatcherEventEmitter> => {
+) => {
   const targets = await validateTargets({ targets: options.targets })
-  const emitter: StrictEventEmitter<EventEmitter, DeviceWatcherEvents> =
-    new EventEmitter()
+  const emitter = new EventEmitter<DeviceWatcherEvents>()
   const currentDevices = await WebRTC.enumerateDevices()
   const kinds = targets?.reduce((reducer, name) => {
     const kind = _getMediaDeviceKindByName(name)

--- a/packages/webrtc/src/utils/webrtcHelpers.ts
+++ b/packages/webrtc/src/utils/webrtcHelpers.ts
@@ -22,7 +22,6 @@ export const supportsGetUserMedia = () => {
  * Returns whether the current environment supports `getDisplayMedia`.
  */
 export const supportsGetDisplayMedia = () => {
-  // @ts-expect-error
   return typeof navigator?.mediaDevices?.getDisplayMedia === 'function'
 }
 
@@ -146,7 +145,6 @@ export const getUserMedia = (
  * ```
  */
 export const getDisplayMedia = (constraints: MediaStreamConstraints) => {
-  // @ts-expect-error
   return getMediaDevicesApi().getDisplayMedia(constraints)
 }
 

--- a/packages/webrtc/src/webrtcMocks.ts
+++ b/packages/webrtc/src/webrtcMocks.ts
@@ -71,10 +71,10 @@ class MediaStreamTrackMock implements MediaStreamTrack {
   readonly: boolean
   readyState: MediaStreamTrackState
   remote: boolean
-  onended: (this: MediaStreamTrack, ev: MediaStreamErrorEvent) => any
+  onended: (this: MediaStreamTrack, ev: any) => any
   onisolationchange: (this: MediaStreamTrack, ev: Event) => any
   onmute: (this: MediaStreamTrack, ev: Event) => any
-  onoverconstrained: (this: MediaStreamTrack, ev: MediaStreamErrorEvent) => any
+  onoverconstrained: (this: MediaStreamTrack, ev: any) => any
   onunmute: (this: MediaStreamTrack, ev: Event) => any
 
   applyConstraints(constraints: any): Promise<void> {
@@ -167,13 +167,13 @@ class RTCPeerConnectionMock implements RTCPeerConnection {
   onicegatheringstatechange: (this: RTCPeerConnection, ev: Event) => any
   onnegotiationneeded: (this: RTCPeerConnection, ev: Event) => any
   onsignalingstatechange: (this: RTCPeerConnection, ev: Event) => any
-  onstatsended: (this: RTCPeerConnection, ev: RTCStatsEvent) => any
+  onstatsended: (this: RTCPeerConnection, ev: any) => any
   ontrack: (this: RTCPeerConnection, ev: RTCTrackEvent) => any
-  peerIdentity: Promise<RTCIdentityAssertion>
+  peerIdentity: Promise<any>
   pendingLocalDescription: RTCSessionDescription
   pendingRemoteDescription: RTCSessionDescription
   remoteDescription: RTCSessionDescription
-  sctp: RTCSctpTransport
+  sctp: any
   signalingState: RTCSignalingState
   // addIceCandidate(candidate: RTCIceCandidateInit | RTCIceCandidate): Promise<void>
   // addIceCandidate(candidate?: RTCIceCandidateInit | RTCIceCandidate): Promise<void>
@@ -249,7 +249,7 @@ class RTCPeerConnectionMock implements RTCPeerConnection {
   getStats(selector?: MediaStreamTrack): Promise<RTCStatsReport>
   getStats(
     selector: MediaStreamTrack,
-    successCallback: RTCStatsCallback,
+    successCallback: RTCSessionDescriptionCallback,
     failureCallback: RTCPeerConnectionErrorCallback
   ): Promise<void>
   getStats(
@@ -272,10 +272,7 @@ class RTCPeerConnectionMock implements RTCPeerConnection {
   setConfiguration(configuration: any) {
     throw new Error('Method not implemented: setConfiguration')
   }
-  setIdentityProvider(
-    provider: string,
-    options?: RTCIdentityProviderOptions
-  ): void {
+  setIdentityProvider(provider: string, options?: any): void {
     throw new Error('Method not implemented: setIdentityProvider')
   }
   setLocalDescription(description: RTCSessionDescriptionInit): Promise<void>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,6 +27,8 @@
     },
     "composite": true,
     "declarationMap": true,
-    "strictPropertyInitialization": false
+    "strictPropertyInitialization": false,
+    "useUnknownInCatchVariables": false,
+    "skipLibCheck": true
   }
 }


### PR DESCRIPTION
The code in this changeset includes:

1. Improve way of having strictly type `EventEmitter`s. We no longer depend on an external package of this `strict-event-emitter-types`. As a result the auto-generated docs (TypeDoc) are a lot better since now the allowed events gets inlined.
2. Upgrade to TS 4.4.2.
3. Removed option to pass a custom EventEmitter when creating the client.