### PR TITLE
Transform the event name before checking for emitter transforms

### DIFF
--- a/packages/core/src/BaseComponent.ts
+++ b/packages/core/src/BaseComponent.ts
@@ -239,7 +239,9 @@ export class BaseComponent<T = Record<string, unknown>> implements Emitter {
     fn: BaseEventHandler
   ) {
     return (payload: unknown) => {
-      const transform = this._emitterTransforms.get(event)
+      // FIXME: review how we're passing events from the on/once/off methods
+      const internalNotNamespacedEvent = toInternalEventName({ event })
+      const transform = this._emitterTransforms.get(internalNotNamespacedEvent)
       if (!transform) {
         return fn(payload)
       }


### PR DESCRIPTION
This is a quick check to fix an issue in the Node sdk on `main`. As discussed we'll review the `event name` logic as well 