### PR TITLE
Realtime whitelist export + rename `run` to `subscribe` in BaseConsumer

### DIFF
--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -42,7 +42,7 @@ export interface BaseConnectionContract<
 export interface ConsumerContract<
   EventTypes extends EventEmitter.ValidEventTypes
 > extends EmitterContract<EventTypes> {
-  run(): Promise<void>
+  subscribe(): Promise<void>
 }
 
 export interface ClientContract<

--- a/packages/realtime-api/examples/ts-vanilla-websockets/index.ts
+++ b/packages/realtime-api/examples/ts-vanilla-websockets/index.ts
@@ -73,7 +73,7 @@ async function run() {
           rec.duration
         )
       })
-      await room.run()
+      await room.subscribe()
 
       const rec = await room.startRecording()
 

--- a/packages/realtime-api/src/BaseConsumer.ts
+++ b/packages/realtime-api/src/BaseConsumer.ts
@@ -22,7 +22,7 @@ export class BaseConsumer<
     return validateEventsToSubscribe(this.eventNames())
   }
 
-  run() {
+  subscribe() {
     return new Promise(async (resolve, reject) => {
       const subscriptions = this.getSubscriptions()
       if (subscriptions.length > 0) {

--- a/packages/realtime-api/src/Client.ts
+++ b/packages/realtime-api/src/Client.ts
@@ -22,7 +22,7 @@ export class Client extends BaseClient<ClientEvents> {
     try {
       if (session.authStatus === 'authorized') {
         this._consumers.forEach((consumer) => {
-          consumer.run()
+          consumer.subscribe()
         })
       }
     } catch (error) {

--- a/packages/realtime-api/src/Video.test.ts
+++ b/packages/realtime-api/src/Video.test.ts
@@ -16,13 +16,13 @@ describe('Member Object', () => {
   })
 
   it('should not invoke execute without event listeners', async () => {
-    await video.run()
+    await video.subscribe()
     expect(video.execute).not.toHaveBeenCalled()
   })
 
   it('should invoke execute with event listeners', async () => {
     video.on('event.here', jest.fn)
-    await video.run()
+    await video.subscribe()
     expect(video.execute).toHaveBeenCalledWith({
       method: 'signalwire.subscribe',
       params: {
@@ -52,7 +52,7 @@ describe('Member Object', () => {
         done()
       })
 
-      video.run()
+      video.subscribe()
       video.emit('video.room.started', firstRoom.params.params)
     })
 
@@ -63,7 +63,7 @@ describe('Member Object', () => {
       }
       video.on('room.started', h)
 
-      video.run()
+      video.subscribe()
       video.emit('video.room.started', firstRoom.params.params)
 
       video.off('room.started', h)
@@ -78,7 +78,7 @@ describe('Member Object', () => {
       video.on('room.started', h)
       video.on('room.started', () => {})
 
-      video.run()
+      video.subscribe()
       video.emit('video.room.started', firstRoom.params.params)
 
       video.off('room.started', h)
@@ -94,7 +94,7 @@ describe('Member Object', () => {
       video.on('room.started', () => {})
       video.on('room.started', () => {})
 
-      video.run()
+      video.subscribe()
       video.emit('video.room.started', firstRoom.params.params)
 
       video.off('room.started')
@@ -113,7 +113,7 @@ describe('Member Object', () => {
 
           room.on('event.here', jest.fn)
           room.execute = mockExecute
-          room.run()
+          room.subscribe()
           mockNameCheck(room.name)
 
           if (room.roomSessionId === 'session-two') {
@@ -122,7 +122,7 @@ describe('Member Object', () => {
         })
       })
 
-      video.run()
+      video.subscribe()
       video.emit('video.room.started', firstRoom.params.params)
 
       video.emit('video.room.started', secondRoom.params.params)

--- a/packages/realtime-api/src/Video.test.ts
+++ b/packages/realtime-api/src/Video.test.ts
@@ -48,7 +48,7 @@ describe('Member Object', () => {
         expect(room.videoMute).toBeDefined()
         expect(room.videoUnmute).toBeDefined()
         expect(room.getMembers).toBeDefined()
-        expect(room.run).toBeDefined()
+        expect(room.subscribe).toBeDefined()
         done()
       })
 
@@ -109,7 +109,7 @@ describe('Member Object', () => {
           expect(room.videoMute).toBeDefined()
           expect(room.videoUnmute).toBeDefined()
           expect(room.getMembers).toBeDefined()
-          expect(room.run).toBeDefined()
+          expect(room.subscribe).toBeDefined()
 
           room.on('event.here', jest.fn)
           room.execute = mockExecute

--- a/packages/realtime-api/src/Video.ts
+++ b/packages/realtime-api/src/Video.ts
@@ -20,6 +20,7 @@ type TransformEvent = Extract<
 export interface VideoObject extends ConsumerContract<RealTimeVideoApiEvents> {}
 export type { RoomSession, RoomSessionMember, RoomSessionRecording }
 
+/** @internal */
 export class Video extends BaseConsumer<RealTimeVideoApiEvents> {
   /** @internal */
   protected _eventsPrefix = 'video' as const
@@ -58,6 +59,7 @@ export class Video extends BaseConsumer<RealTimeVideoApiEvents> {
   }
 }
 
+/** @internal */
 export const createVideoObject = (
   params: BaseComponentOptions<RealTimeVideoApiEvents>
 ): VideoObject => {


### PR DESCRIPTION
- Renamed `.run()` to `.subscribe()` for our Consumers
- Make some methods/objects `@internal` for the Video namespace