### PR TITLE
Add option to enforce casing for imports

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -29,6 +29,7 @@
     "declarationMap": true,
     "strictPropertyInitialization": false,
     "useUnknownInCatchVariables": false,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
   }
 }


### PR DESCRIPTION
By default `ts` doesn't enforce imports to be case-sensitive: If we assume we have a `video` folder (all lowercased) the following would both be valid.

```
export * as Video from './video/Video'
```
and 
```
export * as Video from './Video/Video'
```
