### PR TITLE
Fix `js` roomSession method signatures

### DIFF
--- a/.changeset/few-baboons-itch.md
+++ b/.changeset/few-baboons-itch.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/js': patch
+---
+
+Fix TS signature for member methods

--- a/packages/js/src/utils/interfaces.ts
+++ b/packages/js/src/utils/interfaces.ts
@@ -104,10 +104,10 @@ export interface BaseRoomInterface {
 }
 
 interface RoomMemberMethodsInterface {
-  audioMute(params: MemberCommandParams): Rooms.AudioMuteMember
-  audioUnmute(params: MemberCommandParams): Rooms.AudioUnmuteMember
-  videoMute(params: MemberCommandParams): Rooms.VideoMuteMember
-  videoUnmute(params: MemberCommandParams): Rooms.VideoUnmuteMember
+  audioMute(params?: MemberCommandParams): Rooms.AudioMuteMember
+  audioUnmute(params?: MemberCommandParams): Rooms.AudioUnmuteMember
+  videoMute(params?: MemberCommandParams): Rooms.VideoMuteMember
+  videoUnmute(params?: MemberCommandParams): Rooms.VideoUnmuteMember
   setMicrophoneVolume(
     params: MemberCommandWithVolumeParams
   ): Rooms.SetInputVolumeMember
@@ -134,8 +134,8 @@ interface RoomLayoutMethodsInterface {
 
 interface RoomControlMethodsInterface {
   getMembers(): Rooms.GetMembers
-  deaf(params: MemberCommandParams): Rooms.DeafMember
-  undeaf(params: MemberCommandParams): Rooms.UndeafMember
+  deaf(params?: MemberCommandParams): Rooms.DeafMember
+  undeaf(params?: MemberCommandParams): Rooms.UndeafMember
   setSpeakerVolume(
     params: MemberCommandWithVolumeParams
   ): Rooms.SetOutputVolumeMember


### PR DESCRIPTION
Just making `params` optional for some methods