### PR TITLE
Standardise usage of internal and local events

### DIFF
--- a/.changeset/flat-rockets-draw.md
+++ b/.changeset/flat-rockets-draw.md
@@ -1,6 +1,0 @@
----
-'@signalwire/js': patch
-'@signalwire/realtime-api': patch
----
-
-Improve internal usage of events.

--- a/.changeset/flat-rockets-draw.md
+++ b/.changeset/flat-rockets-draw.md
@@ -1,0 +1,6 @@
+---
+'@signalwire/js': patch
+'@signalwire/realtime-api': patch
+---
+
+Improve internal usage of events.

--- a/.changeset/unlucky-walls-train.md
+++ b/.changeset/unlucky-walls-train.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/core': patch
+---
+
+Normalize usage of events to always use our "internal" version for registering, transforms, caching, etc.

--- a/packages/core/src/BaseComponent.test.ts
+++ b/packages/core/src/BaseComponent.test.ts
@@ -51,29 +51,27 @@ describe('BaseComponent', () => {
     })
 
     it('should keep track of the original events with the _eventsPrefix', () => {
-      const firstInstance = new JestComponent('first')
+      const firstInstance = new JestComponent('first_namespace')
       firstInstance.on('first.event_one', () => {})
       firstInstance.once('video.first.eventOne', () => {})
       firstInstance.on('first.event_two', () => {})
       firstInstance.once('video.first.eventTwo', () => {})
+      firstInstance.once('video.first.eventTwoExtra', () => {})
 
-      const secondInstance = new JestComponent('second')
+      const secondInstance = new JestComponent('second_namespace')
       secondInstance.on('second.event_one', () => {})
       secondInstance.once('video.second.eventOne', () => {})
       secondInstance.on('second.event_two', () => {})
       secondInstance.once('video.second.eventTwo', () => {})
 
       expect(firstInstance.eventNames()).toStrictEqual([
-        'video.first.event_one',
-        'video.first.eventOne',
-        'video.first.event_two',
-        'video.first.eventTwo',
+        'first_namespace:video.first.event_one',
+        'first_namespace:video.first.event_two',
+        'first_namespace:video.first.event_two_extra',
       ])
       expect(secondInstance.eventNames()).toStrictEqual([
-        'video.second.event_one',
-        'video.second.eventOne',
-        'video.second.event_two',
-        'video.second.eventTwo',
+        'second_namespace:video.second.event_one',
+        'second_namespace:video.second.event_two',
       ])
     })
 
@@ -89,10 +87,9 @@ describe('BaseComponent', () => {
       expect(instance.listenerCount('custom:video.test.event_one')).toEqual(2)
       expect(instance.listenerCount('custom:video.test.event_two')).toEqual(2)
 
-      // _trackedEvents contains raw-prefixed event names
       expect(instance.eventNames()).toStrictEqual([
-        'video.test.eventOne',
-        'video.test.eventTwo',
+        'custom:video.test.event_one',
+        'custom:video.test.event_two',
       ])
 
       // No-op
@@ -120,13 +117,14 @@ describe('BaseComponent', () => {
       expect(instance.listenerCount('custom:video.test.event_one')).toEqual(2)
       expect(instance.listenerCount('custom:video.test.event_two')).toEqual(2)
 
-      // _trackedEvents contains raw-prefixed event names
       expect(instance.eventNames()).toStrictEqual([
-        'video.test.eventOne',
-        'video.test.eventTwo',
+        'custom:video.test.event_one',
+        'custom:video.test.event_two',
       ])
 
       instance.removeAllListeners()
+
+      console.log('instance.eventNames()', instance.eventNames())
 
       expect(instance.listenerCount('custom:video.test.event_one')).toEqual(0)
       expect(instance.listenerCount('custom:video.test.event_two')).toEqual(0)

--- a/packages/core/src/BaseComponent.test.ts
+++ b/packages/core/src/BaseComponent.test.ts
@@ -124,8 +124,6 @@ describe('BaseComponent', () => {
 
       instance.removeAllListeners()
 
-      console.log('instance.eventNames()', instance.eventNames())
-
       expect(instance.listenerCount('custom:video.test.event_one')).toEqual(0)
       expect(instance.listenerCount('custom:video.test.event_two')).toEqual(0)
       expect(instance.eventNames()).toStrictEqual([])

--- a/packages/core/src/BaseComponent.ts
+++ b/packages/core/src/BaseComponent.ts
@@ -1,5 +1,5 @@
 import { Action } from '@reduxjs/toolkit'
-import { uuid, logger, toInternalEventName } from './utils'
+import { uuid, logger, toInternalEventName, isLocalEvent } from './utils'
 import { executeAction } from './redux'
 import {
   ExecuteParams,
@@ -69,8 +69,8 @@ export class BaseComponent<
   private _getNamespacedEvent(event: EventEmitter.EventNames<EventTypes>) {
     let namespace = this._eventsNamespace
 
-    // TODO: move to external function
-    if (typeof event === 'string' && event.includes('__internal__')) {
+    // TODO: explain why we're using a diff namespace for local events.
+    if (typeof event === 'string' && isLocalEvent(event)) {
       namespace = this.__uuid
     }
 

--- a/packages/core/src/BaseComponent.ts
+++ b/packages/core/src/BaseComponent.ts
@@ -67,9 +67,20 @@ export class BaseComponent<
    * to that specific room.
    */
   private _getNamespacedEvent(event: EventEmitter.EventNames<EventTypes>) {
+    /**
+     * "Remote" events are the events controlled by the
+     * server. In order to be able to attach them we have to
+     * wait for the server to respond.
+     * `this._eventsNamespace` is usually set with some
+     * piece of data coming from the server.
+     */
     let namespace = this._eventsNamespace
 
-    // TODO: explain why we're using a diff namespace for local events.
+    /**
+     * "Local" events are attached synchronously so in order
+     * to be able to namespaced them properly we must make
+     * use of our locally generated __uuid.
+     */
     if (typeof event === 'string' && isLocalEvent(event)) {
       namespace = this.__uuid
     }

--- a/packages/core/src/BaseComponent.ts
+++ b/packages/core/src/BaseComponent.ts
@@ -284,9 +284,8 @@ export class BaseComponent<
     >
   ) {
     const wrapperHandler = (payload: unknown) => {
-      // FIXME: review how we're passing events from the on/once/off methods
-      const internalNotNamespacedEvent = toInternalEventName({ event })
-      const transform = this._emitterTransforms.get(internalNotNamespacedEvent)
+      const internalEvent = this._getInternalEvent(event)
+      const transform = this._emitterTransforms.get(internalEvent)
       if (!transform) {
         // @ts-expect-error
         return fn(payload)

--- a/packages/core/src/BaseComponent.ts
+++ b/packages/core/src/BaseComponent.ts
@@ -621,26 +621,49 @@ export class BaseComponent<
     return new Map()
   }
 
+  private _setEmitterTransform({
+    event,
+    handler,
+    local,
+  }: {
+    event: string | string[]
+    handler: EventTransform
+    local: boolean
+  }) {
+    if (local && typeof event === 'string' && !isLocalEvent(event)) {
+      return
+    }
+
+    this._emitterTransforms.set(
+      this._getInternalEvent(event as EventEmitter.EventNames<EventTypes>),
+      handler
+    )
+  }
+
   /**
    * Loop through the `getEmitterTransforms` Map and translate those into the
    * internal `_emitterTransforms` Map to quickly select & use the transform starting
    * from the server-side event.
    * @internal
    */
-  protected applyEmitterTransforms() {
+  protected applyEmitterTransforms(
+    { local = false }: { local: boolean } = { local: false }
+  ) {
     this.getEmitterTransforms().forEach((handlersObj, key) => {
       if (Array.isArray(key)) {
-        key.forEach((k) =>
-          this._emitterTransforms.set(
-            this._getInternalEvent(k as EventEmitter.EventNames<EventTypes>),
-            handlersObj
-          )
-        )
+        key.forEach((k) => {
+          this._setEmitterTransform({
+            event: k,
+            handler: handlersObj,
+            local,
+          })
+        })
       } else {
-        this._emitterTransforms.set(
-          this._getInternalEvent(key as EventEmitter.EventNames<EventTypes>),
-          handlersObj
-        )
+        this._setEmitterTransform({
+          event: key,
+          handler: handlersObj,
+          local,
+        })
       }
     })
   }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,6 +3,7 @@ import {
   logger,
   isGlobalEvent,
   toExternalJSON,
+  toLocalEvent,
   validateEventsToSubscribe,
   extendComponent,
 } from './utils'
@@ -33,6 +34,7 @@ export {
   getEventEmitter,
   isGlobalEvent,
   toExternalJSON,
+  toLocalEvent,
   validateEventsToSubscribe,
   GLOBAL_VIDEO_EVENTS,
   MEMBER_UPDATED_EVENTS,

--- a/packages/core/src/rooms/methods.ts
+++ b/packages/core/src/rooms/methods.ts
@@ -1,5 +1,6 @@
 import { BaseRoomInterface } from '.'
 import { VideoMemberEntity, VideoRecordingEntity } from '../types'
+import { toLocalEvent } from '../utils'
 import { ExecuteExtendedOptions, RoomMethod } from '../utils/interfaces'
 
 interface RoomMethodPropertyDescriptor<T, ParamsType>
@@ -136,7 +137,7 @@ export const startRecording: RoomMethodDescriptor<any> = {
       const handler = (instance: any) => {
         resolve(instance)
       }
-      this.on('video.__internal__.recording.start', handler)
+      this.on(toLocalEvent('video.recording.start'), handler)
 
       try {
         const payload = await this.execute({
@@ -145,12 +146,12 @@ export const startRecording: RoomMethodDescriptor<any> = {
             room_session_id: this.roomSessionId,
           },
         })
-        this.emit('video.__internal__.recording.start', {
+        this.emit(toLocalEvent('video.recording.start'), {
           ...(payload as object),
           room_session_id: this.roomSessionId,
         })
       } catch (error) {
-        this.off('video.__internal__.recording.start', handler)
+        this.off(toLocalEvent('video.recording.start'), handler)
         throw error
       }
     })

--- a/packages/core/src/utils/constants.ts
+++ b/packages/core/src/utils/constants.ts
@@ -11,6 +11,11 @@ export enum WebSocketState {
   CLOSED = 3,
 }
 
+/**
+ * Used for namespacing events.
+ */
+export const EVENT_NAMESPACE_DIVIDER = ':'
+
 export const PRODUCT_PREFIX_VIDEO = 'video'
 
 export const GLOBAL_VIDEO_EVENTS = ['room.started', 'room.ended'] as const

--- a/packages/core/src/utils/constants.ts
+++ b/packages/core/src/utils/constants.ts
@@ -16,6 +16,8 @@ export enum WebSocketState {
  */
 export const EVENT_NAMESPACE_DIVIDER = ':'
 
+export const LOCAL_EVENT_PREFIX = '__local__'
+
 export const PRODUCT_PREFIX_VIDEO = 'video'
 
 export const GLOBAL_VIDEO_EVENTS = ['room.started', 'room.ended'] as const

--- a/packages/core/src/utils/index.test.ts
+++ b/packages/core/src/utils/index.test.ts
@@ -84,4 +84,19 @@ describe('validateEventsToSubscribe', () => {
       'video.member.updated',
     ])
   })
+
+  it('should cleanup namespaced events', () => {
+    const events = [
+      '1111-2222-3333-4444:video.member.joined',
+      '12345:video.member.updated',
+      'video.member.ns_one',
+      'video.member.ns_two',
+    ]
+    expect(validateEventsToSubscribe(events)).toStrictEqual([
+      'video.member.joined',
+      'video.member.updated',
+      'video.member.ns_one',
+      'video.member.ns_two',
+    ])
+  })
 })

--- a/packages/core/src/utils/index.test.ts
+++ b/packages/core/src/utils/index.test.ts
@@ -1,8 +1,11 @@
 import {
   checkWebSocketHost,
+  isLocalEvent,
   timeoutPromise,
+  toLocalEvent,
   validateEventsToSubscribe,
 } from './'
+import { LOCAL_EVENT_PREFIX } from './constants'
 
 describe('checkWebSocketHost', () => {
   it('should add wss protocol if not present', () => {
@@ -98,5 +101,20 @@ describe('validateEventsToSubscribe', () => {
       'video.member.ns_one',
       'video.member.ns_two',
     ])
+  })
+})
+
+describe('toLocalEvent', () => {
+  it('should convert the event to our local event syntax', () => {
+    expect(toLocalEvent('video.room.started')).toEqual(
+      `video.${LOCAL_EVENT_PREFIX}.room.started`
+    )
+  })
+})
+
+describe('isLocalEvent', () => {
+  it('should identify when an event is local', () => {
+    expect(isLocalEvent(toLocalEvent('video.room.started'))).toBeTruthy()
+    expect(isLocalEvent('video.room.started')).toBeFalsy()
   })
 })

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -70,7 +70,7 @@ export const getGlobalEvents = (kind: 'all' | 'video' = 'all') => {
   }
 }
 
-export const cleanupEventNamespace = (event: string) => {
+const cleanupEventNamespace = (event: string) => {
   const eventParts = event.split(EVENT_NAMESPACE_DIVIDER)
   return eventParts[eventParts.length - 1]
 }
@@ -101,6 +101,10 @@ export const validateEventsToSubscribe = (events: (string | symbol)[]) => {
   return Array.from(new Set(valid))
 }
 
+/**
+ * "Local" events are events controlled by the SDK and the
+ * server has no knowledge about them.
+ */
 export const isLocalEvent = (event: string) => {
   return event.includes(LOCAL_EVENT_PREFIX)
 }

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -105,7 +105,7 @@ export const isLocalEvent = (event: string) => {
   return event.includes(LOCAL_EVENT_PREFIX)
 }
 
-export const toLocalEvent = (event: string) => {
+export const toLocalEvent = <T extends string>(event: string): T => {
   const eventParts = event.split('.')
   const prefix = eventParts[0]
 
@@ -120,5 +120,5 @@ export const toLocalEvent = (event: string) => {
 
       return reducer
     }, [] as string[])
-    .join('.')
+    .join('.') as T
 }

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -3,6 +3,7 @@ import {
   GLOBAL_VIDEO_EVENTS,
   INTERNAL_GLOBAL_VIDEO_EVENTS,
   EVENT_NAMESPACE_DIVIDER,
+  LOCAL_EVENT_PREFIX,
 } from './constants'
 
 export { v4 as uuid } from 'uuid'
@@ -98,4 +99,26 @@ export const validateEventsToSubscribe = (events: (string | symbol)[]) => {
   })
 
   return Array.from(new Set(valid))
+}
+
+export const isLocalEvent = (event: string) => {
+  return event.includes(LOCAL_EVENT_PREFIX)
+}
+
+export const toLocalEvent = (event: string) => {
+  const eventParts = event.split('.')
+  const prefix = eventParts[0]
+
+  return event
+    .split('.')
+    .reduce((reducer, item) => {
+      reducer.push(item)
+
+      if (item === prefix) {
+        reducer.push(LOCAL_EVENT_PREFIX)
+      }
+
+      return reducer
+    }, [] as string[])
+    .join('.')
 }

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -2,6 +2,7 @@ import {
   STORAGE_PREFIX,
   GLOBAL_VIDEO_EVENTS,
   INTERNAL_GLOBAL_VIDEO_EVENTS,
+  EVENT_NAMESPACE_DIVIDER,
 } from './constants'
 
 export { v4 as uuid } from 'uuid'
@@ -68,6 +69,11 @@ export const getGlobalEvents = (kind: 'all' | 'video' = 'all') => {
   }
 }
 
+export const cleanupEventNamespace = (event: string) => {
+  const eventParts = event.split(EVENT_NAMESPACE_DIVIDER)
+  return eventParts[eventParts.length - 1]
+}
+
 const WITH_CUSTOM_EVENT_NAMES = [
   'video.member.updated',
   'video.member.talking',
@@ -79,17 +85,16 @@ const WITH_CUSTOM_EVENT_NAMES = [
  * @internal
  */
 export const validateEventsToSubscribe = (events: (string | symbol)[]) => {
-  const valid = events.map((event) => {
-    if (typeof event === 'string') {
+  const valid = events.map((internalEvent) => {
+    if (typeof internalEvent === 'string') {
+      const event = cleanupEventNamespace(internalEvent)
       const found = WITH_CUSTOM_EVENT_NAMES.find((withCustomName) => {
         return event.startsWith(withCustomName)
       })
-      if (found) {
-        return found
-      }
+      return found || event
     }
 
-    return event
+    return internalEvent
   })
 
   return Array.from(new Set(valid))

--- a/packages/core/src/utils/toInternalEventName.test.ts
+++ b/packages/core/src/utils/toInternalEventName.test.ts
@@ -1,6 +1,18 @@
+import { EVENT_NAMESPACE_DIVIDER } from './constants'
 import { toInternalEventName } from './toInternalEventName'
 
 describe('toInternalEventName', () => {
+  it('should use the EVENT_NAMESPACE_DIVIDER constant for namespacing the event', () => {
+    const internalEvent = toInternalEventName({
+      event: 'video.room.started',
+      namespace: '1234',
+    })
+
+    expect(internalEvent).toEqual(
+      `1234${EVENT_NAMESPACE_DIVIDER}video.room.started`
+    )
+  })
+
   it('should transform public events into internal without namespace', () => {
     const events = [
       // no-op
@@ -27,6 +39,35 @@ describe('toInternalEventName', () => {
       expect(toInternalEventName({ event: input, namespace })).toEqual(
         `${namespace}:${output}`
       )
+    })
+  })
+
+  it('should not add the namespace to events that are already namespaced', () => {
+    const events = [
+      {
+        input: 'some-namespace:video.room.started',
+        output: 'some-namespace:video.room.started',
+        namespace: 'some-namespace',
+      },
+      {
+        input: '111-222-333:video.member.updated',
+        output: '111-222-333:video.member.updated',
+        namespace: '111-222-333',
+      },
+      {
+        input: 'xxxxxx:video.member.updated.video_muted',
+        output: 'xxxxxx:video.member.updated.video_muted',
+        namespace: 'xxxxxx',
+      },
+      {
+        input: 'y_y:video.other_snake_case',
+        output: 'y_y:video.other_snake_case',
+        namespace: 'y_y',
+      },
+    ]
+
+    events.forEach(({ input, output, namespace }) => {
+      expect(toInternalEventName({ event: input, namespace })).toEqual(output)
     })
   })
 })

--- a/packages/core/src/utils/toInternalEventName.ts
+++ b/packages/core/src/utils/toInternalEventName.ts
@@ -1,3 +1,4 @@
+import { EVENT_NAMESPACE_DIVIDER } from './constants'
 import { EventEmitter } from './EventEmitter'
 
 type ToInternalEventNameParams<
@@ -54,5 +55,5 @@ const getNamespacedEvent = ({
     return event
   }
 
-  return `${namespace}:${event}`
+  return `${namespace}${EVENT_NAMESPACE_DIVIDER}${event}`
 }

--- a/packages/js/src/Room.ts
+++ b/packages/js/src/Room.ts
@@ -6,6 +6,7 @@ import {
   extendComponent,
   BaseComponentOptions,
   BaseConnectionContract,
+  toLocalEvent,
 } from '@signalwire/core'
 import {
   getDisplayMedia,
@@ -61,7 +62,7 @@ export class RoomConnection
     return new Map<string | string[], EventTransform>([
       [
         [
-          'video.__internal__.recording.start',
+          toLocalEvent('video.recording.start'),
           'video.recording.started',
           'video.recording.updated',
           'video.recording.ended',

--- a/packages/realtime-api/src/BaseConsumer.ts
+++ b/packages/realtime-api/src/BaseConsumer.ts
@@ -27,12 +27,13 @@ export class BaseConsumer<
     super(options)
 
     /**
-     * Always apply the emitter transforms
-     * We should split between internal and public:
-     * always apply the internals and apply only the ones
-     * the user registered event listeners to.
+     * Local events can be attached right away because we
+     * have enough information during build time on how to
+     * namespace them. Other events depend on info coming
+     * from the server and for those we have to wait until
+     * the `subscribe()` happen.
      */
-    this.applyEmitterTransforms()
+    this.applyEmitterTransforms({ local: true })
   }
 
   subscribe() {

--- a/packages/realtime-api/src/BaseConsumer.ts
+++ b/packages/realtime-api/src/BaseConsumer.ts
@@ -50,6 +50,7 @@ export class BaseConsumer<
 
         try {
           await this.execute(execParams)
+          this.applyEmitterTransforms()
         } catch (error) {
           return reject(error)
         }

--- a/packages/realtime-api/src/video/RoomSession.test.ts
+++ b/packages/realtime-api/src/video/RoomSession.test.ts
@@ -31,9 +31,8 @@ describe('RoomSession Object', () => {
         roomSession._attachListeners(roomSessionId)
         resolve(roomSession)
       })
-      // tweak "_eventsNamespace" using _attachListeners
-      // @ts-expect-error
-      video._attachListeners('')
+
+      await video.subscribe()
 
       const eventChannelOne = 'room.<uuid-one>'
       const firstRoom = JSON.parse(

--- a/packages/realtime-api/src/video/RoomSession.ts
+++ b/packages/realtime-api/src/video/RoomSession.ts
@@ -7,6 +7,7 @@ import {
   INTERNAL_MEMBER_UPDATED_EVENTS,
   Rooms,
   toExternalJSON,
+  toLocalEvent,
   VideoMemberEventParams,
   InternalVideoRoomSessionEventNames,
   VideoRoomUpdatedEventParams,
@@ -27,7 +28,7 @@ type EmitterTransformsEvents =
   | InternalVideoMemberEventNames
   | InternalVideoLayoutEventNames
   | InternalVideoRecordingEventNames
-  | 'video.__internal__.recording.start'
+  | 'video.__local__.recording.start'
 
 export interface RoomSession
   extends VideoRoomSessionContract,
@@ -117,7 +118,7 @@ class RoomSessionConsumer extends BaseConsumer<RealTimeRoomApiEvents> {
       ],
       [
         [
-          'video.__internal__.recording.start',
+          toLocalEvent<EmitterTransformsEvents>('video.recording.start'),
           'video.recording.started',
           'video.recording.updated',
           'video.recording.ended',


### PR DESCRIPTION
The code in this changeset includes:
1. Improve how we handle transforms, cache and event registering in general by standardising the shape of the event (we're now using `internalEvent` everywhere)
2. Added ability to register local transforms and remote transforms by extending `applyEmitterTransforms`. (I left a `TODO` as a comment: [here](https://github.com/signalwire/signalwire-js/pull/298/files#r710959260))
3. Add the concept of a "local" event to handle events that we generate and trigger (`video.__local__.recording.start`) 