### PR TITLE
Improve the logic for applying local and remote emitter transforms

### DIFF
--- a/.changeset/strong-kings-lie.md
+++ b/.changeset/strong-kings-lie.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/core': patch
+---
+
+Improve the logic for applying local and remote emitter transforms

--- a/packages/core/src/BaseComponent.test.ts
+++ b/packages/core/src/BaseComponent.test.ts
@@ -186,8 +186,6 @@ describe('BaseComponent', () => {
       }
 
       const instance = new CustomComponent()
-      // @ts-expect-error
-      instance.applyEmitterTransforms()
       const payload = { key: 'value' }
 
       const mockFn = jest.fn()
@@ -207,6 +205,8 @@ describe('BaseComponent', () => {
         mockFn(obj)
       })
 
+      // @ts-expect-error
+      instance.applyEmitterTransforms()
       instance.emit('jest.snake_case', payload)
       instance.emit('jest.camel_case', payload)
 

--- a/packages/core/src/BaseComponent.ts
+++ b/packages/core/src/BaseComponent.ts
@@ -637,7 +637,7 @@ export class BaseComponent<
     handler,
     local,
   }: {
-    event: string | string[]
+    event: string
     handler: EventTransform
     local: boolean
   }) {
@@ -646,8 +646,7 @@ export class BaseComponent<
     )
 
     if (
-      typeof event === 'string' &&
-      (local
+      local
         ? /**
            * When `local === true` we filter out `Remote Events`
            */
@@ -656,7 +655,7 @@ export class BaseComponent<
            * When `local !== true` we filter out `Local Events` AND
            * events the user hasn't subscribed to.
            */
-          isLocalEvent(event) || !this.eventNames().includes(internalEvent))
+          isLocalEvent(event) || !this.eventNames().includes(internalEvent)
     ) {
       return
     }

--- a/packages/core/src/BaseComponent.ts
+++ b/packages/core/src/BaseComponent.ts
@@ -641,14 +641,27 @@ export class BaseComponent<
     handler: EventTransform
     local: boolean
   }) {
-    if (local && typeof event === 'string' && !isLocalEvent(event)) {
+    const internalEvent = this._getInternalEvent(
+      event as EventEmitter.EventNames<EventTypes>
+    )
+
+    if (
+      typeof event === 'string' &&
+      (local
+        ? /**
+           * When `local === true` we filter out `Remote Events`
+           */
+          !isLocalEvent(event)
+        : /**
+           * When `local !== true` we filter out `Local Events` AND
+           * events the user hasn't subscribed to.
+           */
+          isLocalEvent(event) || !this.eventNames().includes(internalEvent))
+    ) {
       return
     }
 
-    this._emitterTransforms.set(
-      this._getInternalEvent(event as EventEmitter.EventNames<EventTypes>),
-      handler
-    )
+    this._emitterTransforms.set(internalEvent, handler)
   }
 
   /**

--- a/packages/webrtc/src/BaseConnection.ts
+++ b/packages/webrtc/src/BaseConnection.ts
@@ -132,6 +132,8 @@ export class BaseConnection<EventTypes extends EventEmitter.ValidEventTypes>
 
     this.setState('new')
     logger.debug('New Call with Options:', this.options)
+
+    this.applyEmitterTransforms({ local: true })
   }
 
   get id() {


### PR DESCRIPTION
The code in this changeset includes a change in the logic of how we apply emitters transform.

##### When `local: true` is supplied to `applyEmitterTransforms` :
* remote event emitter transforms are not applied

##### When `local: false | undefined` is supplied to `applyEmitterTransforms` :
* local events emitter transforms are not applied
* if the user hasn't registered a listener to that event the emitter transform won't be applied.