### PR TITLE
Standardize method names

### DIFF
--- a/.changeset/polite-plums-joke.md
+++ b/.changeset/polite-plums-joke.md
@@ -1,0 +1,7 @@
+---
+'@signalwire/core': patch
+'@signalwire/js': patch
+'@signalwire/realtime-api': patch
+---
+
+Added setInputVolume/setOutputVolume and marked setMicrophoneVolume/setSpeakerVolume as deprecated.

--- a/packages/core/src/types/videoMember.ts
+++ b/packages/core/src/types/videoMember.ts
@@ -8,7 +8,7 @@ import type {
   ToInternalVideoEvent,
   OnlyStateProperties,
   OnlyFunctionProperties,
-  AssertSameType
+  AssertSameType,
 } from './utils'
 import * as Rooms from '../rooms'
 
@@ -42,26 +42,29 @@ type VideoMemberUpdatablePropsMain = {
   [K in keyof InternalVideoMemberUpdatableProps as SnakeToCamelCase<K>]: InternalVideoMemberUpdatableProps[K]
 }
 
-type VideoMemberUpdatableProps = AssertSameType<VideoMemberUpdatablePropsMain, {
-  /** Whether the outbound audio is muted (e.g., from the microphone) */
-  audioMuted: boolean,
-  /** Whether the outbound video is muted */
-  videoMuted: boolean,
-  /** Whether the inbound audio is muted */
-  deaf: boolean,
-  /** Whether the member is on hold */
-  onHold: boolean,
-  /** Whether the member is visible */
-  visible: boolean,
-  /** Input volume (e.g., of the microphone). Values range from -50 to 50, with a default of 0. */
-  inputVolume: number,
-  /** Output volume (e.g., of the speaker). Values range from -50 to 50, with a default of 0. */
-  outputVolume: number,
-  /** Input level at which the participant is identified as currently speaking.
-   * The default value is 30 and the scale goes from 0 (lowest sensitivity,
-   * essentially muted) to 100 (highest sensitivity). */
-  inputSensitivity: number
-}>
+type VideoMemberUpdatableProps = AssertSameType<
+  VideoMemberUpdatablePropsMain,
+  {
+    /** Whether the outbound audio is muted (e.g., from the microphone) */
+    audioMuted: boolean
+    /** Whether the outbound video is muted */
+    videoMuted: boolean
+    /** Whether the inbound audio is muted */
+    deaf: boolean
+    /** Whether the member is on hold */
+    onHold: boolean
+    /** Whether the member is visible */
+    visible: boolean
+    /** Input volume (e.g., of the microphone). Values range from -50 to 50, with a default of 0. */
+    inputVolume: number
+    /** Output volume (e.g., of the speaker). Values range from -50 to 50, with a default of 0. */
+    outputVolume: number
+    /** Input level at which the participant is identified as currently speaking.
+     * The default value is 30 and the scale goes from 0 (lowest sensitivity,
+     * essentially muted) to 100 (highest sensitivity). */
+    inputSensitivity: number
+  }
+>
 
 // @ts-expect-error
 export const MEMBER_UPDATABLE_PROPS: VideoMemberUpdatableProps = toExternalJSON(
@@ -209,37 +212,49 @@ export interface VideoMemberContract extends VideoMemberUpdatableProps {
   setDeaf(value: boolean): Rooms.SetDeaf
 
   /**
-   * Sets the microphone input level for the member.
-   *
-   * @param params 
-   * @param params.volume desired volume. Values range from -50 to 50, with a
-   * default of 0.
-   *
-   * @example
-   * ```typescript
-   * await member.setMicrophoneVolume({volume: -10})
-   * ```
+   * @deprecated Use {@link setInputVolume} instead.
+   * `setMicrophoneVolume` will be removed in v4.0.0
    */
   setMicrophoneVolume(params: { volume: number }): Rooms.SetInputVolumeMember
 
   /**
-   * Sets the speaker output level.
+   * Sets the input level for the member.
    *
-   * @param params 
+   * @param params
    * @param params.volume desired volume. Values range from -50 to 50, with a
    * default of 0.
    *
    * @example
    * ```typescript
-   * await member.setSpeakerVolume({volume: -10})
+   * await member.setInputVolume({volume: -10})
    * ```
    */
+  setInputVolume(params: { volume: number }): Rooms.SetInputVolumeMember
+  /**
+   * @deprecated Use {@link setOutputVolume} instead.
+   * `setSpeakerVolume` will be removed in v4.0.0
+   */
+
   setSpeakerVolume(params: { volume: number }): Rooms.SetOutputVolumeMember
+
+  /**
+   * Sets the output level.
+   *
+   * @param params
+   * @param params.volume desired volume. Values range from -50 to 50, with a
+   * default of 0.
+   *
+   * @example
+   * ```typescript
+   * await member.setOutputVolume({volume: -10})
+   * ```
+   */
+  setOutputVolume(params: { volume: number }): Rooms.SetOutputVolumeMember
 
   /**
    * Sets the input level at which the participant is identified as currently
    * speaking.
-   * 
+   *
    * @param params
    * @param params.value desired sensitivity. The default value is 30 and the
    * scale goes from 0 (lowest sensitivity, essentially muted) to 100 (highest
@@ -256,7 +271,7 @@ export interface VideoMemberContract extends VideoMemberUpdatableProps {
 
   /**
    * Removes this member from the room.
-   * 
+   *
    * @example
    * ```typescript
    * await member.remove()

--- a/packages/core/src/types/videoMember.ts
+++ b/packages/core/src/types/videoMember.ts
@@ -218,7 +218,7 @@ export interface VideoMemberContract extends VideoMemberUpdatableProps {
   setMicrophoneVolume(params: { volume: number }): Rooms.SetInputVolumeMember
 
   /**
-   * Sets the input level for the member.
+   * Sets the input volume for the member (e.g., the microphone input level).
    *
    * @param params
    * @param params.volume desired volume. Values range from -50 to 50, with a
@@ -238,7 +238,7 @@ export interface VideoMemberContract extends VideoMemberUpdatableProps {
   setSpeakerVolume(params: { volume: number }): Rooms.SetOutputVolumeMember
 
   /**
-   * Sets the output level.
+   * Sets the output volume for the member (e.g., the speaker output level).
    *
    * @param params
    * @param params.volume desired volume. Values range from -50 to 50, with a

--- a/packages/core/src/types/videoRoomSession.ts
+++ b/packages/core/src/types/videoRoomSession.ts
@@ -64,6 +64,9 @@ export interface VideoRoomSessionContract {
   setMicrophoneVolume(
     params: MemberCommandWithVolumeParams
   ): Rooms.SetInputVolumeMember
+  setInputVolume(
+    params: MemberCommandWithVolumeParams
+  ): Rooms.SetInputVolumeMember
   setInputSensitivity(
     params: MemberCommandWithValueParams
   ): Rooms.SetInputSensitivityMember
@@ -71,6 +74,9 @@ export interface VideoRoomSessionContract {
   deaf(params: MemberCommandParams): Rooms.DeafMember
   undeaf(params: MemberCommandParams): Rooms.UndeafMember
   setSpeakerVolume(
+    params: MemberCommandWithVolumeParams
+  ): Rooms.SetOutputVolumeMember
+  setOutputVolume(
     params: MemberCommandWithVolumeParams
   ): Rooms.SetOutputVolumeMember
   removeMember(params: Required<MemberCommandParams>): Rooms.RemoveMember

--- a/packages/js/src/Room.test.ts
+++ b/packages/js/src/Room.test.ts
@@ -1,10 +1,11 @@
 import { EventEmitter, actions } from '@signalwire/core'
 import { createRoomSessionObject } from './Room'
+import type { Room } from './Room'
 import { configureJestStore, configureFullStack } from './testUtils'
 
 describe('Room Object', () => {
   let store: any
-  let room: any
+  let room: Room
 
   beforeEach(() => {
     store = configureJestStore()
@@ -12,8 +13,10 @@ describe('Room Object', () => {
       store,
       emitter: new EventEmitter(),
     })
+    // @ts-expect-error
     room.execute = jest.fn()
     // mock a room.subscribed event
+    // @ts-expect-error
     room.onRoomSubscribed({
       nodeId: 'node-id',
       roomId: 'room-id',
@@ -29,6 +32,8 @@ describe('Room Object', () => {
     expect(room.videoUnmute).toBeDefined()
     expect(room.deaf).toBeDefined()
     expect(room.undeaf).toBeDefined()
+    expect(room.setInputVolume).toBeDefined()
+    expect(room.setOutputVolume).toBeDefined()
     expect(room.setMicrophoneVolume).toBeDefined()
     expect(room.setSpeakerVolume).toBeDefined()
     expect(room.setInputSensitivity).toBeDefined()
@@ -59,6 +64,7 @@ describe('Room Object', () => {
         emitter,
       })
       // mock a room.subscribed event
+      // @ts-expect-error
       room.onRoomSubscribed({
         nodeId: 'node-id',
         roomId: '6e83849b-5cc2-4fc6-80ed-448113c8a426',
@@ -75,6 +81,7 @@ describe('Room Object', () => {
 
   describe('startRecording', () => {
     it('should return an interactive object', async () => {
+      // @ts-expect-error
       ;(room.execute as jest.Mock).mockResolvedValueOnce({
         code: '200',
         message: 'Recording started',
@@ -82,6 +89,7 @@ describe('Room Object', () => {
       })
 
       const recording = await room.startRecording()
+      // @ts-expect-error
       recording.execute = jest.fn()
       expect(recording.id).toEqual('c22d7223-5a01-49fe-8da0-46bec8e75e32')
       expect(recording.roomSessionId).toEqual('room-session-id')
@@ -97,16 +105,19 @@ describe('Room Object', () => {
         },
       }
       await recording.pause()
+      // @ts-expect-error
       expect(recording.execute).toHaveBeenLastCalledWith({
         ...baseExecuteParams,
         method: 'video.recording.pause',
       })
       await recording.resume()
+      // @ts-expect-error
       expect(recording.execute).toHaveBeenLastCalledWith({
         ...baseExecuteParams,
         method: 'video.recording.resume',
       })
       await recording.stop()
+      // @ts-expect-error
       expect(recording.execute).toHaveBeenLastCalledWith({
         ...baseExecuteParams,
         method: 'video.recording.stop',
@@ -114,11 +125,13 @@ describe('Room Object', () => {
     })
 
     it('should work with simulataneous recordings', async () => {
+      // @ts-expect-error
       ;(room.execute as jest.Mock).mockResolvedValueOnce({
         code: '200',
         message: 'Recording started',
         recording_id: 'first-recording',
       })
+      // @ts-expect-error
       ;(room.execute as jest.Mock).mockResolvedValueOnce({
         code: '200',
         message: 'Recording started',
@@ -126,13 +139,16 @@ describe('Room Object', () => {
       })
 
       const firstRecording = await room.startRecording()
+      // @ts-expect-error
       firstRecording.execute = jest.fn()
       const secondRecording = await room.startRecording()
+      // @ts-expect-error
       secondRecording.execute = jest.fn()
 
       expect(firstRecording.id).toEqual('first-recording')
       expect(firstRecording.roomSessionId).toEqual('room-session-id')
       await firstRecording.stop()
+      // @ts-expect-error
       expect(firstRecording.execute).toHaveBeenLastCalledWith({
         method: 'video.recording.stop',
         params: {
@@ -144,6 +160,7 @@ describe('Room Object', () => {
       expect(secondRecording.id).toEqual('second-recording')
       expect(secondRecording.roomSessionId).toEqual('room-session-id')
       await secondRecording.stop()
+      // @ts-expect-error
       expect(secondRecording.execute).toHaveBeenLastCalledWith({
         method: 'video.recording.stop',
         params: {
@@ -162,8 +179,10 @@ describe('Room Object', () => {
         // @ts-expect-error
         emitter,
       })
+      // @ts-expect-error
       room.execute = jest.fn()
       // mock a room.subscribed event
+      // @ts-expect-error
       room.onRoomSubscribed({
         nodeId: 'node-id',
         roomId: '6e83849b-5cc2-4fc6-80ed-448113c8a426',

--- a/packages/js/src/Room.ts
+++ b/packages/js/src/Room.ts
@@ -286,6 +286,8 @@ export const RoomAPI = extendComponent<RoomConnection, RoomMethods>(
     videoUnmute: Rooms.videoUnmuteMember,
     deaf: Rooms.deafMember,
     undeaf: Rooms.undeafMember,
+    setInputVolume: Rooms.setInputVolumeMember,
+    setOutputVolume: Rooms.setOutputVolumeMember,
     setMicrophoneVolume: Rooms.setInputVolumeMember,
     setSpeakerVolume: Rooms.setOutputVolumeMember,
     setInputSensitivity: Rooms.setInputSensitivityMember,

--- a/packages/js/src/RoomDevice.test.ts
+++ b/packages/js/src/RoomDevice.test.ts
@@ -1,14 +1,16 @@
 import { RoomDeviceAPI } from './RoomDevice'
+import type { RoomDevice } from './RoomDevice'
 import { configureJestStore } from './testUtils'
 
 describe('RoomDevice Object', () => {
-  let roomDevice: any
+  let roomDevice: RoomDevice
 
   beforeEach(() => {
     roomDevice = new RoomDeviceAPI({
       store: configureJestStore(),
       emitter: jest.fn() as any,
-    })
+    }) as any as RoomDevice
+    // @ts-expect-error
     roomDevice.execute = jest.fn()
   })
 
@@ -18,6 +20,7 @@ describe('RoomDevice Object', () => {
     expect(roomDevice.videoMute).toBeDefined()
     expect(roomDevice.videoUnmute).toBeDefined()
     expect(roomDevice.setMicrophoneVolume).toBeDefined()
+    expect(roomDevice.setInputVolume).toBeDefined()
     expect(roomDevice.setInputSensitivity).toBeDefined()
   })
 })

--- a/packages/js/src/RoomDevice.ts
+++ b/packages/js/src/RoomDevice.ts
@@ -34,6 +34,7 @@ export const RoomDeviceAPI = extendComponent<
   audioUnmute: Rooms.audioUnmuteMember,
   videoMute: Rooms.videoMuteMember,
   videoUnmute: Rooms.videoUnmuteMember,
+  setInputVolume: Rooms.setInputVolumeMember,
   setMicrophoneVolume: Rooms.setInputVolumeMember,
   setInputSensitivity: Rooms.setInputSensitivityMember,
 })

--- a/packages/js/src/RoomScreenShare.test.ts
+++ b/packages/js/src/RoomScreenShare.test.ts
@@ -1,14 +1,16 @@
 import { RoomScreenShareAPI } from './RoomScreenShare'
+import type { RoomScreenShare } from './RoomScreenShare'
 import { configureJestStore } from './testUtils'
 
 describe('RoomScreenShare Object', () => {
-  let roomScreenShare: any
+  let roomScreenShare: RoomScreenShare
 
   beforeEach(() => {
     roomScreenShare = new RoomScreenShareAPI({
       store: configureJestStore(),
       emitter: jest.fn() as any,
-    })
+    }) as any as RoomScreenShare
+    // @ts-expect-error
     roomScreenShare.execute = jest.fn()
   })
 
@@ -18,6 +20,7 @@ describe('RoomScreenShare Object', () => {
     expect(roomScreenShare.videoMute).toBeDefined()
     expect(roomScreenShare.videoUnmute).toBeDefined()
     expect(roomScreenShare.setMicrophoneVolume).toBeDefined()
+    expect(roomScreenShare.setInputVolume).toBeDefined()
     expect(roomScreenShare.setInputSensitivity).toBeDefined()
   })
 })

--- a/packages/js/src/RoomScreenShare.ts
+++ b/packages/js/src/RoomScreenShare.ts
@@ -35,5 +35,6 @@ export const RoomScreenShareAPI = extendComponent<
   videoMute: Rooms.videoMuteMember,
   videoUnmute: Rooms.videoUnmuteMember,
   setMicrophoneVolume: Rooms.setInputVolumeMember,
+  setInputVolume: Rooms.setInputVolumeMember,
   setInputSensitivity: Rooms.setInputSensitivityMember,
 })

--- a/packages/js/src/utils/interfaces.ts
+++ b/packages/js/src/utils/interfaces.ts
@@ -108,6 +108,13 @@ interface RoomMemberMethodsInterface {
   audioUnmute(params?: MemberCommandParams): Rooms.AudioUnmuteMember
   videoMute(params?: MemberCommandParams): Rooms.VideoMuteMember
   videoUnmute(params?: MemberCommandParams): Rooms.VideoUnmuteMember
+  setInputVolume(
+    params: MemberCommandWithVolumeParams
+  ): Rooms.SetInputVolumeMember
+  /**
+   * @deprecated Use {@link setInputVolume} instead.
+   * `setMicrophoneVolume` will be removed in v4.0.0
+   */
   setMicrophoneVolume(
     params: MemberCommandWithVolumeParams
   ): Rooms.SetInputVolumeMember
@@ -121,7 +128,12 @@ interface RoomMemberSelfMethodsInterface {
   audioUnmute(): Rooms.AudioUnmuteMember
   videoMute(): Rooms.VideoMuteMember
   videoUnmute(): Rooms.VideoUnmuteMember
+  /**
+   * @deprecated Use {@link setInputVolume} instead.
+   * `setMicrophoneVolume` will be removed in v4.0.0
+   */
   setMicrophoneVolume(params: { volume: number }): Rooms.SetInputVolumeMember
+  setInputVolume(params: { volume: number }): Rooms.SetInputVolumeMember
   setInputSensitivity(params: {
     value: number
   }): Rooms.SetInputSensitivityMember
@@ -136,6 +148,13 @@ interface RoomControlMethodsInterface {
   getMembers(): Rooms.GetMembers
   deaf(params?: MemberCommandParams): Rooms.DeafMember
   undeaf(params?: MemberCommandParams): Rooms.UndeafMember
+  setOutputVolume(
+    params: MemberCommandWithVolumeParams
+  ): Rooms.SetOutputVolumeMember
+  /**
+   * @deprecated Use {@link setOutputVolume} instead.
+   * `setSpeakerVolume` will be removed in v4.0.0
+   */
   setSpeakerVolume(
     params: MemberCommandWithVolumeParams
   ): Rooms.SetOutputVolumeMember

--- a/packages/realtime-api/src/video/RoomSession.test.ts
+++ b/packages/realtime-api/src/video/RoomSession.test.ts
@@ -50,6 +50,8 @@ describe('RoomSession Object', () => {
     expect(roomSession.audioUnmute).toBeDefined()
     expect(roomSession.deaf).toBeDefined()
     expect(roomSession.undeaf).toBeDefined()
+    expect(roomSession.setInputVolume).toBeDefined()
+    expect(roomSession.setOutputVolume).toBeDefined()
     expect(roomSession.setMicrophoneVolume).toBeDefined()
     expect(roomSession.setSpeakerVolume).toBeDefined()
     expect(roomSession.setInputSensitivity).toBeDefined()

--- a/packages/realtime-api/src/video/RoomSession.ts
+++ b/packages/realtime-api/src/video/RoomSession.ts
@@ -44,46 +44,46 @@ interface RoomSessionMain
  *
  * #### Room events:
  *
- * **room.started**,<br>
- * **room.updated**,<br>
- * **room.ended**<br>
+ * **room.started**,<br>  
+ * **room.updated**,<br>  
+ * **room.ended**<br>  
  * Emitted when the room session is, respectively, started, updated, or ended.
  * Your event handler receives an object which is an instance of
  * {@link RoomSession}.
  *
- * **recording.started**,<br>
- * **recording.updated**,<br>
- * **recording.ended**<br>
+ * **recording.started**,<br>  
+ * **recording.updated**,<br>  
+ * **recording.ended**<br>  
  * Emitted when a recording is, respectively, started, updated, or ended. Your
  * event handler receives an object which is an instance of
  * {@link RoomSessionRecording}.
  *
- * **layout.changed**<br>
+ * **layout.changed**<br>  
  * Emitted when the layout of the room changes.
  *
  * #### Member events:
  *
- * **member.joined**<br>
+ * **member.joined**<br>  
  * Emitted when a member joins the room. Your event handler receives an object
  * of type {@link RoomSessionMember}.
  *
- * **member.left**<br>
+ * **member.left**<br>  
  * Emitted when a member leaves the room. Your event handler receives an object
  * of type {@link RoomSessionMember}.
  *
- * **member.talking**<br>
+ * **member.talking**<br>  
  * Emitted when a member starts or stops talking. Your event handler receives an
  * object of type {@link RoomSessionMember}.
  *
- * **member.talking.started**<br>
+ * **member.talking.started**<br>  
  * Emitted when a member starts talking. Your event handler receives an object
  * of type {@link RoomSessionMember}.
  *
- * **member.talking.ended**<br>
+ * **member.talking.ended**<br>  
  * Emitted when a member stops talking. Your event handler receives an object of
  * type {@link RoomSessionMember}.
  *
- * **member.updated**<br>
+ * **member.updated**<br>  
  * Emitted when any property of one of the members is updated. Your event
  * handler receives an object `member` of type {@link RoomSessionMember}. Use
  * `member.updated` to access the list of updated properties. Example:
@@ -94,14 +94,14 @@ interface RoomSessionMain
  * }
  * ```
  *
- * **member.updated.audioMuted**,<br>
- * **member.updated.videoMuted**,<br>
- * **member.updated.deaf**,<br>
- * **member.updated.onHold**,<br>
- * **member.updated.visible**,<br>
- * **member.updated.inputVolume**,<br>
- * **member.updated.outputVolume**,<br>
- * **member.updated.inputSensitivity**<br>
+ * **member.updated.audioMuted**,<br>  
+ * **member.updated.videoMuted**,<br>  
+ * **member.updated.deaf**,<br>  
+ * **member.updated.onHold**,<br>  
+ * **member.updated.visible**,<br>  
+ * **member.updated.inputVolume**,<br>  
+ * **member.updated.outputVolume**,<br>  
+ * **member.updated.inputSensitivity**<br>  
  * Each of the above events is emitted when the associated property changes.
  * Your event handler receives an object `member` of type
  * {@link RoomSessionMember}.
@@ -174,11 +174,11 @@ interface RoomSessionDocs extends RoomSessionMain {
   }): Promise<void>
 
   /**
-   * Sets the input level for a given member.
+   * Sets the input volume for a given member (e.g., the microphone input
+   * level).
    *
    * @param params
-   * @param params.memberId id of the member for which to set microphone
-   * volume
+   * @param params.memberId id of the member to affect
    * @param params.volume desired volume. Values range from -50 to 50, with a
    * default of 0.
    *
@@ -300,7 +300,7 @@ interface RoomSessionDocs extends RoomSessionMain {
   setSpeakerVolume(params: { memberId: string; volume: number }): Promise<void>
 
   /**
-   * Sets the output level.
+   * Sets the output volume for the member (e.g., the speaker output level).
    * @param params
    * @param params.memberId id of the member to affect
    * @param params.volume desired volume. Values range from -50 to 50, with a

--- a/packages/realtime-api/src/video/RoomSession.ts
+++ b/packages/realtime-api/src/video/RoomSession.ts
@@ -19,7 +19,7 @@ import {
   ConsumerContract,
   EntityUpdated,
   VideoMemberEntity,
-  AssertSameType
+  AssertSameType,
 } from '@signalwire/core'
 import { BaseConsumer } from '../BaseConsumer'
 import { RealTimeRoomApiEvents } from '../types'
@@ -34,7 +34,7 @@ type EmitterTransformsEvents =
 
 interface RoomSessionMain
   extends VideoRoomSessionContract,
-  ConsumerContract<RealTimeRoomApiEvents> {}
+    ConsumerContract<RealTimeRoomApiEvents> {}
 
 /**
  * Represents a room session. You can obtain instances of this class by
@@ -44,46 +44,46 @@ interface RoomSessionMain
  *
  * #### Room events:
  *
- * **room.started**,<br>  
- * **room.updated**,<br>  
- * **room.ended**<br>  
+ * **room.started**,<br>
+ * **room.updated**,<br>
+ * **room.ended**<br>
  * Emitted when the room session is, respectively, started, updated, or ended.
  * Your event handler receives an object which is an instance of
  * {@link RoomSession}.
  *
- * **recording.started**,<br>  
- * **recording.updated**,<br>  
- * **recording.ended**<br>  
+ * **recording.started**,<br>
+ * **recording.updated**,<br>
+ * **recording.ended**<br>
  * Emitted when a recording is, respectively, started, updated, or ended. Your
  * event handler receives an object which is an instance of
  * {@link RoomSessionRecording}.
  *
- * **layout.changed**<br>  
+ * **layout.changed**<br>
  * Emitted when the layout of the room changes.
  *
  * #### Member events:
  *
- * **member.joined**<br>  
+ * **member.joined**<br>
  * Emitted when a member joins the room. Your event handler receives an object
  * of type {@link RoomSessionMember}.
  *
- * **member.left**<br>  
+ * **member.left**<br>
  * Emitted when a member leaves the room. Your event handler receives an object
  * of type {@link RoomSessionMember}.
  *
- * **member.talking**<br>  
+ * **member.talking**<br>
  * Emitted when a member starts or stops talking. Your event handler receives an
  * object of type {@link RoomSessionMember}.
  *
- * **member.talking.started**<br>  
+ * **member.talking.started**<br>
  * Emitted when a member starts talking. Your event handler receives an object
  * of type {@link RoomSessionMember}.
  *
- * **member.talking.ended**<br>  
+ * **member.talking.ended**<br>
  * Emitted when a member stops talking. Your event handler receives an object of
  * type {@link RoomSessionMember}.
  *
- * **member.updated**<br>  
+ * **member.updated**<br>
  * Emitted when any property of one of the members is updated. Your event
  * handler receives an object `member` of type {@link RoomSessionMember}. Use
  * `member.updated` to access the list of updated properties. Example:
@@ -94,14 +94,14 @@ interface RoomSessionMain
  * }
  * ```
  *
- * **member.updated.audioMuted**,<br>  
- * **member.updated.videoMuted**,<br>  
- * **member.updated.deaf**,<br>  
- * **member.updated.onHold**,<br>  
- * **member.updated.visible**,<br>  
- * **member.updated.inputVolume**,<br>  
- * **member.updated.outputVolume**,<br>  
- * **member.updated.inputSensitivity**<br>  
+ * **member.updated.audioMuted**,<br>
+ * **member.updated.videoMuted**,<br>
+ * **member.updated.deaf**,<br>
+ * **member.updated.onHold**,<br>
+ * **member.updated.visible**,<br>
+ * **member.updated.inputVolume**,<br>
+ * **member.updated.outputVolume**,<br>
+ * **member.updated.inputSensitivity**<br>
  * Each of the above events is emitted when the associated property changes.
  * Your event handler receives an object `member` of type
  * {@link RoomSessionMember}.
@@ -112,7 +112,7 @@ interface RoomSessionDocs extends RoomSessionMain {
   /**
    * Puts the microphone of a given member on mute. The other participants
    * will not hear audio from the muted participant anymore.
-   * @param params 
+   * @param params
    * @param params.memberId id of the member to mute
    *
    * @example
@@ -125,7 +125,7 @@ interface RoomSessionDocs extends RoomSessionMain {
 
   /**
    * Unmutes the microphone of a given member if it had been previously muted.
-   * @param params 
+   * @param params
    * @param params.memberId id of the member to unmute
    *
    * @example
@@ -139,7 +139,7 @@ interface RoomSessionDocs extends RoomSessionMain {
   /**
    * Puts the video of a given member on mute. Participants will see a mute
    * image instead of the video stream.
-   * @param params 
+   * @param params
    * @param params.memberId id of the member to mute
    *
    * @example
@@ -153,7 +153,7 @@ interface RoomSessionDocs extends RoomSessionMain {
   /**
    * Unmutes the video of a given member if it had been previously muted.
    * Participants will start seeing the video stream again.
-   * @param params 
+   * @param params
    * @param params.memberId id of the member to unmute
    *
    * @example
@@ -165,9 +165,18 @@ interface RoomSessionDocs extends RoomSessionMain {
   videoUnmute(params: { memberId: string }): Promise<void>
 
   /**
-   * Sets the microphone input level for a given member.
+   * @deprecated Use {@link setInputVolume} instead.
+   * `setMicrophoneVolume` will be removed in v4.0.0
+   */
+  setMicrophoneVolume(params: {
+    memberId: string
+    volume: number
+  }): Promise<void>
+
+  /**
+   * Sets the input level for a given member.
    *
-   * @param params 
+   * @param params
    * @param params.memberId id of the member for which to set microphone
    * volume
    * @param params.volume desired volume. Values range from -50 to 50, with a
@@ -176,15 +185,15 @@ interface RoomSessionDocs extends RoomSessionMain {
    * @example
    * ```typescript
    * const id = 'de550c0c-3fac-4efd-b06f-b5b8614b8966'  // you can get this from getMembers()
-   * await room.setMicrophoneVolume({memberId: id, volume: -10})
+   * await room.setInputVolume({memberId: id, volume: -10})
    * ```
    */
-  setMicrophoneVolume(params: { memberId: string, volume: number }): Promise<void>
+  setInputVolume(params: { memberId: string; volume: number }): Promise<void>
 
   /**
    * Sets the input level at which the participant is identified as currently
    * speaking.
-   * @param params 
+   * @param params
    * @param params.memberId id of the member to affect
    * @param params.value desired sensitivity. The default value is 30 and the
    * scale goes from 0 (lowest sensitivity, essentially muted) to 100 (highest
@@ -196,13 +205,16 @@ interface RoomSessionDocs extends RoomSessionMain {
    * await room.setInputSensitivity({memberId: id, value: 80})
    * ```
    */
-  setInputSensitivity(params: { memberId: string, value: number }): Promise<void>
+  setInputSensitivity(params: {
+    memberId: string
+    value: number
+  }): Promise<void>
 
   /**
    * Returns a list of members currently in the room.
-   * 
+   *
    * @returns an object with type: Promise<{members: {@link VideoMember}[]}>
-   * 
+   *
    * @example
    * ```typescript
    * await room.getMembers()
@@ -252,7 +264,7 @@ interface RoomSessionDocs extends RoomSessionMain {
    * Note that in addition to making a participant deaf, this will also
    * automatically mute the microphone of the target participant. If you want,
    * you can then manually unmute it by calling {@link audioUnmute}.
-   * @param params 
+   * @param params
    * @param params.memberId id of the member to affect
    *
    * @example
@@ -270,7 +282,7 @@ interface RoomSessionDocs extends RoomSessionMain {
    * Note that in addition to allowing a participants to hear the others, this
    * will also automatically unmute the microphone of the target participant.
    * If you want, you can then manually mute it by calling {@link audioMute}.
-   * @param params 
+   * @param params
    * @param params.memberId id of the member to affect
    *
    * @example
@@ -282,8 +294,14 @@ interface RoomSessionDocs extends RoomSessionMain {
   undeaf(params: { memberId: string }): Promise<void>
 
   /**
-   * Sets the speaker output level.
-   * @param params 
+   * @deprecated Use {@link setOutputVolume} instead.
+   * `setSpeakerVolume` will be removed in v4.0.0
+   */
+  setSpeakerVolume(params: { memberId: string; volume: number }): Promise<void>
+
+  /**
+   * Sets the output level.
+   * @param params
    * @param params.memberId id of the member to affect
    * @param params.volume desired volume. Values range from -50 to 50, with a
    * default of 0.
@@ -291,16 +309,16 @@ interface RoomSessionDocs extends RoomSessionMain {
    * @example
    * ```typescript
    * const id = 'de550c0c-3fac-4efd-b06f-b5b8614b8966'  // you can get this from getMembers()
-   * await room.setSpeakerVolume({memberId: id, volume: -10})
+   * await room.setOutputVolume({memberId: id, volume: -10})
    * ```
    */
-  setSpeakerVolume(params: { memberId: string, volume: number }): Promise<void>
+  setOutputVolume(params: { memberId: string; volume: number }): Promise<void>
 
   /**
    * Removes a specific participant from the room.
-   * @param params 
+   * @param params
    * @param params.memberId id of the member to remove
-   * 
+   *
    * @example
    * ```typescript
    * const id = 'de550c0c-3fac-4efd-b06f-b5b8614b8966'  // you can get this from getMembers()
@@ -345,9 +363,9 @@ interface RoomSessionDocs extends RoomSessionMain {
   /**
    * Sets a layout for the room. You can obtain a list of available layouts
    * with {@link getLayouts}.
-   * @param params 
+   * @param params
    * @param params.name name of the layout
-   * 
+   *
    * @example Set the 6x6 layout:
    * ```typescript
    * await room.setLayout({name: "6x6"})
@@ -364,7 +382,7 @@ interface RoomSessionDocs extends RoomSessionMain {
    * Starts the recording of the room. You can use the returned
    * {@link RoomSessionRecording} object to control the recording (e.g., pause,
    * resume, stop).
-   * 
+   *
    * @example
    * ```typescript
    * const rec = await room.startRecording()
@@ -379,7 +397,8 @@ interface RoomSessionDocs extends RoomSessionMain {
   subscribe(): Promise<void>
 }
 
-export interface RoomSession extends AssertSameType<RoomSessionMain, RoomSessionDocs> {}
+export interface RoomSession
+  extends AssertSameType<RoomSessionMain, RoomSessionDocs> {}
 
 export type RoomSessionUpdated = EntityUpdated<RoomSession>
 
@@ -508,6 +527,8 @@ export const RoomSessionAPI = extendComponent<
   audioUnmute: Rooms.audioUnmuteMember,
   deaf: Rooms.deafMember,
   undeaf: Rooms.undeafMember,
+  setInputVolume: Rooms.setInputVolumeMember,
+  setOutputVolume: Rooms.setOutputVolumeMember,
   setMicrophoneVolume: Rooms.setInputVolumeMember,
   setSpeakerVolume: Rooms.setOutputVolumeMember,
   setInputSensitivity: Rooms.setInputSensitivityMember,

--- a/packages/realtime-api/src/video/RoomSessionMember.test.ts
+++ b/packages/realtime-api/src/video/RoomSessionMember.test.ts
@@ -99,7 +99,7 @@ describe('Member Object', () => {
         member_id: memberId,
       },
     })
-    await member.setMicrophoneVolume({ volume: 10 })
+    await member.setInputVolume({ volume: 10 })
     expectExecute({
       method: 'video.member.set_input_volume',
       params: {
@@ -108,7 +108,7 @@ describe('Member Object', () => {
         volume: 10,
       },
     })
-    await member.setSpeakerVolume({ volume: 10 })
+    await member.setOutputVolume({ volume: 10 })
     expectExecute({
       method: 'video.member.set_output_volume',
       params: {

--- a/packages/realtime-api/src/video/RoomSessionMember.ts
+++ b/packages/realtime-api/src/video/RoomSessionMember.ts
@@ -18,7 +18,7 @@ import {
  * > The state of RoomSessionMember objects, for example `member.visible`, is
  * > immutable. When you receive instances of RoomSessionMember from event
  * > listeners, the state of the member always refers to that specific point in
- * > time and remains fixed for the whole lifetime of the object. 
+ * > time and remains fixed for the whole lifetime of the object.
  */
 export interface RoomSessionMember extends VideoMemberContract {}
 export type RoomSessionMemberUpdated = EntityUpdated<RoomSessionMember>
@@ -48,7 +48,9 @@ const RoomSessionMemberAPI = extendComponent<
   videoUnmute: Rooms.videoUnmuteMember,
   setDeaf: Rooms.setDeaf,
   setMicrophoneVolume: Rooms.setInputVolumeMember,
+  setInputVolume: Rooms.setInputVolumeMember,
   setSpeakerVolume: Rooms.setOutputVolumeMember,
+  setOutputVolume: Rooms.setOutputVolumeMember,
   setInputSensitivity: Rooms.setInputSensitivityMember,
 })
 


### PR DESCRIPTION
The code in this changeset includes `setInputVolume` and `setOutputVolume` as future replacements for `setMicrophoneVolume` and `setSpeakerVolume` respectively.