### PR TITLE
Internal migration from `room` -> `room_session` + Typed `PubSub` payloads

### DIFF
--- a/.changeset/four-ladybugs-accept.md
+++ b/.changeset/four-ladybugs-accept.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/core': patch
+---
+
+Improve typings for the PubSub channel and when finding the namespace from the payload. Fix usages of `room` for `room_session`.

--- a/packages/core/src/redux/features/session/sessionSaga.test.ts
+++ b/packages/core/src/redux/features/session/sessionSaga.test.ts
@@ -10,7 +10,7 @@ describe('sessionChannelWatcher', () => {
   describe('videoAPIWorker', () => {
     it('should handle video.room.subscribed dispatching componentActions.upsert and the room.joined', async () => {
       const jsonrpc = JSON.parse(
-        '{"jsonrpc":"2.0","id":"83cbf7d3-4364-454e-af84-6f1f9176901b","method":"signalwire.event","params":{"params":{"room":{"room_session_id":"6fbe4472-e6dd-431f-887f-33171cd83ccb","logos_visible":true,"members":[{"visible":false,"room_session_id":"6fbe4472-e6dd-431f-887f-33171cd83ccb","input_volume":0,"id":"0e5f67e0-8dbf-48dd-b920-804b97fccee6","input_sensitivity":200,"output_volume":0,"audio_muted":false,"on_hold":false,"name":"Edo","deaf":false,"video_muted":false,"room_id":"790d6c79-f0d1-421e-b5f2-f09bd05941ce","type":"member"}],"blind_mode":false,"recording":false,"silent_mode":false,"name":"edoRoom2","hide_video_muted":false,"locked":false,"meeting_mode":false,"room_id":"790d6c79-f0d1-421e-b5f2-f09bd05941ce","event_channel":"room.649c069f-c0a1-4cc8-9d6a-be642ad68eab"},"call_id":"0e5f67e0-8dbf-48dd-b920-804b97fccee6","member_id":"0e5f67e0-8dbf-48dd-b920-804b97fccee6"},"timestamp":1627373985.2656,"event_type":"video.room.subscribed","event_channel":"room.649c069f-c0a1-4cc8-9d6a-be642ad68eab"}}'
+        '{"jsonrpc":"2.0","id":"828e8cf4-3be5-44d1-97eb-e701f470cepe","method":"signalwire.event","params":{"params":{"member_id":"e196da29-0080-4347-8811-b60bd35e4xxx","room":{"recording":false,"room_session_id":"9067212d-22d3-4ed9-90bb-9055367213pep","name":"realtimeRoom","hide_video_muted":false,"members":[{"visible":false,"room_session_id":"9067212d-22d3-4ed9-90bb-9055367213pep","input_volume":0,"id":"e196da29-0080-4347-8811-b60bd35e4xxx","input_sensitivity":44,"audio_muted":false,"output_volume":0,"name":"francisco","deaf":false,"video_muted":false,"room_id":"90e1349e-1c72-44f8-908c-a96dac60b47xx","type":"member"}],"room_id":"90e1349e-1c72-44f8-908c-a96dac60b47xx","event_channel":"room.4e143e89-f5d5-4476-8dd8-c52f6b4cef11x"},"call_id":"e196da29-0080-4347-8811-b60bd35e4xxx","room_session":{"recording":false,"name":"realtimeRoom","hide_video_muted":false,"id":"9067212d-22d3-4ed9-90bb-9055367213pep","members":[{"visible":false,"room_session_id":"9067212d-22d3-4ed9-90bb-9055367213pep","input_volume":0,"id":"e196da29-0080-4347-8811-b60bd35e4xxx","input_sensitivity":44,"audio_muted":false,"output_volume":0,"name":"francisco","deaf":false,"video_muted":false,"room_id":"90e1349e-1c72-44f8-908c-a96dac60b47xx","type":"member"}],"room_id":"90e1349e-1c72-44f8-908c-a96dac60b47xx","event_channel":"room.4e143e89-f5d5-4476-8dd8-c52f6b4cef11x"}},"timestamp":1632471983.7166,"event_type":"video.room.subscribed","event_channel":"room.4e143e89-f5d5-4476-8dd8-c52f6b4cef11x"}}'
       )
       let runSaga = true
       const session = {
@@ -45,10 +45,10 @@ describe('sessionChannelWatcher', () => {
         ])
         .put(
           componentActions.upsert({
-            id: '0e5f67e0-8dbf-48dd-b920-804b97fccee6',
-            roomId: '790d6c79-f0d1-421e-b5f2-f09bd05941ce',
-            roomSessionId: '6fbe4472-e6dd-431f-887f-33171cd83ccb',
-            memberId: '0e5f67e0-8dbf-48dd-b920-804b97fccee6',
+            id: 'e196da29-0080-4347-8811-b60bd35e4xxx',
+            roomId: '90e1349e-1c72-44f8-908c-a96dac60b47xx',
+            roomSessionId: '9067212d-22d3-4ed9-90bb-9055367213pep',
+            memberId: 'e196da29-0080-4347-8811-b60bd35e4xxx',
           })
         )
         .put(pubSubChannel, {

--- a/packages/core/src/redux/features/session/sessionSaga.ts
+++ b/packages/core/src/redux/features/session/sessionSaga.ts
@@ -212,8 +212,8 @@ export function* sessionChannelWatcher({
         yield put(
           componentActions.upsert({
             id: params.params.call_id,
-            roomId: params.params.room.room_id,
-            roomSessionId: params.params.room.room_session_id,
+            roomId: params.params.room_session.room_id,
+            roomSessionId: params.params.room_session.id,
             memberId: params.params.member_id,
           })
         )

--- a/packages/core/src/redux/features/session/sessionSaga.ts
+++ b/packages/core/src/redux/features/session/sessionSaga.ts
@@ -8,6 +8,8 @@ import type {
   VideoAPIEventParams,
   SwEventParams,
   WebRTCMessageParams,
+  InternalMemberUpdatedEventNames,
+  MemberTalkingEventNames,
 } from '../../../types'
 import {
   ExecuteActionParams,
@@ -229,9 +231,9 @@ export function* sessionChannelWatcher({
           member: { updated = [] },
         } = params.params
         for (const key of updated) {
-          const type = `video.member.updated.${key}` as const
+          const type =
+            `video.member.updated.${key}` as InternalMemberUpdatedEventNames
           yield put(pubSubChannel, {
-            // @ts-expect-error
             type,
             payload: params.params,
           })
@@ -266,13 +268,13 @@ export function* sessionChannelWatcher({
         if ('talking' in member) {
           const suffix = member.talking ? 'started' : 'ended'
           yield put(pubSubChannel, {
-            type: `video.member.talking.${suffix}` as const,
+            type: `video.member.talking.${suffix}` as MemberTalkingEventNames,
             payload: params.params,
           })
           // Keep for backwards compat.
           const deprecatedSuffix = member.talking ? 'start' : 'stop'
           yield put(pubSubChannel, {
-            type: `video.member.talking.${deprecatedSuffix}` as const,
+            type: `video.member.talking.${deprecatedSuffix}` as MemberTalkingEventNames,
             payload: params.params,
           })
         }
@@ -283,6 +285,7 @@ export function* sessionChannelWatcher({
     // Emit on the pubSubChannel this "event_type"
     yield put(pubSubChannel, {
       type: params.event_type,
+      // @ts-expect-error
       payload: params.params,
     })
   }

--- a/packages/core/src/redux/interfaces.ts
+++ b/packages/core/src/redux/interfaces.ts
@@ -83,7 +83,7 @@ export type CustomSaga<T> = (params: CustomSagaParams<T>) => SagaIterator<any>
  * into
  * { type: <value>, payload: <value> }
  */
-type MapToPubSubShape<T> = {
+export type MapToPubSubShape<T> = {
   [K in keyof T as K extends 'event_type'
     ? 'type'
     : K extends 'params'

--- a/packages/core/src/redux/interfaces.ts
+++ b/packages/core/src/redux/interfaces.ts
@@ -4,10 +4,11 @@ import {
   JSONRPCResponse,
   SessionAuthError,
   SessionAuthStatus,
+  SessionEvents,
   JSONRPCMethod,
   BaseConnectionState,
 } from '../utils/interfaces'
-import type { PubSubChannelEvents } from '../types'
+import type { VideoAPIEventParams, InternalVideoAPIEvent } from '../types'
 
 interface SWComponent {
   id: string
@@ -76,8 +77,25 @@ export interface CustomSagaParams<T> {
 
 export type CustomSaga<T> = (params: CustomSagaParams<T>) => SagaIterator<any>
 
-export interface PubSubAction {
-  type: PubSubChannelEvents
-  payload?: any
+/**
+ * Converts from:
+ * { event_type: <value>, params: <value> }
+ * into
+ * { type: <value>, payload: <value> }
+ */
+type MapToPubSubShape<T> = {
+  [K in keyof T as K extends 'event_type'
+    ? 'type'
+    : K extends 'params'
+    ? 'payload'
+    : never]: T[K]
 }
+
+export type PubSubAction =
+  | MapToPubSubShape<VideoAPIEventParams | InternalVideoAPIEvent>
+  | {
+      type: SessionEvents
+      payload: undefined
+    }
+
 export type PubSubChannel = Channel<PubSubAction>

--- a/packages/core/src/types/video.ts
+++ b/packages/core/src/types/video.ts
@@ -2,14 +2,13 @@ import {
   VideoRoomSessionEventNames,
   VideoRoomEvent,
   InternalVideoRoomSessionEventNames,
-  InternalVideoRoomJoinedEvent,
+  InternalVideoRoomEvent,
 } from './videoRoomSession'
 import {
   VideoMemberEventNames,
   VideoMemberEvent,
   InternalVideoMemberEventNames,
-  InternalVideoMemberUpdatedEvent,
-  InternalVideoMemberTalkingEvent,
+  InternalVideoMemberEvent,
 } from './videoMember'
 import {
   VideoLayoutEventNames,
@@ -52,9 +51,8 @@ export type InternalVideoEventNames =
   | RTCTrackEventName
 
 export type InternalVideoAPIEvent =
-  | InternalVideoRoomJoinedEvent
-  | InternalVideoMemberUpdatedEvent
-  | InternalVideoMemberTalkingEvent
+  | InternalVideoRoomEvent
+  | InternalVideoMemberEvent
 
 export type VideoAPIEventParams =
   | VideoRoomEvent

--- a/packages/core/src/types/video.ts
+++ b/packages/core/src/types/video.ts
@@ -2,11 +2,14 @@ import {
   VideoRoomSessionEventNames,
   VideoRoomEvent,
   InternalVideoRoomSessionEventNames,
+  InternalVideoRoomJoinedEvent,
 } from './videoRoomSession'
 import {
   VideoMemberEventNames,
   VideoMemberEvent,
   InternalVideoMemberEventNames,
+  InternalVideoMemberUpdatedEvent,
+  InternalVideoMemberTalkingEvent,
 } from './videoMember'
 import {
   VideoLayoutEventNames,
@@ -47,6 +50,11 @@ export type InternalVideoEventNames =
   | InternalVideoLayoutEventNames
   | InternalVideoRecordingEventNames
   | RTCTrackEventName
+
+export type InternalVideoAPIEvent =
+  | InternalVideoRoomJoinedEvent
+  | InternalVideoMemberUpdatedEvent
+  | InternalVideoMemberTalkingEvent
 
 export type VideoAPIEventParams =
   | VideoRoomEvent

--- a/packages/core/src/types/videoMember.ts
+++ b/packages/core/src/types/videoMember.ts
@@ -325,6 +325,10 @@ export interface InternalVideoMemberTalkingEvent extends SwEvent {
   params: VideoMemberTalkingEventParams
 }
 
+export type InternalVideoMemberEvent =
+  | InternalVideoMemberUpdatedEvent
+  | InternalVideoMemberTalkingEvent
+
 /**
  * ==========
  * ==========

--- a/packages/core/src/types/videoMember.ts
+++ b/packages/core/src/types/videoMember.ts
@@ -121,6 +121,9 @@ export type VideoMemberEventNames =
   | MemberUpdatedEventNames
   | MemberTalkingEventNames
 
+export type InternalMemberUpdatedEventNames =
+  typeof INTERNAL_MEMBER_UPDATED_EVENTS[number]
+
 /**
  * List of internal events
  * @internal
@@ -129,7 +132,7 @@ export type InternalVideoMemberEventNames =
   | ToInternalVideoEvent<
       MemberJoined | MemberLeft | MemberUpdated | MemberTalkingEventNames
     >
-  | typeof INTERNAL_MEMBER_UPDATED_EVENTS[number]
+  | InternalMemberUpdatedEventNames
 
 export type VideoMemberType = 'member' | 'screen' | 'device'
 
@@ -311,6 +314,16 @@ export type InternalVideoMemberEntity = {
  */
 export type InternalVideoMemberEntityUpdated =
   EntityUpdated<InternalVideoMemberEntity>
+
+export interface InternalVideoMemberUpdatedEvent extends SwEvent {
+  event_type: InternalMemberUpdatedEventNames
+  params: VideoMemberUpdatedEventParams
+}
+
+export interface InternalVideoMemberTalkingEvent extends SwEvent {
+  event_type: MemberTalkingEventNames
+  params: VideoMemberTalkingEventParams
+}
 
 /**
  * ==========

--- a/packages/core/src/types/videoRoomSession.ts
+++ b/packages/core/src/types/videoRoomSession.ts
@@ -11,6 +11,10 @@ import type {
 } from './utils'
 import type { InternalVideoMemberEntity } from './videoMember'
 import * as Rooms from '../rooms'
+import {
+  INTERNAL_MEMBER_UPDATED_EVENTS,
+  VideoMemberUpdatedEventParams,
+} from '..'
 
 /**
  * Public event types
@@ -133,6 +137,11 @@ type InternalVideoRoomEntity = {
  */
 export type InternalVideoRoomUpdated =
   EntityUpdated<InternalVideoRoomSessionEntity>
+
+export interface InternalVideoRoomJoinedEvent extends SwEvent {
+  event_type: ToInternalVideoEvent<RoomJoined>
+  params: VideoRoomSubscribedEventParams
+}
 
 /**
  * ==========

--- a/packages/core/src/types/videoRoomSession.ts
+++ b/packages/core/src/types/videoRoomSession.ts
@@ -11,10 +11,6 @@ import type {
 } from './utils'
 import type { InternalVideoMemberEntity } from './videoMember'
 import * as Rooms from '../rooms'
-import {
-  INTERNAL_MEMBER_UPDATED_EVENTS,
-  VideoMemberUpdatedEventParams,
-} from '..'
 
 /**
  * Public event types

--- a/packages/core/src/types/videoRoomSession.ts
+++ b/packages/core/src/types/videoRoomSession.ts
@@ -139,6 +139,8 @@ export interface InternalVideoRoomJoinedEvent extends SwEvent {
   params: VideoRoomSubscribedEventParams
 }
 
+export type InternalVideoRoomEvent = InternalVideoRoomJoinedEvent
+
 /**
  * ==========
  * ==========


### PR DESCRIPTION
The code in this changeset includes:

- [x] Fixed last usages of `room` instead of `room_session`
- [x] Stronger types for the `PubSub` channel.
  -  Before `PubSubAction` was only able to type the `action.type` but we were using `any` for `action.payload`. As of this PR we'll be able to use the `PubSub` channel with full types for both.
- [x] Added types to `findNamespaceInPayload`
  -  We won't have to guess where to grab the namespace no more since we can now discriminate payloads based on the `action.type`.
