### PR TITLE
Handle `room.subscribed` in realtime-api package

### DIFF
--- a/.changeset/stale-insects-happen.md
+++ b/.changeset/stale-insects-happen.md
@@ -3,3 +3,4 @@
 ---
 
 Update `ConsumerContract` interface and add array-keys to the toExternalJSON whitelist.
+Fix issue on converting timestamp values to `Date` objects. [realtime-api]

--- a/.changeset/stale-insects-happen.md
+++ b/.changeset/stale-insects-happen.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/core': patch
+---
+
+Update `ConsumerContract` interface and add array-keys to the toExternalJSON whitelist.

--- a/.changeset/tidy-ducks-dress.md
+++ b/.changeset/tidy-ducks-dress.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/realtime-api': patch
+---
+
+Allow users to listen the `room.subscribed` event and change the `roomSession.subscribe()` to return a `Promise<RoomSessionFullState>`.

--- a/packages/core/src/BaseComponent.test.ts
+++ b/packages/core/src/BaseComponent.test.ts
@@ -161,6 +161,7 @@ describe('BaseComponent', () => {
             [
               ['video.jest.snake_case', 'video.jest.camel_case'],
               {
+                type: 'roomSession' as const,
                 instanceFactory: () => {
                   return {
                     instance: this,
@@ -230,13 +231,14 @@ describe('BaseComponent', () => {
       const mockPayloadTransformLocal = jest.fn()
 
       const localEventName = toLocalEvent('video.jest.localEvent')
-
+      const eventTransformKey = 'roomSession' as const
       class CustomComponent extends JestComponent {
         protected getEmitterTransforms() {
           return new Map([
             [
               ['video.jest.eventOne', 'video.jest.eventTwo'],
               {
+                type: eventTransformKey,
                 instanceFactory: mockInstanceFactoryRegistered,
                 payloadTransform: mockPayloadTransformRegistered,
               },
@@ -244,6 +246,7 @@ describe('BaseComponent', () => {
             [
               ['video.jest.notRegistered'],
               {
+                type: eventTransformKey,
                 instanceFactory: mockInstanceFactoryNotRegistered,
                 payloadTransform: mockPayloadTransformNotRegistered,
               },
@@ -251,6 +254,7 @@ describe('BaseComponent', () => {
             [
               [localEventName],
               {
+                type: eventTransformKey,
                 instanceFactory: mockInstanceFactoryLocal,
                 payloadTransform: mockPayloadTransformLocal,
               },
@@ -280,6 +284,10 @@ describe('BaseComponent', () => {
       expect(mockInstanceFactoryNotRegistered).toHaveBeenCalledTimes(0)
       expect(mockPayloadTransformNotRegistered).toHaveBeenCalledTimes(0)
 
+      /** 2 transforms because we added the transform `key` too */
+      // @ts-expect-error
+      expect(instance._emitterTransforms.size).toEqual(2)
+
       // @ts-expect-error
       instance.applyEmitterTransforms()
       instance.emit(localEventName, {})
@@ -295,8 +303,10 @@ describe('BaseComponent', () => {
       expect(mockPayloadTransformRegistered).toHaveBeenCalledTimes(1)
       expect(mockInstanceFactoryNotRegistered).toHaveBeenCalledTimes(0)
       expect(mockPayloadTransformNotRegistered).toHaveBeenCalledTimes(0)
+
+      /** 3 transforms because we added the transform `key` too */
       // @ts-expect-error
-      expect(instance._emitterTransforms.size).toEqual(2)
+      expect(instance._emitterTransforms.size).toEqual(3)
     })
   })
 })

--- a/packages/core/src/BaseComponent.test.ts
+++ b/packages/core/src/BaseComponent.test.ts
@@ -284,7 +284,7 @@ describe('BaseComponent', () => {
       expect(mockInstanceFactoryNotRegistered).toHaveBeenCalledTimes(0)
       expect(mockPayloadTransformNotRegistered).toHaveBeenCalledTimes(0)
 
-      /** 2 transforms because we added the transform `key` too */
+      /** 2 transforms because we added the transform `type` too */
       // @ts-expect-error
       expect(instance._emitterTransforms.size).toEqual(2)
 
@@ -304,7 +304,7 @@ describe('BaseComponent', () => {
       expect(mockInstanceFactoryNotRegistered).toHaveBeenCalledTimes(0)
       expect(mockPayloadTransformNotRegistered).toHaveBeenCalledTimes(0)
 
-      /** 3 transforms because we added the transform `key` too */
+      /** 3 transforms because we added the transform `type` too */
       // @ts-expect-error
       expect(instance._emitterTransforms.size).toEqual(3)
     })

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -40,9 +40,10 @@ export interface BaseConnectionContract<
 }
 
 export interface ConsumerContract<
-  EventTypes extends EventEmitter.ValidEventTypes
+  EventTypes extends EventEmitter.ValidEventTypes,
+  SubscribeType = void
 > extends EmitterContract<EventTypes> {
-  subscribe(): Promise<void>
+  subscribe(): Promise<SubscribeType>
 }
 
 export interface ClientContract<

--- a/packages/core/src/utils/eventTransformUtils.test.ts
+++ b/packages/core/src/utils/eventTransformUtils.test.ts
@@ -1,0 +1,86 @@
+import { EventTransform } from './interfaces'
+import {
+  instanceProxyFactory,
+  _instanceByTransformType,
+} from './eventTransformUtils'
+import { toExternalJSON } from './toExternalJSON'
+
+describe('instanceProxyFactory', () => {
+  const mockInstance = jest.fn()
+
+  const payload = {
+    nested: {
+      id: 'random',
+      snake_case: 'foo',
+      camelCase: 'baz',
+      otherTest: true,
+      counter: 0,
+    },
+  }
+
+  const transform: EventTransform = {
+    // @ts-expect-error
+    type: 'randomKey',
+    instanceFactory: () => {
+      return mockInstance
+    },
+    payloadTransform: (payload: any) => {
+      return toExternalJSON(payload.nested)
+    },
+    getInstanceEventNamespace: (payload: any) => {
+      return payload.nested.id
+    },
+    getInstanceEventChannel: (payload: any) => {
+      return payload.nested.snake_case
+    },
+  }
+
+  it('should return a cached Proxy object reading from the payload', () => {
+    for (let i = 0; i < 4; i++) {
+      const proxy = instanceProxyFactory({
+        transform,
+        payload: {
+          nested: {
+            ...payload.nested,
+            counter: i,
+          },
+        },
+      })
+
+      expect(proxy.snakeCase).toBe('foo')
+      expect(proxy.snake_case).toBeUndefined()
+      expect(proxy.camelCase).toBe('baz')
+      expect(proxy.otherTest).toBe(true)
+      expect(proxy.counter).toBe(i)
+      expect(proxy.eventChannel).toBe('foo')
+      expect(proxy._eventsNamespace).toBe('random')
+    }
+
+    expect(_instanceByTransformType.size).toBe(1)
+    expect(_instanceByTransformType.get('randomKey')).toBe(mockInstance)
+  })
+
+  it('should cache the instances by type', () => {
+    const firstProxy = instanceProxyFactory({ transform, payload })
+    expect(firstProxy.snakeCase).toBe('foo')
+
+    const secondProxy = instanceProxyFactory({ transform, payload })
+    expect(secondProxy.snakeCase).toBe('foo')
+
+    expect(_instanceByTransformType.size).toBe(1)
+    expect(_instanceByTransformType.get('randomKey')).toBe(mockInstance)
+
+    const thirdProxy = instanceProxyFactory({
+      transform: {
+        ...transform,
+        // @ts-expect-error
+        type: 'otherKey',
+      },
+      payload,
+    })
+    expect(thirdProxy.snakeCase).toBe('foo')
+
+    expect(_instanceByTransformType.size).toBe(2)
+    expect(_instanceByTransformType.get('otherKey')).toBe(mockInstance)
+  })
+})

--- a/packages/core/src/utils/eventTransformUtils.ts
+++ b/packages/core/src/utils/eventTransformUtils.ts
@@ -1,0 +1,86 @@
+import { EventTransform, EventTransformType } from './interfaces'
+
+interface InstanceProxyFactoryParams {
+  transform: EventTransform
+  payload: Record<any, unknown>
+}
+
+interface NestedFieldToProcess {
+  /** Nested field to transform through an EventTransform */
+  field: string
+  /**
+   * Allow us to update the nested `payload` to match the shape we already
+   * treat consuming other events from the server.
+   * For example: wrapping the `payload` within a specific key.
+   *  `payload` becomes `{ "member": payload }`
+   */
+  preProcessPayload: (payload: any) => any
+  /** Type of the EventTransform to select from `instance._emitterTransforms` */
+  eventTransformType: EventTransformType
+}
+
+/**
+ * Note: the cached instances within `_instanceByTransformType` will never be
+ * cleaned since we're caching by `transform.type` so we will always have one
+ * instance per type regardless of the Room/Member/Recording we're working on.
+ * This is something we can improve in the future, but not an issue right now.
+ * Exported for test purposes
+ */
+export const _instanceByTransformType = new Map<string, EventTransform>()
+export const NESTED_FIELDS_TO_PROCESS: NestedFieldToProcess[] = [
+  {
+    field: 'members',
+    preProcessPayload: (payload) => ({ member: payload }),
+    eventTransformType: 'roomSessionMember',
+  },
+  {
+    field: 'recordings',
+    preProcessPayload: (payload) => ({ recording: payload }),
+    eventTransformType: 'roomSessionRecording',
+  },
+]
+
+const _getOrCreateInstance = ({
+  transform,
+  payload,
+}: InstanceProxyFactoryParams) => {
+  if (!_instanceByTransformType.has(transform.type)) {
+    const instance = transform.instanceFactory(payload)
+    _instanceByTransformType.set(transform.type, instance)
+
+    return instance
+  }
+
+  return _instanceByTransformType.get(transform.type)
+}
+
+export const instanceProxyFactory = ({
+  transform,
+  payload,
+}: InstanceProxyFactoryParams) => {
+  /** Create the instance or pick from cache */
+  const cachedInstance = _getOrCreateInstance({
+    transform,
+    payload,
+  })
+
+  const transformedPayload = transform.payloadTransform(payload)
+  const proxiedObj = new Proxy(cachedInstance, {
+    get(target: any, prop: any, receiver: any) {
+      if (prop === '_eventsNamespace' && transform.getInstanceEventNamespace) {
+        return transform.getInstanceEventNamespace(payload)
+      }
+      if (prop === 'eventChannel' && transform.getInstanceEventChannel) {
+        return transform.getInstanceEventChannel(payload)
+      }
+
+      if (prop in transformedPayload) {
+        return transformedPayload[prop]
+      }
+
+      return Reflect.get(target, prop, receiver)
+    },
+  })
+
+  return proxiedObj
+}

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -12,6 +12,7 @@ export * from './parseRPCResponse'
 export * from './toExternalJSON'
 export * from './toInternalEventName'
 export * from './extendComponent'
+export * from './eventTransformUtils'
 
 export const mutateStorageKey = (key: string) => `${STORAGE_PREFIX}${key}`
 

--- a/packages/core/src/utils/interfaces.ts
+++ b/packages/core/src/utils/interfaces.ts
@@ -245,6 +245,22 @@ export type InternalGlobalVideoEvents =
   typeof INTERNAL_GLOBAL_VIDEO_EVENTS[number]
 
 /**
+ * NOTE: `EventTransformType` is not tied to a constructor but more on
+ * the event payloads.
+ * We are using `roomSession` and `roomSessionSubscribed` here because
+ * some "Room" events have similar payloads while `room.subscribed` has
+ * nested fields the SDK has to process.
+ * `EventTransformType` identifies a unique `EventTransform` type based on the
+ * payload it has to process.
+ */
+export type EventTransformType =
+  | 'roomSession'
+  | 'roomSessionSubscribed'
+  | 'roomSessionMember'
+  | 'roomSessionLayout'
+  | 'roomSessionRecording'
+  | 'roomSessionPlayback'
+/**
  * `EventTransform`s represent our internal pipeline for
  * creating specific instances for each event handler. This
  * is basically what let us create and pass a `Member`
@@ -285,6 +301,11 @@ export type InternalGlobalVideoEvents =
  * └───────────────────────────────────┘
  */
 export interface EventTransform {
+  /**
+   * Using the `key` we can cache and retrieve a single instance
+   * for the **stateless** object returned by `instanceFactory`
+   */
+  type: EventTransformType
   /**
    * Must return an **stateless** object. Think of it as a
    * set of APIs representing the behavior you want to

--- a/packages/core/src/utils/toExternalJSON.test.ts
+++ b/packages/core/src/utils/toExternalJSON.test.ts
@@ -117,11 +117,11 @@ describe('toExternalJSON', () => {
 
   it('converts timestamp properties to Date objects', () => {
     const input = {
-      started_at: 1632305086964,
-      ended_at: 1632305100130,
+      started_at: 1632305086964 / 1000,
+      ended_at: 1632305100130 / 1000,
       completed_at: 'an invalid date',
-      started: 1632305086964,
-      ended: 1632305100130,
+      started: 1632305086964 / 1000,
+      ended: 1632305100130 / 1000,
       prop_one: 'one',
       prop_two: 'two',
       prop_three: 1,
@@ -131,8 +131,8 @@ describe('toExternalJSON', () => {
       startedAt: new Date(1632305086964),
       endedAt: new Date(1632305100130),
       completedAt: 'an invalid date',
-      started: 1632305086964,
-      ended: 1632305100130,
+      started: 1632305086964 / 1000,
+      ended: 1632305100130 / 1000,
       propOne: 'one',
       propTwo: 'two',
       propThree: 1,
@@ -141,11 +141,11 @@ describe('toExternalJSON', () => {
     expect(toExternalJSON(input)).toStrictEqual(output)
   })
 
-  it('converts the layout `layers` key to be camelCase', () => {
+  it('converts nested key like members and recordings', () => {
     const id = '5074e94f-de6e-4477-8068-f046cab81f77'
     const roomId = '297ec3bb-fdc5-4995-ae75-c40a43c272ee'
     const input = JSON.parse(
-      `{"recording":false,"name":"test","hide_video_muted":false,"id":"${id}","members":[{"visible":false,"room_session_id":"${id}","input_volume":0,"id":"b3b0cfd6-2382-4ac6-a8c9-9182584697ae","input_sensitivity":44,"audio_muted":false,"output_volume":0,"name":"user","deaf":false,"video_muted":false,"room_id":"${roomId}","type":"member"}],"room_id":"${roomId}","event_channel":"room.uuid"}`
+      `{"recording":false,"name":"test","hide_video_muted":false,"id":"${id}","members":[{"visible":false,"room_session_id":"${id}","input_volume":0,"id":"b3b0cfd6-2382-4ac6-a8c9-9182584697ae","input_sensitivity":44,"audio_muted":false,"output_volume":0,"name":"user","deaf":false,"video_muted":false,"room_id":"${roomId}","type":"member"}],"recordings":[{"id":"rec1","state":"recording","started_at":1633340944.785},{"id":"rec2","state":"completed","started_at":1633340944.785,"ended_at":1633340976.802}],"room_id":"${roomId}","event_channel":"room.uuid"}`
     )
 
     const output = {
@@ -169,6 +169,19 @@ describe('toExternalJSON', () => {
           outputVolume: 0,
           inputVolume: 0,
           inputSensitivity: 44,
+        },
+      ],
+      recordings: [
+        {
+          id: 'rec1',
+          state: 'recording',
+          startedAt: new Date(1633340944.785 * 1000),
+        },
+        {
+          id: 'rec2',
+          state: 'completed',
+          startedAt: new Date(1633340944.785 * 1000),
+          endedAt: new Date(1633340976.802 * 1000),
         },
       ],
     }

--- a/packages/core/src/utils/toExternalJSON.test.ts
+++ b/packages/core/src/utils/toExternalJSON.test.ts
@@ -175,4 +175,32 @@ describe('toExternalJSON', () => {
 
     expect(toExternalJSON(input)).toStrictEqual(output)
   })
+
+  it('should not change keys already camelCase-d', async () => {
+    const input = {
+      someId: 'test',
+      anotherProp: null,
+      this_change: null,
+      someOtherProperty: {
+        nested_property: {
+          nestedProp2: 'nested prop value',
+        },
+        firstLevel: 'test',
+      },
+    }
+
+    const output = {
+      someId: 'test',
+      anotherProp: null,
+      thisChange: null,
+      someOtherProperty: {
+        nestedProperty: {
+          nestedProp2: 'nested prop value',
+        },
+        firstLevel: 'test',
+      },
+    }
+
+    expect(toExternalJSON(input)).toStrictEqual(output)
+  })
 })

--- a/packages/core/src/utils/toExternalJSON.test.ts
+++ b/packages/core/src/utils/toExternalJSON.test.ts
@@ -140,4 +140,39 @@ describe('toExternalJSON', () => {
 
     expect(toExternalJSON(input)).toStrictEqual(output)
   })
+
+  it('converts the layout `layers` key to be camelCase', () => {
+    const id = '5074e94f-de6e-4477-8068-f046cab81f77'
+    const roomId = '297ec3bb-fdc5-4995-ae75-c40a43c272ee'
+    const input = JSON.parse(
+      `{"recording":false,"name":"test","hide_video_muted":false,"id":"${id}","members":[{"visible":false,"room_session_id":"${id}","input_volume":0,"id":"b3b0cfd6-2382-4ac6-a8c9-9182584697ae","input_sensitivity":44,"audio_muted":false,"output_volume":0,"name":"user","deaf":false,"video_muted":false,"room_id":"${roomId}","type":"member"}],"room_id":"${roomId}","event_channel":"room.uuid"}`
+    )
+
+    const output = {
+      id,
+      roomId,
+      eventChannel: 'room.uuid',
+      recording: false,
+      name: 'test',
+      hideVideoMuted: false,
+      members: [
+        {
+          id: 'b3b0cfd6-2382-4ac6-a8c9-9182584697ae',
+          roomSessionId: id,
+          roomId,
+          type: 'member',
+          name: 'user',
+          visible: false,
+          audioMuted: false,
+          videoMuted: false,
+          deaf: false,
+          outputVolume: 0,
+          inputVolume: 0,
+          inputSensitivity: 44,
+        },
+      ],
+    }
+
+    expect(toExternalJSON(input)).toStrictEqual(output)
+  })
 })

--- a/packages/core/src/utils/toExternalJSON.ts
+++ b/packages/core/src/utils/toExternalJSON.ts
@@ -93,6 +93,9 @@ export const toExternalJSON = <T>(
  * @internal
  */
 const fromSnakeToCamelCase = (input: string) => {
+  if (!input.includes('_')) {
+    return input
+  }
   return input.split('_').reduce((reducer, part, index) => {
     const fc = part.trim().charAt(0)
     const remainingChars = part.substr(1).toLowerCase()

--- a/packages/core/src/utils/toExternalJSON.ts
+++ b/packages/core/src/utils/toExternalJSON.ts
@@ -21,7 +21,13 @@ const DEFAULT_OPTIONS = {
    * Properties coming from the server where their value will be
    * converted to camelCase
    */
-  propsToUpdateValue: ['updated', 'layers'],
+  propsToUpdateValue: [
+    'updated',
+    'layers',
+    'members',
+    'recordings',
+    'playbacks',
+  ],
 }
 
 /**

--- a/packages/core/src/utils/toExternalJSON.ts
+++ b/packages/core/src/utils/toExternalJSON.ts
@@ -3,7 +3,7 @@ const toDateObject = (timestamp?: number) => {
     return timestamp
   }
 
-  const date = new Date(timestamp)
+  const date = new Date(timestamp * 1000)
 
   /**
    * If for some reason we can't convert to a valid date

--- a/packages/js/src/Room.ts
+++ b/packages/js/src/Room.ts
@@ -69,6 +69,7 @@ export class RoomConnection
           'video.recording.ended',
         ],
         {
+          type: 'roomSessionRecording',
           instanceFactory: (_payload: any) => {
             return Rooms.createRoomSessionRecordingObject({
               store: this.store,

--- a/packages/realtime-api/examples/ts-vanilla-websockets/index.ts
+++ b/packages/realtime-api/examples/ts-vanilla-websockets/index.ts
@@ -50,7 +50,19 @@ async function run() {
           rec.duration
         )
       })
-      await roomSession.subscribe()
+
+      const roomSessionState = await roomSession.subscribe()
+
+      console.log(
+        'State:',
+        roomSessionState.name,
+        roomSessionState.id,
+        roomSessionState.roomId,
+        roomSessionState.members
+      )
+      roomSessionState.members.forEach((member: any) => {
+        console.log('Room Member', member.id, member.name)
+      })
 
       const rec = await roomSession.startRecording()
 

--- a/packages/realtime-api/src/BaseConsumer.ts
+++ b/packages/realtime-api/src/BaseConsumer.ts
@@ -45,8 +45,8 @@ export class BaseConsumer<
         }
 
         try {
-          await this.execute(execParams)
           this.applyEmitterTransforms()
+          await this.execute(execParams)
         } catch (error) {
           return reject(error)
         }

--- a/packages/realtime-api/src/types/video.ts
+++ b/packages/realtime-api/src/types/video.ts
@@ -3,6 +3,7 @@ import type {
   VideoMemberEventNames,
   RoomStarted,
   RoomUpdated,
+  RoomSubscribed,
   RoomEnded,
   VideoLayoutEventNames,
   MemberTalkingEventNames,
@@ -10,7 +11,11 @@ import type {
   MemberUpdated,
   MemberUpdatedEventNames,
 } from '@signalwire/core'
-import type { RoomSession, RoomSessionUpdated } from '../video/RoomSession'
+import type {
+  RoomSession,
+  RoomSessionUpdated,
+  RoomSessionFullState,
+} from '../video/RoomSession'
 import type {
   RoomSessionMember,
   RoomSessionMemberUpdated,
@@ -39,8 +44,9 @@ export type RealTimeRoomApiEventsHandlerMapping = Record<
     (member: RoomSessionMemberUpdated) => void
   > &
   Record<MemberTalkingEventNames, (member: RoomSessionMember) => void> &
-  Record<RoomStarted | RoomEnded, (room: RoomSession) => void> &
-  Record<RoomUpdated, (room: RoomSessionUpdated) => void> &
+  Record<RoomStarted | RoomEnded, (roomSession: RoomSession) => void> &
+  Record<RoomUpdated, (roomSession: RoomSessionUpdated) => void> &
+  Record<RoomSubscribed, (roomSessionFull: RoomSessionFullState) => void> &
   Rooms.RoomSessionRecordingEventsHandlerMapping
 
 export type RealTimeRoomApiEvents = {

--- a/packages/realtime-api/src/video/RoomSession.ts
+++ b/packages/realtime-api/src/video/RoomSession.ts
@@ -416,6 +416,11 @@ class RoomSessionConsumer extends BaseConsumer<RealTimeRoomApiEvents> {
   protected _eventsPrefix = 'video' as const
 
   /** @internal */
+  protected subscribeParams = {
+    get_initial_state: true,
+  }
+
+  /** @internal */
   protected getEmitterTransforms() {
     return new Map<
       EmitterTransformsEvents | EmitterTransformsEvents[],

--- a/packages/realtime-api/src/video/RoomSession.ts
+++ b/packages/realtime-api/src/video/RoomSession.ts
@@ -320,7 +320,8 @@ interface RoomSessionDocs extends RoomSessionMain {
   startRecording(): Promise<Rooms.RoomSessionRecording>
 
   /**
-   * Start listening for the events for which you have provided event handlers.
+   * Start listening for the events for which you have provided event handlers and
+   * returns the {@link RoomSessionFullState} the contains the full state of the room session.
    */
   subscribe(): Promise<RoomSessionFullState>
 }

--- a/packages/realtime-api/src/video/RoomSession.ts
+++ b/packages/realtime-api/src/video/RoomSession.ts
@@ -428,6 +428,14 @@ class RoomSessionConsumer extends BaseConsumer<RealTimeRoomApiEvents> {
     get_initial_state: true,
   }
 
+  /**
+   * @privateRemarks
+   *
+   * Override BaseConsumer `subscribe` to resolve the promise when the 'room.subscribed'
+   * event comes. This way we can return to the user the room full state.
+   * Note: the payload will go through an EventTrasform - see the `type: roomSessionSubscribed`
+   * below.
+   */
   subscribe() {
     return new Promise(async (resolve, reject) => {
       const handler = (payload: RoomSessionFullState) => {

--- a/packages/realtime-api/src/video/RoomSession.ts
+++ b/packages/realtime-api/src/video/RoomSession.ts
@@ -11,6 +11,7 @@ import {
   VideoMemberEventParams,
   InternalVideoRoomSessionEventNames,
   VideoRoomUpdatedEventParams,
+  VideoRoomSubscribedEventParams,
   InternalVideoLayoutEventNames,
   InternalVideoRecordingEventNames,
   VideoLayoutChangedEventParams,
@@ -23,7 +24,10 @@ import {
 } from '@signalwire/core'
 import { BaseConsumer } from '../BaseConsumer'
 import { RealTimeRoomApiEvents } from '../types'
-import { createRoomSessionMemberObject } from './RoomSessionMember'
+import {
+  createRoomSessionMemberObject,
+  RoomSessionMember,
+} from './RoomSessionMember'
 
 type EmitterTransformsEvents =
   | InternalVideoRoomSessionEventNames
@@ -413,7 +417,7 @@ export interface RoomSession
 
 export type RoomSessionUpdated = EntityUpdated<RoomSession>
 export interface RoomSessionFullState extends RoomSession {
-  members: VideoMemberEntity[]
+  members: RoomSessionMember[]
 }
 
 class RoomSessionConsumer extends BaseConsumer<RealTimeRoomApiEvents> {
@@ -448,16 +452,21 @@ class RoomSessionConsumer extends BaseConsumer<RealTimeRoomApiEvents> {
       [
         'video.room.subscribed',
         {
+          type: 'roomSessionSubscribed',
           instanceFactory: () => {
             return this
           },
-          payloadTransform: (payload: VideoRoomUpdatedEventParams) => {
+          payloadTransform: (payload: VideoRoomSubscribedEventParams) => {
             return toExternalJSON(payload.room_session)
           },
-          getInstanceEventNamespace: (payload: VideoRoomUpdatedEventParams) => {
+          getInstanceEventNamespace: (
+            payload: VideoRoomSubscribedEventParams
+          ) => {
             return payload.room_session.id
           },
-          getInstanceEventChannel: (payload: VideoRoomUpdatedEventParams) => {
+          getInstanceEventChannel: (
+            payload: VideoRoomSubscribedEventParams
+          ) => {
             return payload.room_session.event_channel
           },
         },
@@ -465,6 +474,7 @@ class RoomSessionConsumer extends BaseConsumer<RealTimeRoomApiEvents> {
       [
         'video.room.updated',
         {
+          type: 'roomSession',
           instanceFactory: () => {
             return this
           },
@@ -485,6 +495,7 @@ class RoomSessionConsumer extends BaseConsumer<RealTimeRoomApiEvents> {
       [
         'video.layout.changed',
         {
+          type: 'roomSessionLayout',
           instanceFactory: () => {
             // TODO: Implement a Layout object when we have a better payload
             // from the backend
@@ -508,6 +519,7 @@ class RoomSessionConsumer extends BaseConsumer<RealTimeRoomApiEvents> {
           ...INTERNAL_MEMBER_UPDATED_EVENTS,
         ],
         {
+          type: 'roomSessionMember',
           instanceFactory: (_payload: VideoMemberEventParams) => {
             return createRoomSessionMemberObject({
               store: this.store,
@@ -542,6 +554,7 @@ class RoomSessionConsumer extends BaseConsumer<RealTimeRoomApiEvents> {
           'video.recording.ended',
         ],
         {
+          type: 'roomSessionRecording',
           instanceFactory: (_payload: any) => {
             return Rooms.createRoomSessionRecordingObject({
               store: this.store,

--- a/packages/realtime-api/src/video/RoomSessionMember.test.ts
+++ b/packages/realtime-api/src/video/RoomSessionMember.test.ts
@@ -32,12 +32,19 @@ describe('Member Object', () => {
       // tweak "_eventsNamespace" using _attachListeners
       // @ts-expect-error
       roomSession._attachListeners(roomSessionId)
-      await roomSession.subscribe()
+      roomSession.subscribe().then(() => {
+        // Trigger a member.joined event to resolve the main Promise
+        const memberJoinedEvent = JSON.parse(
+          `{"jsonrpc":"2.0","id":"uuid","method":"signalwire.event","params":{"params":{"room_session_id":"${roomSessionId}","room_id":"03b71e19-1ed2-4417-a544-7d0ca01186ed","member":{"visible":false,"room_session_id":"${roomSessionId}","input_volume":0,"id":"${memberId}","input_sensitivity":44,"audio_muted":false,"output_volume":0,"name":"edoardo","deaf":false,"video_muted":false,"room_id":"03b71e19-1ed2-4417-a544-7d0ca01186ed","type":"member"}},"timestamp":1234,"event_type":"video.member.joined","event_channel":"${roomSession.eventChannel}"}}`
+        )
+        session.dispatch(actions.socketMessageAction(memberJoinedEvent))
+      })
 
-      const memberJoinedEvent = JSON.parse(
-        `{"jsonrpc":"2.0","id":"uuid","method":"signalwire.event","params":{"params":{"room_session_id":"${roomSessionId}","room_id":"03b71e19-1ed2-4417-a544-7d0ca01186ed","member":{"visible":false,"room_session_id":"${roomSessionId}","input_volume":0,"id":"${memberId}","input_sensitivity":44,"audio_muted":false,"output_volume":0,"name":"edoardo","deaf":false,"video_muted":false,"room_id":"03b71e19-1ed2-4417-a544-7d0ca01186ed","type":"member"}},"timestamp":1234,"event_type":"video.member.joined","event_channel":"${roomSession.eventChannel}"}}`
+      // Emit room.subscribed event to resolve the promise above.
+      const roomSubscribedEvent = JSON.parse(
+        `{"jsonrpc":"2.0","id":"4198ee12-ec98-4002-afc5-e031fc32bb8a","method":"signalwire.event","params":{"params":{"room_session":{"recording":false,"name":"behindTheWire","hide_video_muted":false,"id":"${roomSessionId}","members":[{"visible":false,"room_session_id":"${roomSessionId}","input_volume":0,"id":"b3b0cfd6-2382-4ac6-a8c9-9182584697ae","input_sensitivity":44,"audio_muted":false,"output_volume":0,"name":"edoardo","deaf":false,"video_muted":false,"room_id":"297ec3bb-fdc5-4995-ae75-c40a43c272ee","type":"member"}],"room_id":"297ec3bb-fdc5-4995-ae75-c40a43c272ee","event_channel":"${roomSession.eventChannel}"}},"timestamp":1632738590.6955,"event_type":"video.room.subscribed","event_channel":"${roomSession.eventChannel}"}}`
       )
-      session.dispatch(actions.socketMessageAction(memberJoinedEvent))
+      session.dispatch(actions.socketMessageAction(roomSubscribedEvent))
     })
   })
 

--- a/packages/realtime-api/src/video/Video.test.ts
+++ b/packages/realtime-api/src/video/Video.test.ts
@@ -143,15 +143,17 @@ describe('Video Object', () => {
       expect(mockExecute).toHaveBeenNthCalledWith(1, {
         method: 'signalwire.subscribe',
         params: {
+          get_initial_state: true,
           event_channel: eventChannelOne,
-          events: ['video.member.updated'],
+          events: ['video.member.updated', 'video.room.subscribed'],
         },
       })
       expect(mockExecute).toHaveBeenNthCalledWith(2, {
         method: 'signalwire.subscribe',
         params: {
+          get_initial_state: true,
           event_channel: eventChannelTwo,
-          events: ['video.member.updated'],
+          events: ['video.member.updated', 'video.room.subscribed'],
         },
       })
 

--- a/packages/realtime-api/src/video/Video.ts
+++ b/packages/realtime-api/src/video/Video.ts
@@ -10,7 +10,11 @@ import {
 } from '@signalwire/core'
 import { BaseConsumer } from '../BaseConsumer'
 import { RealTimeVideoApiEvents } from '../types/video'
-import { createRoomSessionObject, RoomSession } from './RoomSession'
+import {
+  createRoomSessionObject,
+  RoomSession,
+  RoomSessionFullState,
+} from './RoomSession'
 import type { RoomSessionMember } from './RoomSessionMember'
 
 type TransformEvent = Extract<
@@ -54,7 +58,12 @@ export interface Video extends ConsumerContract<RealTimeVideoApiEvents> {
   /** @internal */
   subscribe(): Promise<void>
 }
-export type { RoomSession, RoomSessionMember, RoomSessionRecording }
+export type {
+  RoomSession,
+  RoomSessionFullState,
+  RoomSessionMember,
+  RoomSessionRecording,
+}
 
 /** @internal */
 export class VideoAPI extends BaseConsumer<RealTimeVideoApiEvents> {

--- a/packages/realtime-api/src/video/Video.ts
+++ b/packages/realtime-api/src/video/Video.ts
@@ -81,6 +81,8 @@ export class VideoAPI extends BaseConsumer<RealTimeVideoApiEvents> {
       [
         ['video.room.started', 'video.room.ended'],
         {
+          // TODO: create a new key or use `roomSession`?
+          type: 'roomSession',
           instanceFactory: () => {
             return createRoomSessionObject({
               store: this.store,


### PR DESCRIPTION
This PR adds the ability to listen for `room.subscribed` events and also return the "full roomSession state" on the `.subscribe()` call.

Example usage: 

```ts
      const roomSessionState = await roomSession.subscribe()

      console.log(
        'State:',
        roomSessionState.name,
        roomSessionState.id,
        roomSessionState.roomId,
        roomSessionState.members, // Array of JSON objects 
        roomSessionState.recordings, // Array of JSON objects
      )
```