### PR TITLE
Tweak localOverlay styles to avoid issues when used with fixed height

### DIFF
--- a/.changeset/lovely-gorillas-exist.md
+++ b/.changeset/lovely-gorillas-exist.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/js': patch
+---
+
+Remove `height: 100%` on the localVideo overlay to avoid positioning issues if the wrapper has a fixed height.

--- a/packages/js/src/features/mediaElements/mediaElementsSagas.ts
+++ b/packages/js/src/features/mediaElements/mediaElementsSagas.ts
@@ -190,7 +190,6 @@ function* videoElementSetupWorker({
     setVideoMediaTrack({ element, track })
 
     element.style.width = '100%'
-    element.style.height = '100%'
 
     if (!applyLocalVideoOverlay) {
       rootElement.appendChild(element)
@@ -216,10 +215,12 @@ function* videoElementSetupWorker({
     const relativeWrapper = document.createElement('div')
     relativeWrapper.style.position = 'relative'
     relativeWrapper.style.width = '100%'
-    relativeWrapper.style.height = '100%'
     relativeWrapper.style.margin = '0 auto'
     relativeWrapper.appendChild(paddingWrapper)
 
+    rootElement.style.display = 'flex'
+    rootElement.style.alignItems = 'center'
+    rootElement.style.justifyContent = 'center'
     rootElement.appendChild(relativeWrapper)
   }
 


### PR DESCRIPTION
Removing `height: 100%` to allow end-user to set fixed height on the wrapper and not having issues with localOverlay positions. 