### PR TITLE
deprecate `createRoomObject`/`joinRoom`, introduce `RoomSession` constructor

### DIFF
--- a/.changeset/empty-doors-dream.md
+++ b/.changeset/empty-doors-dream.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/js': patch
+---
+
+Introduce `RoomSession` as a new primitive for connecting to a Room. Mark `createRoomObject` and `joinRoom` as deprecated.

--- a/packages/core/src/utils/interfaces.ts
+++ b/packages/core/src/utils/interfaces.ts
@@ -66,7 +66,6 @@ export interface SessionOptions {
   project?: string
   /** SignalWire project token, e.g. `PT9e5660c101cd140a1c93a0197640a369cf5f16975a0079c9` */
   token: string
-  autoConnect?: boolean
   // From `LogLevelDesc` of loglevel to simplify our docs
   /** logging level */
   logLevel?: 'trace' | 'debug' | 'info' | 'warn' | 'error' | 'silent'

--- a/packages/js/examples/heroku/index.js
+++ b/packages/js/examples/heroku/index.js
@@ -121,101 +121,99 @@ function initDeviceOptions() {
  * Connect with Relay creating a client and attaching all the event handler.
  */
 window.connect = () => {
-  Video.createRoomObject({
+  const roomSession = new Video.RoomSession({
     host: document.getElementById('host').value,
     token: document.getElementById('token').value,
     rootElementId: 'rootElement',
     audio: true,
     video: true,
-  }).then((roomObject) => {
-    roomObj = roomObject
-    window._roomObj = roomObject
+  })
 
-    console.debug('Video SDK roomObj', roomObj)
+  roomObj = roomSession
+  window._roomObj = roomSession
 
-    roomObj.on('room.started', (params) =>
-      console.debug('>> room.started', params)
-    )
-    roomObj.on('room.joined', (params) => {
-      console.debug('>> room.joined', params)
+  console.debug('Video SDK roomObj', roomObj)
 
-      btnConnect.classList.add('d-none')
-      btnDisconnect.classList.remove('d-none')
-      connectStatus.innerHTML = 'Connected'
+  roomObj.on('room.started', (params) =>
+    console.debug('>> room.started', params)
+  )
+  roomObj.on('room.joined', (params) => {
+    console.debug('>> room.joined', params)
 
-      inCallElements.forEach((button) => {
-        button.classList.remove('d-none')
-        button.disabled = false
-      })
+    btnConnect.classList.add('d-none')
+    btnDisconnect.classList.remove('d-none')
+    connectStatus.innerHTML = 'Connected'
 
-      loadLayouts()
+    inCallElements.forEach((button) => {
+      button.classList.remove('d-none')
+      button.disabled = false
     })
-    roomObj.on('room.updated', (params) =>
-      console.debug('>> room.updated', params)
-    )
 
-    roomObj.on('recording.started', (params) => {
-      console.debug('>> recording.started', params)
-      document.getElementById('recordingState').innerText = 'recording'
-    })
-    roomObj.on('recording.ended', (params) => {
-      console.debug('>> recording.ended', params)
-      document.getElementById('recordingState').innerText = 'completed'
-    })
-    roomObj.on('recording.updated', (params) => {
-      console.debug('>> recording.updated', params)
-      document.getElementById('recordingState').innerText = params.state
-    })
-    roomObj.on('room.ended', (params) => {
-      console.debug('>> room.ended', params)
-      hangup()
-    })
-    roomObj.on('member.joined', (params) =>
-      console.debug('>> member.joined', params)
-    )
-    roomObj.on('member.updated', (params) =>
-      console.debug('>> member.updated', params)
-    )
+    loadLayouts()
+  })
+  roomObj.on('room.updated', (params) =>
+    console.debug('>> room.updated', params)
+  )
 
-    roomObj.on('member.updated.audio_muted', (params) =>
-      console.debug('>> member.updated.audio_muted', params)
-    )
-    roomObj.on('member.updated.video_muted', (params) =>
-      console.debug('>> member.updated.video_muted', params)
-    )
+  roomObj.on('recording.started', (params) => {
+    console.debug('>> recording.started', params)
+    document.getElementById('recordingState').innerText = 'recording'
+  })
+  roomObj.on('recording.ended', (params) => {
+    console.debug('>> recording.ended', params)
+    document.getElementById('recordingState').innerText = 'completed'
+  })
+  roomObj.on('recording.updated', (params) => {
+    console.debug('>> recording.updated', params)
+    document.getElementById('recordingState').innerText = params.state
+  })
+  roomObj.on('room.ended', (params) => {
+    console.debug('>> room.ended', params)
+    hangup()
+  })
+  roomObj.on('member.joined', (params) =>
+    console.debug('>> member.joined', params)
+  )
+  roomObj.on('member.updated', (params) =>
+    console.debug('>> member.updated', params)
+  )
 
-    roomObj.on('member.left', (params) =>
-      console.debug('>> member.left', params)
-    )
-    roomObj.on('member.talking', (params) =>
-      console.debug('>> member.talking', params)
-    )
-    roomObj.on('layout.changed', (params) =>
-      console.debug('>> layout.changed', params)
-    )
-    roomObj.on('track', (event) => console.debug('>> DEMO track', event))
+  roomObj.on('member.updated.audio_muted', (params) =>
+    console.debug('>> member.updated.audio_muted', params)
+  )
+  roomObj.on('member.updated.video_muted', (params) =>
+    console.debug('>> member.updated.video_muted', params)
+  )
 
-    roomObj
-      .join()
-      .then((result) => {
-        console.log('>> Room Joined', result)
+  roomObj.on('member.left', (params) => console.debug('>> member.left', params))
+  roomObj.on('member.talking', (params) =>
+    console.debug('>> member.talking', params)
+  )
+  roomObj.on('layout.changed', (params) =>
+    console.debug('>> layout.changed', params)
+  )
+  roomObj.on('track', (event) => console.debug('>> DEMO track', event))
 
-        enumerateDevices()
-          .then(initDeviceOptions)
-          .catch((error) => {
-            console.error(error)
-          })
+  roomObj
+    .join()
+    .then((result) => {
+      console.log('>> Room Joined', result)
 
-        createDeviceWatcher().then((deviceWatcher) => {
-          deviceWatcher.on('changed', () => {
-            initDeviceOptions()
-          })
+      enumerateDevices()
+        .then(initDeviceOptions)
+        .catch((error) => {
+          console.error(error)
+        })
+
+      createDeviceWatcher().then((deviceWatcher) => {
+        deviceWatcher.on('changed', () => {
+          initDeviceOptions()
         })
       })
-      .catch((error) => {
-        console.error('Join error?', error)
-      })
-  })
+    })
+    .catch((error) => {
+      console.error('Join error?', error)
+    })
 
   connectStatus.innerHTML = 'Connecting...'
 }

--- a/packages/js/src/RoomSession.test.ts
+++ b/packages/js/src/RoomSession.test.ts
@@ -1,0 +1,28 @@
+import { RoomSession, UNSAFE_PROP_ACCESS } from './RoomSession'
+
+describe('RoomSession Object', () => {
+  it('should control which properties the user can access before connecting the room.', async () => {
+    const roomSession = new RoomSession({
+      token: '<some-token>',
+    })
+
+    expect(() => roomSession.active).not.toThrow()
+    expect(() => roomSession.memberId).not.toThrow()
+    expect(() => roomSession.join()).not.toThrow()
+    UNSAFE_PROP_ACCESS.map((prop) => {
+      // @ts-expect-error
+      expect(() => roomSession[prop]).toThrow()
+    })
+
+    // @ts-expect-error
+    roomSession.state = 'active'
+
+    expect(() => roomSession.active).not.toThrow()
+    expect(() => roomSession.memberId).not.toThrow()
+    expect(() => roomSession.join()).not.toThrow()
+    UNSAFE_PROP_ACCESS.map((prop) => {
+      // @ts-expect-error
+      expect(() => roomSession[prop]).not.toThrow()
+    })
+  })
+})

--- a/packages/js/src/RoomSession.ts
+++ b/packages/js/src/RoomSession.ts
@@ -9,6 +9,40 @@ const VIDEO_CONSTRAINTS: MediaTrackConstraints = {
   aspectRatio: { ideal: 16 / 9 },
 }
 
+/**
+ * List of properties/methods the user won't be able to use
+ * before they sucessfully call `roomSession.join()`.
+ */
+const UNSAFE_PROP_ACCESS = [
+  'active',
+  'audioMute',
+  'audioUnmute',
+  'deaf',
+  'getLayouts',
+  'getMembers',
+  'getRecordings',
+  'hideVideoMuted',
+  'join',
+  'leave',
+  'memberId',
+  'removerMember',
+  'restoreOutboundAudio',
+  'restoreOutboundVideo',
+  'setInputSensitivity',
+  'setInputVolume',
+  'setLayout',
+  'setOutputVolume',
+  'showVideoMuted',
+  'startRecording',
+  'stopOutboundAudio',
+  'stopOutboundVideo',
+  'undeaf',
+  'videoMute',
+  'videoUnmute',
+  'setMicrophoneVolume',
+  'setSpeakerVolume',
+]
+
 export const RoomSession = function (roomOptions: CreateRoomObjectOptions) {
   const {
     audio = true,
@@ -54,14 +88,17 @@ export const RoomSession = function (roomOptions: CreateRoomObjectOptions) {
     return room
   }
 
-  // TODO: add types
   return new Proxy<Room>(room, {
-    get(target: any, prop: any, receiver: any) {
+    get(target: Room, prop: any, receiver: any) {
       if (prop === 'join') {
         return join
       }
 
-      // TODO: throw errors if the user tries to access certain properties before we're connected.
+      if (!target.active && UNSAFE_PROP_ACCESS.includes(prop)) {
+        throw new Error(
+          `Tried to access the property/method "${prop}" before the room was connected. Please call roomSession.join() first.`
+        )
+      }
 
       return Reflect.get(target, prop, receiver)
     },

--- a/packages/js/src/RoomSession.ts
+++ b/packages/js/src/RoomSession.ts
@@ -55,10 +55,7 @@ export const RoomSession = function (roomOptions: RoomSessionOptions) {
     ...userOptions
   } = roomOptions
 
-  const client = createClient({
-    ...userOptions,
-  })
-
+  const client = createClient(userOptions)
   const room = client.rooms.makeRoomObject({
     audio,
     video: video === true ? VIDEO_CONSTRAINTS : video,
@@ -83,6 +80,7 @@ export const RoomSession = function (roomOptions: RoomSessionOptions) {
       await room.join()
     } catch (e) {
       logger.error(e)
+      throw e
     }
     return room
   }

--- a/packages/js/src/RoomSession.ts
+++ b/packages/js/src/RoomSession.ts
@@ -3,15 +3,13 @@ import { createClient } from './createClient'
 import type { MakeRoomOptions } from './Client'
 import type { Room } from './Room'
 
-export interface CreateRoomObjectOptions extends UserOptions, MakeRoomOptions {}
-
 const VIDEO_CONSTRAINTS: MediaTrackConstraints = {
   aspectRatio: { ideal: 16 / 9 },
 }
 
 /**
- * List of properties/methods the user won't be able to use
- * before they sucessfully call `roomSession.join()`.
+ * List of properties/methods the user shouldn't be able to
+ * use until they sucessfully call `roomSession.join()`.
  */
 export const UNSAFE_PROP_ACCESS = [
   'audioMute',
@@ -40,7 +38,11 @@ export const UNSAFE_PROP_ACCESS = [
   'setSpeakerVolume',
 ]
 
-export const RoomSession = function (roomOptions: CreateRoomObjectOptions) {
+export interface RoomSessionOptions extends UserOptions, MakeRoomOptions {}
+
+export interface RoomSession extends Room {}
+
+export const RoomSession = function (roomOptions: RoomSessionOptions) {
   const {
     audio = true,
     video = true,
@@ -85,7 +87,7 @@ export const RoomSession = function (roomOptions: CreateRoomObjectOptions) {
     return room
   }
 
-  return new Proxy<Room>(room, {
+  return new Proxy<RoomSession>(room, {
     get(target: Room, prop: any, receiver: any) {
       if (prop === 'join') {
         return join
@@ -100,4 +102,4 @@ export const RoomSession = function (roomOptions: CreateRoomObjectOptions) {
       return Reflect.get(target, prop, receiver)
     },
   })
-} as unknown as { new (roomOptions: CreateRoomObjectOptions): Room }
+} as unknown as { new (roomOptions: RoomSessionOptions): RoomSession }

--- a/packages/js/src/RoomSession.ts
+++ b/packages/js/src/RoomSession.ts
@@ -42,6 +42,19 @@ export interface RoomSessionOptions extends UserOptions, MakeRoomOptions {}
 
 export interface RoomSession extends Room {}
 
+/**
+ * @privateRemarks
+ *
+ * The use of a function expression as a contructor instead
+ * of a class was picked because it made a couple things
+ * simpler for this use case.
+ * 1. Making classes behave as factories can be tricky when
+ *    working with TypeScript since it's non trivial to
+ *    switch the type returned by the constructor
+ * 2. It also generates more verbose code (once transpiled)
+ *    if we want to have private fields to store `room` and
+ *    `client`.
+ */
 export const RoomSession = function (roomOptions: RoomSessionOptions) {
   const {
     audio = true,
@@ -100,4 +113,5 @@ export const RoomSession = function (roomOptions: RoomSessionOptions) {
       return Reflect.get(target, prop, receiver)
     },
   })
+  // For consistency with other constructors we'll make TS force the use of `new`
 } as unknown as { new (roomOptions: RoomSessionOptions): RoomSession }

--- a/packages/js/src/RoomSession.ts
+++ b/packages/js/src/RoomSession.ts
@@ -1,0 +1,69 @@
+import { UserOptions, logger } from '@signalwire/core'
+import { createClient } from './createClient'
+import type { MakeRoomOptions } from './Client'
+import type { Room } from './Room'
+
+export interface CreateRoomObjectOptions extends UserOptions, MakeRoomOptions {}
+
+const VIDEO_CONSTRAINTS: MediaTrackConstraints = {
+  aspectRatio: { ideal: 16 / 9 },
+}
+
+export const RoomSession = function (roomOptions: CreateRoomObjectOptions) {
+  const {
+    audio = true,
+    video = true,
+    iceServers,
+    rootElementId,
+    applyLocalVideoOverlay = true,
+    stopCameraWhileMuted = true,
+    stopMicrophoneWhileMuted = true,
+    speakerId,
+    ...userOptions
+  } = roomOptions
+
+  const client = createClient({
+    ...userOptions,
+  })
+
+  const room = client.rooms.makeRoomObject({
+    audio,
+    video: video === true ? VIDEO_CONSTRAINTS : video,
+    negotiateAudio: true,
+    negotiateVideo: true,
+    iceServers,
+    rootElementId,
+    applyLocalVideoOverlay,
+    stopCameraWhileMuted,
+    stopMicrophoneWhileMuted,
+    speakerId,
+  })
+
+  // WebRTC connection left the room.
+  room.once('destroy', () => {
+    client.disconnect()
+  })
+
+  const join = async () => {
+    try {
+      await client.connect()
+      await room.join()
+    } catch (e) {
+      logger.error(e)
+    }
+    return room
+  }
+
+  // TODO: add types
+  return new Proxy<Room>(room, {
+    get(target: any, prop: any, receiver: any) {
+      if (prop === 'join') {
+        return join
+      }
+
+      // TODO: throw errors if the user tries to access certain properties before we're connected.
+
+      return Reflect.get(target, prop, receiver)
+    },
+  })
+} as unknown as { new (roomOptions: CreateRoomObjectOptions): Room }

--- a/packages/js/src/RoomSession.ts
+++ b/packages/js/src/RoomSession.ts
@@ -13,8 +13,7 @@ const VIDEO_CONSTRAINTS: MediaTrackConstraints = {
  * List of properties/methods the user won't be able to use
  * before they sucessfully call `roomSession.join()`.
  */
-const UNSAFE_PROP_ACCESS = [
-  'active',
+export const UNSAFE_PROP_ACCESS = [
   'audioMute',
   'audioUnmute',
   'deaf',
@@ -22,9 +21,7 @@ const UNSAFE_PROP_ACCESS = [
   'getMembers',
   'getRecordings',
   'hideVideoMuted',
-  'join',
   'leave',
-  'memberId',
   'removerMember',
   'restoreOutboundAudio',
   'restoreOutboundVideo',

--- a/packages/js/src/createClient.ts
+++ b/packages/js/src/createClient.ts
@@ -50,7 +50,7 @@ import { JWTSession } from './JWTSession'
  * }
  * ```
  */
-export const createClient = async (userOptions: UserOptions) => {
+export const createClient = (userOptions: UserOptions) => {
   const baseUserOptions = {
     ...userOptions,
     emitter: getEventEmitter<ClientEvents>(),
@@ -68,8 +68,6 @@ export const createClient = async (userOptions: UserOptions) => {
       id: 'onClientSubscribed',
     },
   })(baseUserOptions)
-  if (baseUserOptions.autoConnect) {
-    await client.connect()
-  }
+
   return client
 }

--- a/packages/js/src/createRoomObject.ts
+++ b/packages/js/src/createRoomObject.ts
@@ -33,6 +33,7 @@ const VIDEO_CONSTRAINTS: MediaTrackConstraints = {
  *   console.error('Error', error)
  * }
  * ```
+ * @deprecated Use {@link RoomSession} instead.
  */
 export const createRoomObject = (
   roomOptions: CreateRoomObjectOptions
@@ -51,13 +52,10 @@ export const createRoomObject = (
       ...userOptions
     } = roomOptions
 
-    const client = await createClient({
+    const client = createClient({
       ...userOptions,
-      autoConnect: true,
-    }).catch((error) => {
-      reject(error)
-      return null
     })
+    await client.connect()
 
     if (!client) {
       return

--- a/packages/js/src/joinRoom.ts
+++ b/packages/js/src/joinRoom.ts
@@ -23,6 +23,7 @@ import { CreateRoomObjectOptions, createRoomObject } from './createRoomObject'
  *   console.error('Error', error)
  * }
  * ```
+ * @deprecated Use {@link RoomSession} instead.
  */
 export const joinRoom = (roomOptions: CreateRoomObjectOptions) => {
   return createRoomObject({

--- a/packages/js/src/video.ts
+++ b/packages/js/src/video.ts
@@ -4,8 +4,16 @@ import { MakeRoomOptions } from './Client'
 import { Room } from './Room'
 import { RoomScreenShare } from './RoomScreenShare'
 import { RoomDevice } from './RoomDevice'
+import { RoomSession } from './RoomSession'
 
-export { createRoomObject, joinRoom, Room, RoomScreenShare, RoomDevice }
+export {
+  createRoomObject,
+  joinRoom,
+  Room,
+  RoomScreenShare,
+  RoomDevice,
+  RoomSession,
+}
 
 export type { MakeRoomOptions }
 export type {


### PR DESCRIPTION
The code in this changeset includes:
* `RoomSession` constructor as a replacement for `createRoomObject` and `joinRoom`.
* Updated heroku demo to use the new primitve
* Deprectated `createRoomObject` and `joinRoom`