### PR TITLE
Add ability to define env variables per build mode

### DIFF
--- a/scripts/sw-build/index.js
+++ b/scripts/sw-build/index.js
@@ -83,6 +83,9 @@ const OPTIONS_MAP = {
    */
   '--dev': {
     minify: false,
+    define: {
+      'process.env.NODE_ENV': JSON.stringify('development'),
+    },
     watch: {
       onRebuild(error, result) {
         if (error) console.error('watch build failed:', error)
@@ -144,6 +147,7 @@ const getBuildOptions = ({ flags, pkgJson }) => {
     'process.env.SDK_PKG_NAME': JSON.stringify(pkgJson.name),
     'process.env.SDK_PKG_DESCRIPTION': JSON.stringify(pkgJson.description),
     'process.env.SDK_PKG_AGENT': JSON.stringify(getPackageAgentName(pkgJson)),
+    'process.env.NODE_ENV': JSON.stringify('production'),
   }
 
   /**
@@ -159,10 +163,7 @@ const getBuildOptions = ({ flags, pkgJson }) => {
         process.exit(1)
       }
 
-      return {
-        ...reducer,
-        ...options,
-      }
+      return mergeOptions(reducer, options)
     },
     {
       define: sdkEnvVariables,
@@ -188,19 +189,11 @@ const getBuildOptions = ({ flags, pkgJson }) => {
       )
     }
 
-    return [
-      {
-        ...activeMode,
-        ...commonOptions,
-      },
-    ]
+    return [mergeOptions(activeMode, commonOptions)]
   }
 
   return OPTIONS_MAP[modeFlag].map((opt) => {
-    return {
-      ...opt,
-      ...commonOptions,
-    }
+    return mergeOptions(opt, commonOptions)
   })
 }
 /**
@@ -266,6 +259,16 @@ const buildUmd = async (options) => {
     file: outfile,
     sourcemap: true,
   })
+}
+const mergeOptions = (options, defaultOptions = {}) => {
+  return {
+    ...defaultOptions,
+    ...options,
+    define: {
+      ...defaultOptions.define,
+      ...options.define,
+    },
+  }
 }
 
 /**


### PR DESCRIPTION
The code in this changeset includes the ability to define env variables during build time when executing `sw-build`.

#### (`core`) Before:
<img width="197" alt="ss_2021-10-04 at 12 40 24@2x" src="https://user-images.githubusercontent.com/840935/135837541-583bfd7f-e9bc-4f8c-821d-6872cd81fbcd.png">

#### (`core`) After:
<img width="196" alt="ss_2021-10-04 at 12 40 45@2x" src="https://user-images.githubusercontent.com/840935/135837574-01c9e8c0-2ac9-4a36-8686-fcd933c54747.png">