### PR TITLE
Extending `js` interfaces from `core` contracts

### DIFF
--- a/.changeset/eight-tools-switch.md
+++ b/.changeset/eight-tools-switch.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/js': minor
+---
+
+Added setHideVideoMuted to RoomSession interface.

--- a/.changeset/stale-chairs-accept.md
+++ b/.changeset/stale-chairs-accept.md
@@ -1,0 +1,7 @@
+---
+'@signalwire/core': patch
+'@signalwire/js': patch
+'@signalwire/webrtc': patch
+---
+
+Improved internal typings for the Video namespace.

--- a/packages/core/src/BaseComponent.ts
+++ b/packages/core/src/BaseComponent.ts
@@ -21,7 +21,11 @@ import {
 import { EventEmitter } from './utils/EventEmitter'
 import { SDKState } from './redux/interfaces'
 import { makeCustomSagaAction } from './redux/actions'
-import { OnlyStateProperties, EmitterContract } from './types'
+import {
+  OnlyStateProperties,
+  EmitterContract,
+  BaseComponentContract,
+} from './types'
 
 type EventRegisterHandlers<EventTypes extends EventEmitter.ValidEventTypes> =
   | {
@@ -46,7 +50,7 @@ const identity: ExecuteTransform<any, any> = (payload) => payload
 export class BaseComponent<
   EventTypes extends EventEmitter.ValidEventTypes,
   StateProperties = Record<string, unknown>
-> implements EmitterContract<EventTypes>
+> implements EmitterContract<EventTypes>, BaseComponentContract
 {
   /** @internal */
   private readonly uuid = uuid()

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -43,7 +43,6 @@ export interface BaseConnectionContract<
   remoteStream: MediaStream | undefined
   roomId: string
   roomSessionId: string
-  trying: boolean
   active: boolean
   memberId: string
   updateCamera(constraints: MediaTrackConstraints): Promise<void>

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -29,13 +29,18 @@ export interface EmitterContract<
 export interface BaseConnectionContract<
   EventTypes extends EventEmitter.ValidEventTypes
 > extends EmitterContract<EventTypes> {
-  // TODO: remove this property and move logic into BaseConnection.hangup()
+  cameraId: string | null
+  cameraLabel: string | null
+  localAudioTrack: MediaStreamTrack | null
+  localStream: MediaStream | undefined
+  localVideoTrack: MediaStreamTrack | null
+  microphoneId: string | null
+  microphoneLabel: string | null
+  remoteStream: MediaStream | undefined
+  roomId: string
+  roomSessionId: string
+  trying: boolean
   active: boolean
-  // TODO: remove these
-  stopOutboundAudio: any
-  restoreOutboundAudio: any
-  restoreOutboundVideo: any
-  stopOutboundVideo: any
   memberId: string
 }
 

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -26,6 +26,10 @@ export interface EmitterContract<
   ): EmitterContract<EventTypes>
 }
 
+export interface BaseComponentContract {
+  destroy(): void
+}
+
 export interface BaseConnectionContract<
   EventTypes extends EventEmitter.ValidEventTypes
 > extends EmitterContract<EventTypes> {

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -42,6 +42,8 @@ export interface BaseConnectionContract<
   trying: boolean
   active: boolean
   memberId: string
+  updateCamera(constraints: MediaTrackConstraints): Promise<void>
+  updateMicrophone(constraints: MediaTrackConstraints): Promise<void>
 }
 
 export interface ConsumerContract<

--- a/packages/core/src/types/videoRoomSession.ts
+++ b/packages/core/src/types/videoRoomSession.ts
@@ -61,6 +61,7 @@ export interface VideoRoomSessionContract {
   audioUnmute(params: MemberCommandParams): Rooms.AudioUnmuteMember
   videoMute(params: MemberCommandParams): Rooms.VideoMuteMember
   videoUnmute(params: MemberCommandParams): Rooms.VideoUnmuteMember
+  /** @deprecated Use {@link setInputVolume} instead. */
   setMicrophoneVolume(
     params: MemberCommandWithVolumeParams
   ): Rooms.SetInputVolumeMember

--- a/packages/core/src/types/videoRoomSession.ts
+++ b/packages/core/src/types/videoRoomSession.ts
@@ -74,6 +74,7 @@ export interface VideoRoomSessionContract {
   getMembers(): Rooms.GetMembers
   deaf(params: MemberCommandParams): Rooms.DeafMember
   undeaf(params: MemberCommandParams): Rooms.UndeafMember
+  /** @deprecated Use {@link setOutputVolume} instead. */
   setSpeakerVolume(
     params: MemberCommandWithVolumeParams
   ): Rooms.SetOutputVolumeMember

--- a/packages/js/src/BaseRoomSession.ts
+++ b/packages/js/src/BaseRoomSession.ts
@@ -24,6 +24,7 @@ import type {
   BaseRoomInterface,
   RoomMethods,
   StartScreenShareOptions,
+  RoomSessionConnectionContract,
 } from './utils/interfaces'
 import {
   ROOM_COMPONENT_LISTENERS,
@@ -43,6 +44,7 @@ import {
 
 export interface BaseRoomSession<T>
   extends RoomMethods,
+    RoomSessionConnectionContract,
     BaseConnectionContract<RoomSessionObjectEvents> {
   join(): Promise<T>
   leave(): Promise<void>
@@ -50,7 +52,7 @@ export interface BaseRoomSession<T>
 
 export class RoomSessionConnection
   extends BaseConnection<RoomSessionObjectEvents>
-  implements BaseRoomInterface
+  implements BaseRoomInterface, RoomSessionConnectionContract
 {
   private _screenShareList = new Set<RoomSessionScreenShare>()
   private _deviceList = new Set<RoomSessionDevice>()

--- a/packages/js/src/BaseRoomSession.ts
+++ b/packages/js/src/BaseRoomSession.ts
@@ -339,6 +339,7 @@ export const RoomSessionAPI = extendComponent<
   startRecording: Rooms.startRecording,
   getPlaybacks: Rooms.getPlaybacks,
   play: Rooms.play,
+  setHideVideoMuted: Rooms.setHideVideoMuted,
 })
 
 type RoomSessionObjectEventsHandlerMapping = RoomSessionObjectEvents &

--- a/packages/js/src/BaseRoomSession.ts
+++ b/packages/js/src/BaseRoomSession.ts
@@ -4,6 +4,7 @@ import {
   Rooms,
   EventTransform,
   extendComponent,
+  BaseComponentContract,
   BaseComponentOptions,
   BaseConnectionContract,
   toLocalEvent,
@@ -45,6 +46,7 @@ import {
 export interface BaseRoomSession<T>
   extends RoomMethods,
     RoomSessionConnectionContract,
+    BaseComponentContract,
     BaseConnectionContract<RoomSessionObjectEvents> {
   join(): Promise<T>
   leave(): Promise<void>

--- a/packages/js/src/utils/interfaces.ts
+++ b/packages/js/src/utils/interfaces.ts
@@ -141,9 +141,9 @@ interface RoomMemberSelfMethodsInterface {
  */
 export interface RoomMethods
   extends OnlyFunctionProperties<VideoRoomSessionContract> {
-  /** @deprecated */
+  /** @deprecated Use {@link setVideoMuted} instead */
   hideVideoMuted(): Rooms.HideVideoMuted
-  /** @deprecated */
+  /** @deprecated Use {@link setVideoMuted} instead */
   showVideoMuted(): Rooms.ShowVideoMuted
 }
 

--- a/packages/js/src/utils/interfaces.ts
+++ b/packages/js/src/utils/interfaces.ts
@@ -131,33 +131,6 @@ interface RoomMemberSelfMethodsInterface {
     value: number
   }): Rooms.SetInputSensitivityMember
 }
-interface RoomLayoutMethodsInterface {
-  getLayouts(): Rooms.GetLayouts
-  setLayout(params: { name: string }): Rooms.SetLayout
-}
-
-interface RoomControlMethodsInterface {
-  getMembers(): Rooms.GetMembers
-  deaf(params?: MemberCommandParams): Rooms.DeafMember
-  undeaf(params?: MemberCommandParams): Rooms.UndeafMember
-  setOutputVolume(
-    params: MemberCommandWithVolumeParams
-  ): Rooms.SetOutputVolumeMember
-  /**
-   * @deprecated Use {@link setOutputVolume} instead.
-   * `setSpeakerVolume` will be removed in v4.0.0
-   */
-  setSpeakerVolume(
-    params: MemberCommandWithVolumeParams
-  ): Rooms.SetOutputVolumeMember
-  removeMember(params: Required<MemberCommandParams>): Rooms.RemoveMember
-  hideVideoMuted(): Rooms.HideVideoMuted
-  showVideoMuted(): Rooms.ShowVideoMuted
-  getRecordings(): Rooms.GetRecordings
-  startRecording(): Promise<Rooms.RoomSessionRecording>
-  getPlaybacks(): Rooms.GetPlaybacks
-  play(params: Rooms.PlayParams): Promise<Rooms.RoomSessionPlayback>
-}
 
 interface RoomMemberSelfMethodsInterface
   extends Pick<
@@ -189,6 +162,7 @@ export interface RoomMethods
 export interface RoomSessionConnectionContract {
   screenShareList: RoomSessionScreenShare[]
   deviceList: RoomSessionDevice[]
+  /** @deprecated Use {@link startScreenShare} instead. */
   createScreenShareObject(
     opts?: CreateScreenShareObjectOptions
   ): Promise<RoomSessionScreenShare>

--- a/packages/js/src/utils/interfaces.ts
+++ b/packages/js/src/utils/interfaces.ts
@@ -132,18 +132,6 @@ interface RoomMemberSelfMethodsInterface {
   }): Rooms.SetInputSensitivityMember
 }
 
-interface RoomMemberSelfMethodsInterface
-  extends Pick<
-    OnlyFunctionProperties<VideoRoomSessionContract>,
-    | 'audioMute'
-    | 'audioUnmute'
-    | 'videoMute'
-    | 'videoUnmute'
-    | 'setMicrophoneVolume'
-    | 'setInputVolume'
-    | 'setInputSensitivity'
-  > {}
-
 /**
  * We are using these interfaces in combination of
  * Object.defineProperties() to avoid code duplication and

--- a/packages/js/src/utils/interfaces.ts
+++ b/packages/js/src/utils/interfaces.ts
@@ -19,6 +19,8 @@ import type {
   VideoPlaybackEventNames,
   RoomSessionRecording,
   RoomSessionPlayback,
+  VideoRoomSessionContract,
+  OnlyFunctionProperties,
 } from '@signalwire/core'
 import { INTERNAL_MEMBER_UPDATABLE_PROPS } from '@signalwire/core'
 import type { RoomSession } from '../RoomSession'
@@ -112,26 +114,6 @@ export interface BaseRoomInterface {
   leave(): Promise<unknown>
 }
 
-interface RoomMemberMethodsInterface {
-  audioMute(params?: MemberCommandParams): Rooms.AudioMuteMember
-  audioUnmute(params?: MemberCommandParams): Rooms.AudioUnmuteMember
-  videoMute(params?: MemberCommandParams): Rooms.VideoMuteMember
-  videoUnmute(params?: MemberCommandParams): Rooms.VideoUnmuteMember
-  setInputVolume(
-    params: MemberCommandWithVolumeParams
-  ): Rooms.SetInputVolumeMember
-  /**
-   * @deprecated Use {@link setInputVolume} instead.
-   * `setMicrophoneVolume` will be removed in v4.0.0
-   */
-  setMicrophoneVolume(
-    params: MemberCommandWithVolumeParams
-  ): Rooms.SetInputVolumeMember
-  setInputSensitivity(
-    params: MemberCommandWithValueParams
-  ): Rooms.SetInputSensitivityMember
-}
-
 interface RoomMemberSelfMethodsInterface {
   audioMute(): Rooms.AudioMuteMember
   audioUnmute(): Rooms.AudioUnmuteMember
@@ -147,7 +129,6 @@ interface RoomMemberSelfMethodsInterface {
     value: number
   }): Rooms.SetInputSensitivityMember
 }
-
 interface RoomLayoutMethodsInterface {
   getLayouts(): Rooms.GetLayouts
   setLayout(params: { name: string }): Rooms.SetLayout
@@ -186,9 +167,12 @@ interface RoomControlMethodsInterface {
  * flexibility across different objects.
  */
 export interface RoomMethods
-  extends RoomMemberMethodsInterface,
-    RoomLayoutMethodsInterface,
-    RoomControlMethodsInterface {}
+  extends OnlyFunctionProperties<VideoRoomSessionContract> {
+  /** @deprecated */
+  hideVideoMuted(): Rooms.HideVideoMuted
+  /** @deprecated */
+  showVideoMuted(): Rooms.ShowVideoMuted
+}
 
 export interface RoomSessionDeviceMethods
   extends RoomMemberSelfMethodsInterface {}

--- a/packages/js/src/utils/interfaces.ts
+++ b/packages/js/src/utils/interfaces.ts
@@ -157,6 +157,18 @@ interface RoomControlMethodsInterface {
   play(params: Rooms.PlayParams): Promise<Rooms.RoomSessionPlayback>
 }
 
+interface RoomMemberSelfMethodsInterface
+  extends Pick<
+    OnlyFunctionProperties<VideoRoomSessionContract>,
+    | 'audioMute'
+    | 'audioUnmute'
+    | 'videoMute'
+    | 'videoUnmute'
+    | 'setMicrophoneVolume'
+    | 'setInputVolume'
+    | 'setInputSensitivity'
+  > {}
+
 /**
  * We are using these interfaces in
  * combination of Object.defineProperties()

--- a/packages/js/src/utils/interfaces.ts
+++ b/packages/js/src/utils/interfaces.ts
@@ -24,6 +24,8 @@ import type {
 } from '@signalwire/core'
 import { INTERNAL_MEMBER_UPDATABLE_PROPS } from '@signalwire/core'
 import type { RoomSession } from '../RoomSession'
+import type { RoomSessionDevice } from '../RoomSessionDevice'
+import type { RoomSessionScreenShare } from '../RoomSessionScreenShare'
 
 const INTERNAL_MEMBER_UPDATED_EVENTS = Object.keys(
   INTERNAL_MEMBER_UPDATABLE_PROPS
@@ -170,12 +172,10 @@ interface RoomMemberSelfMethodsInterface
   > {}
 
 /**
- * We are using these interfaces in
- * combination of Object.defineProperties()
- * to avoid code duplication and expose a
- * nice documentation via TypeDoc.
- * The interface forces TS checking
- * while Object.defineProperties allow us
+ * We are using these interfaces in combination of
+ * Object.defineProperties() to avoid code duplication and
+ * expose a nice documentation via TypeDoc. The interface
+ * forces TS checking while Object.defineProperties allow us
  * flexibility across different objects.
  */
 export interface RoomMethods
@@ -184,6 +184,21 @@ export interface RoomMethods
   hideVideoMuted(): Rooms.HideVideoMuted
   /** @deprecated */
   showVideoMuted(): Rooms.ShowVideoMuted
+}
+
+export interface RoomSessionConnectionContract {
+  screenShareList: RoomSessionScreenShare[]
+  deviceList: RoomSessionDevice[]
+  createScreenShareObject(
+    opts?: CreateScreenShareObjectOptions
+  ): Promise<RoomSessionScreenShare>
+  startScreenShare(
+    opts?: StartScreenShareOptions
+  ): Promise<RoomSessionScreenShare>
+  addCamera(opts: AddCameraOptions): Promise<RoomSessionDevice>
+  addMicrophone(opts: AddMicrophoneOptions): Promise<RoomSessionDevice>
+  addDevice(opts: AddDeviceOptions): Promise<RoomSessionDevice>
+  updateSpeaker(opts: { deviceId: string }): Promise<undefined>
 }
 
 export interface RoomSessionDeviceMethods

--- a/packages/webrtc/src/BaseConnection.ts
+++ b/packages/webrtc/src/BaseConnection.ts
@@ -10,6 +10,7 @@ import {
   Rooms,
   JSONRPCRequest,
   EventEmitter,
+  BaseConnectionContract,
 } from '@signalwire/core'
 import RTCPeer from './RTCPeer'
 import { ConnectionOptions } from './utils/interfaces'
@@ -48,7 +49,8 @@ export type BaseConnectionOptions<
 export class BaseConnection<EventTypes extends EventEmitter.ValidEventTypes>
   extends BaseComponent<EventTypes & BaseConnectionStateEventTypes>
   implements
-    Rooms.BaseRoomInterface<EventTypes & BaseConnectionStateEventTypes>
+    Rooms.BaseRoomInterface<EventTypes & BaseConnectionStateEventTypes>,
+    BaseConnectionContract<EventTypes & BaseConnectionStateEventTypes>
 {
   public nodeId = ''
   public direction: 'inbound' | 'outbound'


### PR DESCRIPTION
The code in this changeset includes:

 * `js` now implements `core` contracts for the video namespace.
 * New low level contracts for `BaseConnection` and `BaseComponent`.
