### PR TITLE
Production/Beta release 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3624,6 +3624,25 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/better-path-resolve": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/better-path-resolve/-/better-path-resolve-1.0.0.tgz",
@@ -3641,6 +3660,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
       }
     },
     "node_modules/boxen": {
@@ -3727,6 +3756,29 @@
       "integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
       "dependencies": {
         "node-int64": "^0.4.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/buffer-from": {
@@ -3964,6 +4016,17 @@
         "node": ">=8"
       }
     },
+    "node_modules/cli-spinners": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.6.1.tgz",
+      "integrity": "sha512-x/5fWmGMnbKQAaNwN+UZlV79qBLM9JFnJuJ03gIi5whrob0xV0ofNVHy9DhwGdsMJQc2OKv0oGmLzvaqvAVv+g==",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/cli-truncate": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-2.1.0.tgz",
@@ -4023,7 +4086,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
       "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==",
-      "dev": true,
       "engines": {
         "node": ">= 10"
       }
@@ -5187,7 +5249,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
       "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
-      "dev": true,
       "dependencies": {
         "escape-string-regexp": "^1.0.5"
       },
@@ -5924,6 +5985,25 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/ignore": {
       "version": "5.1.8",
       "license": "MIT",
@@ -6266,6 +6346,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-interactive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
+      "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-module": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
@@ -6330,6 +6418,17 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/is-windows": {
       "version": "1.0.2",
@@ -9355,6 +9454,85 @@
       "resolved": "https://registry.npmjs.org/lodash.startcase/-/lodash.startcase-4.4.0.tgz",
       "integrity": "sha1-lDbjTtJgk+1/+uGTYUQ1CRXZrdg="
     },
+    "node_modules/log-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-symbols/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/log-symbols/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/log-symbols/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/log-symbols/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/log-symbols/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/log-symbols/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/log-update": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/log-update/-/log-update-4.0.0.tgz",
@@ -9942,8 +10120,7 @@
     "node_modules/mute-stream": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
-      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
-      "dev": true
+      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
     },
     "node_modules/nanomatch": {
       "version": "1.2.13",
@@ -10187,6 +10364,111 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/ora": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
+      "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
+      "dependencies": {
+        "bl": "^4.1.0",
+        "chalk": "^4.1.0",
+        "cli-cursor": "^3.1.0",
+        "cli-spinners": "^2.5.0",
+        "is-interactive": "^1.0.0",
+        "is-unicode-supported": "^0.1.0",
+        "log-symbols": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "wcwidth": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ora/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/ora/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/ora/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/ora/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/ora/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ora/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ora/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/os-tmpdir": {
@@ -10779,6 +11061,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/readdirp": {
       "version": "3.5.0",
       "dev": true,
@@ -11176,7 +11471,6 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
       "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
-      "dev": true,
       "engines": {
         "node": ">=0.12.0"
       }
@@ -11872,6 +12166,33 @@
         "events": "^3.3.0"
       }
     },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/string-length": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
@@ -12555,6 +12876,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
     "node_modules/util-inspect": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/util-inspect/-/util-inspect-0.1.8.tgz",
@@ -12968,7 +13294,7 @@
     },
     "packages/core": {
       "name": "@signalwire/core",
-      "version": "3.1.4",
+      "version": "3.2.0",
       "license": "MIT",
       "dependencies": {
         "@reduxjs/toolkit": "^1.6.0",
@@ -12989,11 +13315,11 @@
     },
     "packages/js": {
       "name": "@signalwire/js",
-      "version": "3.3.0",
+      "version": "3.4.0",
       "license": "MIT",
       "dependencies": {
-        "@signalwire/core": "3.1.4",
-        "@signalwire/webrtc": "3.1.4"
+        "@signalwire/core": "3.2.0",
+        "@signalwire/webrtc": "3.1.5"
       },
       "engines": {
         "node": ">=10"
@@ -13016,8 +13342,8 @@
       "version": "0.0.1-beta.4",
       "license": "MIT",
       "dependencies": {
-        "@signalwire/core": "3.1.4",
-        "@signalwire/webrtc": "3.1.4"
+        "@signalwire/core": "3.2.0",
+        "@signalwire/webrtc": "3.1.5"
       },
       "engines": {
         "node": ">=10"
@@ -13025,10 +13351,10 @@
     },
     "packages/realtime-api": {
       "name": "@signalwire/realtime-api",
-      "version": "3.0.0-beta.1",
+      "version": "3.0.0-beta.2",
       "license": "MIT",
       "dependencies": {
-        "@signalwire/core": "3.1.4",
+        "@signalwire/core": "3.2.0",
         "ws": "^8.2.3"
       },
       "devDependencies": {
@@ -13082,7 +13408,7 @@
       "version": "0.0.1-beta.4",
       "license": "MIT",
       "dependencies": {
-        "@signalwire/core": "3.1.4",
+        "@signalwire/core": "3.2.0",
         "node-abort-controller": "^2.0.0",
         "node-fetch": "^2.6.1"
       },
@@ -13097,10 +13423,10 @@
     },
     "packages/webrtc": {
       "name": "@signalwire/webrtc",
-      "version": "3.1.4",
+      "version": "3.1.5",
       "license": "MIT",
       "dependencies": {
-        "@signalwire/core": "3.1.4"
+        "@signalwire/core": "3.2.0"
       },
       "engines": {
         "node": ">=10"
@@ -13270,11 +13596,65 @@
       "dependencies": {
         "@sw-internal/common": "^0.0.0",
         "execa": "^5.1.1",
+        "inquirer": "^8.2.0",
         "listr2": "^3.12.2"
       },
       "bin": {
         "sw-release": "bin/cli.js"
       }
+    },
+    "scripts/sw-release/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "scripts/sw-release/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "scripts/sw-release/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "scripts/sw-release/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "scripts/sw-release/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "scripts/sw-release/node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -13322,6 +13702,46 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "scripts/sw-release/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "scripts/sw-release/node_modules/inquirer": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.0.tgz",
+      "integrity": "sha512-0crLweprevJ02tTuA6ThpoAERAGyVILC4sS74uib58Xf/zSr1/ZWtmm7D5CI+bSQEaA04f0K7idaHpQbSWgiVQ==",
+      "dependencies": {
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.1.1",
+        "cli-cursor": "^3.1.0",
+        "cli-width": "^3.0.0",
+        "external-editor": "^3.0.3",
+        "figures": "^3.0.0",
+        "lodash": "^4.17.21",
+        "mute-stream": "0.0.8",
+        "ora": "^5.4.1",
+        "run-async": "^2.4.0",
+        "rxjs": "^7.2.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "through": "^2.3.6"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "scripts/sw-release/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "scripts/sw-release/node_modules/is-stream": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
@@ -13352,6 +13772,14 @@
         "node": ">=8"
       }
     },
+    "scripts/sw-release/node_modules/rxjs": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.4.0.tgz",
+      "integrity": "sha512-7SQDi7xeTMCJpqViXh8gL/lebcwlp3d831F05+9B44A4B0WfsEwUQHR64gsH1kvJ+Ep/J9K2+n1hVl1CsGN23w==",
+      "dependencies": {
+        "tslib": "~2.1.0"
+      }
+    },
     "scripts/sw-release/node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -13367,6 +13795,41 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "scripts/sw-release/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "scripts/sw-release/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "scripts/sw-release/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
       "engines": {
         "node": ">=8"
       }
@@ -15385,8 +15848,8 @@
     "@signalwire/js": {
       "version": "file:packages/js",
       "requires": {
-        "@signalwire/core": "3.1.4",
-        "@signalwire/webrtc": "3.1.4"
+        "@signalwire/core": "3.2.0",
+        "@signalwire/webrtc": "3.1.5"
       }
     },
     "@signalwire/node": {
@@ -15399,14 +15862,14 @@
     "@signalwire/react-native": {
       "version": "file:packages/react-native",
       "requires": {
-        "@signalwire/core": "3.1.4",
-        "@signalwire/webrtc": "3.1.4"
+        "@signalwire/core": "3.2.0",
+        "@signalwire/webrtc": "3.1.5"
       }
     },
     "@signalwire/realtime-api": {
       "version": "file:packages/realtime-api",
       "requires": {
-        "@signalwire/core": "3.1.4",
+        "@signalwire/core": "3.2.0",
         "@types/ws": "^8.2.0",
         "ts-node": "^10.0.0",
         "ws": "^8.2.3"
@@ -15432,7 +15895,7 @@
     "@signalwire/web-api": {
       "version": "file:packages/web-api",
       "requires": {
-        "@signalwire/core": "3.1.4",
+        "@signalwire/core": "3.2.0",
         "@types/node-fetch": "^2.5.10",
         "msw": "^0.28.2",
         "node-abort-controller": "^2.0.0",
@@ -15443,7 +15906,7 @@
     "@signalwire/webrtc": {
       "version": "file:packages/webrtc",
       "requires": {
-        "@signalwire/core": "3.1.4"
+        "@signalwire/core": "3.2.0"
       }
     },
     "@sindresorhus/is": {
@@ -15576,9 +16039,45 @@
       "requires": {
         "@sw-internal/common": "^0.0.0",
         "execa": "^5.1.1",
+        "inquirer": "^8.2.0",
         "listr2": "^3.12.2"
       },
       "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
         "cross-spawn": {
           "version": "7.0.3",
           "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -15610,6 +16109,37 @@
           "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
           "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg=="
         },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "inquirer": {
+          "version": "8.2.0",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.0.tgz",
+          "integrity": "sha512-0crLweprevJ02tTuA6ThpoAERAGyVILC4sS74uib58Xf/zSr1/ZWtmm7D5CI+bSQEaA04f0K7idaHpQbSWgiVQ==",
+          "requires": {
+            "ansi-escapes": "^4.2.1",
+            "chalk": "^4.1.1",
+            "cli-cursor": "^3.1.0",
+            "cli-width": "^3.0.0",
+            "external-editor": "^3.0.3",
+            "figures": "^3.0.0",
+            "lodash": "^4.17.21",
+            "mute-stream": "0.0.8",
+            "ora": "^5.4.1",
+            "run-async": "^2.4.0",
+            "rxjs": "^7.2.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0",
+            "through": "^2.3.6"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+        },
         "is-stream": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
@@ -15628,6 +16158,14 @@
           "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
           "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
         },
+        "rxjs": {
+          "version": "7.4.0",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.4.0.tgz",
+          "integrity": "sha512-7SQDi7xeTMCJpqViXh8gL/lebcwlp3d831F05+9B44A4B0WfsEwUQHR64gsH1kvJ+Ep/J9K2+n1hVl1CsGN23w==",
+          "requires": {
+            "tslib": "~2.1.0"
+          }
+        },
         "shebang-command": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -15640,6 +16178,32 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
           "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
+        },
+        "string-width": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+          "requires": {
+            "ansi-regex": "^5.0.1"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
         },
         "which": {
           "version": "2.0.2",
@@ -16211,6 +16775,11 @@
         }
       }
     },
+    "base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+    },
     "better-path-resolve": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/better-path-resolve/-/better-path-resolve-1.0.0.tgz",
@@ -16222,6 +16791,16 @@
     "binary-extensions": {
       "version": "2.2.0",
       "dev": true
+    },
+    "bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "requires": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
     },
     "boxen": {
       "version": "1.3.0",
@@ -16285,6 +16864,15 @@
       "integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
       "requires": {
         "node-int64": "^0.4.0"
+      }
+    },
+    "buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "requires": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "buffer-from": {
@@ -16440,6 +17028,11 @@
         "restore-cursor": "^3.1.0"
       }
     },
+    "cli-spinners": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.6.1.tgz",
+      "integrity": "sha512-x/5fWmGMnbKQAaNwN+UZlV79qBLM9JFnJuJ03gIi5whrob0xV0ofNVHy9DhwGdsMJQc2OKv0oGmLzvaqvAVv+g=="
+    },
     "cli-truncate": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-2.1.0.tgz",
@@ -16482,8 +17075,7 @@
     "cli-width": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
-      "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==",
-      "dev": true
+      "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw=="
     },
     "cliui": {
       "version": "6.0.0",
@@ -17278,7 +17870,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
       "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
-      "dev": true,
       "requires": {
         "escape-string-regexp": "^1.0.5"
       }
@@ -17777,6 +18368,11 @@
         "safer-buffer": ">= 2.1.2 < 3"
       }
     },
+    "ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+    },
     "ignore": {
       "version": "5.1.8"
     },
@@ -18010,6 +18606,11 @@
         "is-extglob": "^2.1.1"
       }
     },
+    "is-interactive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
+      "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w=="
+    },
     "is-module": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
@@ -18055,6 +18656,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+    },
+    "is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw=="
     },
     "is-windows": {
       "version": "1.0.2"
@@ -20227,6 +20833,60 @@
       "resolved": "https://registry.npmjs.org/lodash.startcase/-/lodash.startcase-4.4.0.tgz",
       "integrity": "sha1-lDbjTtJgk+1/+uGTYUQ1CRXZrdg="
     },
+    "log-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "requires": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "log-update": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/log-update/-/log-update-4.0.0.tgz",
@@ -20625,8 +21285,7 @@
     "mute-stream": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
-      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
-      "dev": true
+      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -20804,6 +21463,80 @@
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2",
         "word-wrap": "~1.2.3"
+      }
+    },
+    "ora": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
+      "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
+      "requires": {
+        "bl": "^4.1.0",
+        "chalk": "^4.1.0",
+        "cli-cursor": "^3.1.0",
+        "cli-spinners": "^2.5.0",
+        "is-interactive": "^1.0.0",
+        "is-unicode-supported": "^0.1.0",
+        "log-symbols": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "wcwidth": "^1.0.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+          "requires": {
+            "ansi-regex": "^5.0.1"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
       }
     },
     "os-tmpdir": {
@@ -21150,6 +21883,16 @@
         "strip-bom": "^3.0.0"
       }
     },
+    "readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "requires": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      }
+    },
     "readdirp": {
       "version": "3.5.0",
       "dev": true,
@@ -21433,8 +22176,7 @@
     "run-async": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
-      "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
-      "dev": true
+      "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ=="
     },
     "run-parallel": {
       "version": "1.2.0",
@@ -21962,6 +22704,21 @@
         "events": "^3.3.0"
       }
     },
+    "string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "requires": {
+        "safe-buffer": "~5.2.0"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+        }
+      }
+    },
     "string-length": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
@@ -22396,6 +23153,11 @@
     },
     "use": {
       "version": "3.1.1"
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "util-inspect": {
       "version": "0.1.8",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
     "build": "manypkg exec rm -rf dist && sw-build-all",
     "prettier": "prettier --write .",
     "start:web": "concurrently \"manypkg run @signalwire/core start\" \"manypkg run @signalwire/js start\" \"manypkg run @signalwire/webrtc start\" \"manypkg run @signalwire/js example\"",
-    "release:dev": "sw-release --dev"
+    "release:dev": "sw-release --development",
+    "prepare:prod": "sw-release --prepare-prod",
+    "release:prod": "sw-release --production"
   },
   "dependencies": {
     "@babel/core": "^7.14.6",

--- a/packages/realtime-api/package.json
+++ b/packages/realtime-api/package.json
@@ -5,6 +5,7 @@
   "license": "MIT",
   "version": "3.0.0-beta.2",
   "main": "dist/index.node.js",
+  "beta": true,
   "exports": {
     "require": "./dist/index.node.js",
     "default": "./dist/index.node.mjs"

--- a/scripts/sw-common/index.js
+++ b/scripts/sw-common/index.js
@@ -86,10 +86,33 @@ const isCleanGitStatus = async () => {
   return true
 }
 
+const getLatestPublishedVersion = async (packageName, tag = '') => {
+  const status = await execa('npm', ['show', packageName, 'versions'])
+  const allVersions = JSON.parse(status.stdout.replace(/\'/g, '"'))
+
+  if (!tag) {
+    // we'll return only the versions that don't have any
+    // custom tag like `-dev`, `-beta`, etc.
+    const versions = allVersions.filter((v) => v.split('-').length === 1)
+
+    return versions[versions.length - 1]
+  }
+
+  const versions = allVersions
+    .filter((v) => v.split('-').length === 2)
+    .filter((v) => {
+      const parts = v.split('-')
+      return parts[1].startsWith(tag)
+    })
+
+  return versions[versions.length - 1]
+}
+
 export {
   getPackages,
   getChangedPackages,
   getModeFlag,
   getLastGitSha,
+  getLatestPublishedVersion,
   isCleanGitStatus,
 }

--- a/scripts/sw-common/index.js
+++ b/scripts/sw-common/index.js
@@ -29,6 +29,7 @@ const _scan = (pathname, level = 0, acc = []) => {
       }
 
       acc.push({
+        version: pkgJson.version,
         name: pkgJson.name,
         pathname,
       })
@@ -51,6 +52,14 @@ const getPackages = ({ pathname = PACKAGES_PATH } = DEFAULT_OPTIONS) => {
   return pkgDeps
 }
 
+const getChangedPackages = (originalPackages) => {
+  const currentPackages = getPackages()
+
+  return currentPackages.filter((pkg, index) => {
+    return pkg.version !== originalPackages[index].version
+  })
+}
+
 const BUILD_MODES = ['--development', '--production']
 const isModeFlag = (flag) => {
   return BUILD_MODES.includes(flag)
@@ -65,4 +74,4 @@ const getLastGitSha = async (length = 7) => {
   return sha.substring(0, length)
 }
 
-export { getPackages, getModeFlag, getLastGitSha }
+export { getPackages, getChangedPackages, getModeFlag, getLastGitSha }

--- a/scripts/sw-common/index.js
+++ b/scripts/sw-common/index.js
@@ -52,14 +52,6 @@ const getPackages = ({ pathname = PACKAGES_PATH } = DEFAULT_OPTIONS) => {
   return pkgDeps
 }
 
-const getChangedPackages = (originalPackages) => {
-  const currentPackages = getPackages()
-
-  return currentPackages.filter((pkg, index) => {
-    return pkg.version !== originalPackages[index].version
-  })
-}
-
 const BUILD_MODES = ['--development', '--production', '--prepare-prod']
 const isModeFlag = (flag) => {
   return BUILD_MODES.includes(flag)
@@ -86,33 +78,21 @@ const isCleanGitStatus = async () => {
   return true
 }
 
-const getLatestPublishedVersion = async (packageName, tag = '') => {
+const isPackagePublished = async ({ name, version }) => {
+  const packageName = version ? `${name}@${version}` : name
   const status = await execa('npm', ['show', packageName, 'versions'])
-  const allVersions = JSON.parse(status.stdout.replace(/\'/g, '"'))
 
-  if (!tag) {
-    // we'll return only the versions that don't have any
-    // custom tag like `-dev`, `-beta`, etc.
-    const versions = allVersions.filter((v) => v.split('-').length === 1)
-
-    return versions[versions.length - 1]
+  if (status.stdout) {
+    return true
   }
 
-  const versions = allVersions
-    .filter((v) => v.split('-').length === 2)
-    .filter((v) => {
-      const parts = v.split('-')
-      return parts[1].startsWith(tag)
-    })
-
-  return versions[versions.length - 1]
+  return false
 }
 
 export {
   getPackages,
-  getChangedPackages,
   getModeFlag,
   getLastGitSha,
-  getLatestPublishedVersion,
+  isPackagePublished,
   isCleanGitStatus,
 }

--- a/scripts/sw-common/index.js
+++ b/scripts/sw-common/index.js
@@ -135,9 +135,14 @@ const isCleanGitStatus = async ({ executer }) => {
   return true
 }
 
-const isPackagePublished = async ({ name, version, executer }) => {
+const isPackagePublished = async ({ name, version, executer, options }) => {
+  // During `dev` we'll execute the real command since we
+  // have to check if the new version has been published on
+  // npm.
+  const localExecuter = options.includes('dev') ? execa : executer
+
   const packageName = version ? `${name}@${version}` : name
-  const status = await executer(
+  const status = await localExecuter(
     'npm',
     ['show', packageName, 'versions'],
     undefined,

--- a/scripts/sw-common/index.js
+++ b/scripts/sw-common/index.js
@@ -60,7 +60,7 @@ const getChangedPackages = (originalPackages) => {
   })
 }
 
-const BUILD_MODES = ['--development', '--production']
+const BUILD_MODES = ['--development', '--production', '--prepare-prod']
 const isModeFlag = (flag) => {
   return BUILD_MODES.includes(flag)
 }

--- a/scripts/sw-common/index.js
+++ b/scripts/sw-common/index.js
@@ -104,18 +104,19 @@ const isDryRun = (flags) => {
   return getDryRunFlag(flags) ? true : false
 }
 
-const getProductionReleaseType = (flags) => {
+const getReleaseType = (flags) => {
   const flag = getProductionFlag(flags)
 
   if (flag) {
     return {
-      status: true,
       type: flag.includes('prepare-prod') ? 'prepare' : 'publish',
+      mode: 'production',
     }
   }
 
   return {
-    status: false,
+    type: 'publish',
+    mode: 'development',
   }
 }
 
@@ -159,6 +160,6 @@ export {
   getLastGitSha,
   isCleanGitStatus,
   isDryRun,
-  getProductionReleaseType,
+  getReleaseType,
   isPackagePublished,
 }

--- a/scripts/sw-common/index.js
+++ b/scripts/sw-common/index.js
@@ -59,11 +59,23 @@ const isModeFlag = (flag) => {
 const isDryRunFlag = (flag) => {
   return flag === '--dry-run'
 }
+const isProductionModeFlag = (flag) => {
+  return flag === '--production'
+}
+const isPrepareProductionModeFlag = (flag) => {
+  return flag === '--prepare-prod'
+}
 const getModeFlag = (flags = []) => {
   return flags.find((f) => isModeFlag(f))
 }
 const getDryRunFlag = (flags = []) => {
   return flags.find((f) => isDryRunFlag(f))
+}
+// We'll detect if it's either a `prepare` or `release`
+const getProductionFlag = (flags = []) => {
+  return flags.find(
+    (f) => isProductionModeFlag(f) || isPrepareProductionModeFlag(f)
+  )
 }
 
 const getLastGitSha = async ({ executer }) => {
@@ -89,9 +101,22 @@ const getExecuter = ({ flags }) => {
 }
 
 const isDryRun = (flags) => {
-  const isDryRun = getDryRunFlag(flags)
+  return getDryRunFlag(flags) ? true : false
+}
 
-  return isDryRun ? true : false
+const getProductionReleaseType = (flags) => {
+  const flag = getProductionFlag(flags)
+
+  if (flag) {
+    return {
+      status: true,
+      type: flag.includes('prepare-prod') ? 'prepare' : 'publish',
+    }
+  }
+
+  return {
+    status: false,
+  }
 }
 
 const isCleanGitStatus = async ({ executer }) => {
@@ -134,5 +159,6 @@ export {
   getLastGitSha,
   isCleanGitStatus,
   isDryRun,
+  getProductionReleaseType,
   isPackagePublished,
 }

--- a/scripts/sw-common/index.js
+++ b/scripts/sw-common/index.js
@@ -74,4 +74,22 @@ const getLastGitSha = async (length = 7) => {
   return sha.substring(0, length)
 }
 
-export { getPackages, getChangedPackages, getModeFlag, getLastGitSha }
+const isCleanGitStatus = async () => {
+  const status = await execa('git', ['status', '--porcelain'])
+
+  if (status.stdout !== '') {
+    throw new Error(
+      'Git is in a dirty state. Please commit or stash your changes first.'
+    )
+  }
+
+  return true
+}
+
+export {
+  getPackages,
+  getChangedPackages,
+  getModeFlag,
+  getLastGitSha,
+  isCleanGitStatus,
+}

--- a/scripts/sw-release/index.js
+++ b/scripts/sw-release/index.js
@@ -65,17 +65,22 @@ const getBuildTask = ({ dryRun, executer }) => {
   let tasks = []
   return [
     {
-      title: '🏗️  Building all packages...',
-      task: async (_ctx, currentTask) => {
+      title: '🏗️  Build all packages...',
+      task: async (_ctx, task) => {
+        task.title = '🏗️  Building all packages...'
         try {
           tasks.push(
             await executer('npm', ['run', 'build'], {
               cwd: ROOT_DIR,
             })
           )
-          currentTask.title = '🏗️  Build ran successfully!'
+          if (dryRun) {
+            task.title = 'ℹ️  [Dry Run] Build Tasks:'
+          } else {
+            task.title = '🏗️  Build ran successfully!'
+          }
         } catch (e) {
-          currentTask.title = '🛑 Build failed.'
+          task.title = '🛑 Build failed.'
           throw e
         }
       },
@@ -91,8 +96,9 @@ const getTestTask = ({ dryRun, executer }) => {
 
   return [
     {
-      title: '🧪 Running test suites...',
+      title: '🧪 Run test suites...',
       task: (_ctx, task) => {
+        task.title = '🧪 Running test suites...'
         return task.newListr((parentTask) => {
           return packages.map(({ name }, index) => {
             return {
@@ -109,7 +115,11 @@ const getTestTask = ({ dryRun, executer }) => {
 
                 // Updates the `parent`'s task title
                 if (index + 1 === totalPackages) {
-                  parentTask.title = `🧪 Test suites ran successfully!`
+                  if (dryRun) {
+                    parentTask.title = `ℹ️  [Dry Run] Test Tasks:`
+                  } else {
+                    parentTask.title = `🧪 Test suites ran successfully!`
+                  }
                 } else {
                   parentTask.title = `🟢 Ran ${index + 1} of ${
                     packages.length
@@ -220,7 +230,11 @@ const publishTaskFactory = (options) => {
 
                   // Updates the `parent`'s task title
                   if (index + 1 === totalPackages) {
-                    parentTask.title = `🚀 All updated packages have been published!`
+                    if (dryRun) {
+                      parentTask.title = `ℹ️  [Dry Run] Packages to be published:`
+                    } else {
+                      parentTask.title = `🚀 All updated packages have been published!`
+                    }
                   } else {
                     parentTask.title = `🟢 Published ${index + 1} of ${
                       packages.length

--- a/scripts/sw-release/index.js
+++ b/scripts/sw-release/index.js
@@ -184,6 +184,7 @@ const getProductionTasks = () => {
       task: async (_ctx, task) => {
         try {
           await isCleanGitStatus()
+          task.title = '🔍 Git: clean working tree!'
         } catch (e) {
           task.title = `🛑 ${e.message}`
 

--- a/scripts/sw-release/index.js
+++ b/scripts/sw-release/index.js
@@ -144,7 +144,7 @@ const publishTaskFactory = (options) => {
                   // been published in npm then there's no
                   // need to do anything else.
                   if (await isPackagePublished({ name, version, executer })) {
-                    currentTask.title = `Skipped ${name}`
+                    currentTask.title = `Skipped ${name}: version: ${version} is already published on npm.`
                   } else {
                     tasks.push(
                       await executer(
@@ -173,9 +173,9 @@ const publishTaskFactory = (options) => {
                           }
                         )
                       )
-                      taskTitle = `${name}: Published to npm + git tag created.`
+                      taskTitle = `${name}: Published on npm + git tag created.`
                     } else {
-                      taskTitle = name
+                      taskTitle = `${name}: Published on npm.`
                     }
 
                     // If we're in dry-run mode we'll

--- a/scripts/sw-release/index.js
+++ b/scripts/sw-release/index.js
@@ -230,7 +230,7 @@ const getDevelopmentTasks = ({ dryRun, executer }) => {
             task: async () => {
               const devVersion = await getDevVersion()
 
-              await executer(
+              const status = await executer(
                 'npm',
                 ['run', 'changeset', 'pre', 'enter', devVersion],
                 {
@@ -238,7 +238,11 @@ const getDevelopmentTasks = ({ dryRun, executer }) => {
                 }
               )
 
-              task.title = '⚒️  "development" release ready to be published.'
+              if (dryRun) {
+                task.title = `→ ℹ️  [Dry Run] Executed commands: ${status.command}`
+              } else {
+                task.title = '⚒️  "development" release ready to be published.'
+              }
             },
           },
           {

--- a/scripts/sw-release/index.js
+++ b/scripts/sw-release/index.js
@@ -159,7 +159,13 @@ const publishTaskFactory = (options) => {
                       tasks.push(
                         await executer(
                           'git',
-                          ['tag', '-a', `${name}@${version}`],
+                          [
+                            'tag',
+                            '-a',
+                            `${name}@${version}`,
+                            '-m',
+                            `Release ${name}@${version}`,
+                          ],
                           {
                             cwd: pathname,
                           }

--- a/scripts/sw-release/index.js
+++ b/scripts/sw-release/index.js
@@ -195,6 +195,47 @@ const getProductionTasks = () => {
   ]
 }
 
+const getPrepareProductionTasks = () => {
+  return [
+    getBuildTask(),
+    getTestTask(),
+    {
+      title: '⚒️  Preparing "production" release',
+      task: async () => {
+        return execa('npm', ['run', 'changeset', 'version'], {
+          cwd: ROOT_DIR,
+        })
+      },
+    },
+    {
+      title: '📝 Next Steps',
+      task: async (_ctx, task) => {
+        return task.newListr(
+          [
+            {
+              title: '1. Verify/Modify all the affected CHANGELOG.md files',
+              task: () => {},
+            },
+            {
+              title: '2. `git commit -m "<release-message>`',
+              task: () => {},
+            },
+            {
+              title: '3. `npm run release:prod`',
+              task: () => {},
+            },
+          ],
+          {
+            rendererOptions: {
+              collapse: false,
+            },
+          }
+        )
+      },
+    },
+  ]
+}
+
 const getModeTasks = (flags) => {
   const mode = getModeFlag(flags) || '--development'
   // We get a reference of the original packages to detect
@@ -207,6 +248,9 @@ const getModeTasks = (flags) => {
     }
     case '--production': {
       return getProductionTasks({ flags, packages })
+    }
+    case '--prepare-prod': {
+      return getPrepareProductionTasks({ flags, packages })
     }
   }
 }

--- a/scripts/sw-release/index.js
+++ b/scripts/sw-release/index.js
@@ -7,6 +7,7 @@ import {
   getModeFlag,
   getLastGitSha,
   getChangedPackages,
+  isCleanGitStatus,
 } from '@sw-internal/common'
 
 const __filename = fileURLToPath(import.meta.url)
@@ -175,7 +176,22 @@ const getDevelopmentTasks = ({ packages }) => {
 }
 
 const getProductionTasks = () => {
-  return [getBuildTask(), getTestTask()]
+  return [
+    getBuildTask(),
+    getTestTask(),
+    {
+      title: '🔍 Checking Git status',
+      task: async (_ctx, task) => {
+        try {
+          await isCleanGitStatus()
+        } catch (e) {
+          task.title = `🛑 ${e.message}`
+
+          return Promise.reject('')
+        }
+      },
+    },
+  ]
 }
 
 const getModeTasks = (flags) => {

--- a/scripts/sw-release/index.js
+++ b/scripts/sw-release/index.js
@@ -177,8 +177,6 @@ const getDevelopmentTasks = ({ packages }) => {
 
 const getProductionTasks = () => {
   return [
-    getBuildTask(),
-    getTestTask(),
     {
       title: '🔍 Checking Git status',
       task: async (_ctx, task) => {
@@ -192,6 +190,8 @@ const getProductionTasks = () => {
         }
       },
     },
+    getBuildTask(),
+    getTestTask(),
   ]
 }
 

--- a/scripts/sw-release/index.js
+++ b/scripts/sw-release/index.js
@@ -296,10 +296,16 @@ const getPrepareProductionTasks = ({ dryRun, executer }) => {
     ...getTestTask({ executer }),
     {
       title: '⚒️  Preparing "production" release',
-      task: async () => {
-        return executer('npm', ['run', 'changeset', 'version'], {
+      task: async (_ctx, task) => {
+        const status = await executer('npm', ['run', 'changeset', 'version'], {
           cwd: ROOT_DIR,
         })
+
+        if (dryRun) {
+          task.title = `→ ℹ️  [Dry Run] Executed commands: ${status.command}`
+        } else {
+          task.title = '⚒️  "production" release ready to be published.'
+        }
       },
     },
     {

--- a/scripts/sw-release/index.js
+++ b/scripts/sw-release/index.js
@@ -148,7 +148,7 @@ const publishTaskFactory = (options) => {
               // skip the package.
               if (beta && npmTag !== 'beta') {
                 return {
-                  title: `Skipping ${name}: package is in beta`,
+                  title: `Skipped ${name}: package is in beta`,
                   task: () => {},
                 }
               }

--- a/scripts/sw-release/index.js
+++ b/scripts/sw-release/index.js
@@ -11,7 +11,7 @@ import {
   isCleanGitStatus,
   getExecuter,
   isDryRun,
-  getProductionReleaseType,
+  getReleaseType,
 } from '@sw-internal/common'
 
 const __filename = fileURLToPath(import.meta.url)
@@ -360,14 +360,14 @@ const getModeTasks = (flags) => {
 
 const getExtendedFlags = async (flags) => {
   const dryRun = isDryRun(flags)
-  const prodType = getProductionReleaseType(flags)
+  const releaseType = getReleaseType(flags)
 
-  if (prodType.status && !dryRun) {
+  if (!dryRun) {
     const answer = await inquirer.prompt([
       {
         type: 'confirm',
         name: 'continue',
-        message: `**Important**:\nYou're about to ${prodType.type} a production release.\nWould you like to run it in --dry-mode first?`,
+        message: `**Important**:\nYou're about to ${releaseType.type} a ${releaseType.mode} release.\nWould you like to run it in --dry-mode first?`,
         default: true,
       },
     ])

--- a/scripts/sw-release/package.json
+++ b/scripts/sw-release/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@sw-internal/common": "^0.0.0",
     "execa": "^5.1.1",
+    "inquirer": "^8.2.0",
     "listr2": "^3.12.2"
   }
 }


### PR DESCRIPTION
For now all side-effect-like commands are commented so every command is totally safe to run.

### Prod release:
#### 1.  run `npm run prepare:prod`
After running this command you'll have the chance to update all of the affected `CHANGELOG.md` files and verify that everything looks. It's important to note that at this point everything happens locally and nothing will be published to `npm` nor `git`. You'll see a list of next steps after the scripts finishes executing.

##### Example
<img width="475" alt="ss_2021-10-13 at 13 28 24@2x" src="https://user-images.githubusercontent.com/840935/137124351-1c79fb43-16af-4d70-a8f8-a2db62da4554.png">


#### 2.  run `npm run prepare:release`
This is the command that will take care of publishing to both, `npm` and `git` (tag) if required.

##### Example
Example output simulating a change in the `js` package.
<img width="477" alt="ss_2021-10-13 at 13 30 35@2x" src="https://user-images.githubusercontent.com/840935/137124653-6c3fe424-b007-4a95-b45d-6a7744b97c75.png">

### TODO

- [ ] Add `--beta` mode
- [x] Prevent packages in `beta` to be published during `production` mode
- [ ] Uncomment tasks for publishing to npm and git
- [x] Update task titles to better reflect that the CLI is running in `dry-run` mode
- [x] Add a `--dry-run` mode 