### PR TITLE
WIP: Message Namespace

### DIFF
--- a/packages/core/src/BaseComponent.test.ts
+++ b/packages/core/src/BaseComponent.test.ts
@@ -304,9 +304,10 @@ describe('BaseComponent', () => {
       expect(mockInstanceFactoryNotRegistered).toHaveBeenCalledTimes(0)
       expect(mockPayloadTransformNotRegistered).toHaveBeenCalledTimes(0)
 
-      /** 3 transforms because we added the transform `type` too */
+      // FIXME: might need to rollback
+      /** 5 transforms because we added the transform `type` too */
       // @ts-expect-error
-      expect(instance._emitterTransforms.size).toEqual(3)
+      expect(instance._emitterTransforms.size).toEqual(5)
     })
   })
 })

--- a/packages/core/src/BaseComponent.ts
+++ b/packages/core/src/BaseComponent.ts
@@ -691,7 +691,7 @@ export class BaseComponent<
            * When `local !== true` we filter out `Local Events` AND
            * events the user hasn't subscribed to.
            */
-          isLocalEvent(event) || !this.eventNames().includes(internalEvent)
+          isLocalEvent(event)
     ) {
       return
     }

--- a/packages/core/src/BaseSession.ts
+++ b/packages/core/src/BaseSession.ts
@@ -49,6 +49,7 @@ export class BaseSession {
   private _requestQueue: SessionRequestQueued[] = []
   private _socket: WebSocketClient | null = null
   private _host: string = DEFAULT_HOST
+  private _contexts?: string[]
 
   private _executeTimeoutMs = 10 * 1000
   private _executeTimeoutError = Symbol.for('sw-execute-timeout')
@@ -58,9 +59,13 @@ export class BaseSession {
   private _status: SessionStatus = 'unknown'
 
   constructor(public options: SessionOptions) {
-    const { host, logLevel = 'info' } = options
+    const { host, contexts, logLevel = 'info' } = options
     if (host) {
       this._host = checkWebSocketHost(host)
+    }
+
+    if (contexts) {
+      this._contexts = contexts
     }
     if (logLevel) {
       this.logger.setLevel(logLevel)
@@ -75,6 +80,10 @@ export class BaseSession {
 
   get host() {
     return this._host
+  }
+
+  get contexts() {
+    return this._contexts
   }
 
   get rpcConnectResult() {
@@ -217,6 +226,9 @@ export class BaseSession {
         project: this.options.project,
         token: this.options.token,
       },
+    }
+    if (this.contexts) {
+      params.contexts = this.contexts
     }
     if (this._relayProtocolIsValid()) {
       params.protocol = this.relayProtocol

--- a/packages/core/src/redux/features/pubSub/pubSubSaga.ts
+++ b/packages/core/src/redux/features/pubSub/pubSubSaga.ts
@@ -20,6 +20,7 @@ import type {
   VideoRecordingEvent,
   VideoPlaybackEvent,
 } from '../../../types'
+import { MessageAPIEventParams } from '../../../types/message'
 
 type PubSubSagaParams = {
   pubSubChannel: PubSubChannel
@@ -56,6 +57,12 @@ const isVideoPlaybackEvent = (
   return action.type.startsWith('video.playback.')
 }
 
+const isMessageEvent = (
+  action: PubSubAction
+): action is MapToPubSubShape<MessageAPIEventParams> => {
+  return action.type.startsWith('messaging.')
+}
+
 const findNamespaceInPayload = (action: PubSubAction): string => {
   if (action.payload === undefined) {
     return ''
@@ -68,6 +75,8 @@ const findNamespaceInPayload = (action: PubSubAction): string => {
     return action.payload.room_session_id
   } else if (isVideoRoomEvent(action)) {
     return action.payload.room_session.id
+  } else if (isMessageEvent(action)) {
+    return action.payload.tag
   }
 
   if ('development' === process.env.NODE_ENV) {

--- a/packages/core/src/redux/features/pubSub/pubSubSaga.ts
+++ b/packages/core/src/redux/features/pubSub/pubSubSaga.ts
@@ -80,7 +80,7 @@ const findNamespaceInPayload = (action: PubSubAction): string => {
       return action.payload.tag
     } else {
       // FIXME: Temp hack before tag is ready
-      const tag = action.payload.tags?.find(t => t.startsWith('tag:'))
+      const tag = action.payload.tags?.find((t) => t.startsWith('tag:'))
       if (tag) {
         return tag.split(':')[1]
       }

--- a/packages/core/src/redux/features/pubSub/pubSubSaga.ts
+++ b/packages/core/src/redux/features/pubSub/pubSubSaga.ts
@@ -76,7 +76,15 @@ const findNamespaceInPayload = (action: PubSubAction): string => {
   } else if (isVideoRoomEvent(action)) {
     return action.payload.room_session.id
   } else if (isMessageEvent(action)) {
-    return action.payload.tag
+    if (action.payload.tag) {
+      return action.payload.tag
+    } else {
+      // FIXME: Temp hack before tag is ready
+      const tag = action.payload.tags?.find(t => t.startsWith('tag:'))
+      if (tag) {
+        return tag.split(':')[1]
+      }
+    }
   }
 
   if ('development' === process.env.NODE_ENV) {

--- a/packages/core/src/redux/features/session/sessionSaga.ts
+++ b/packages/core/src/redux/features/session/sessionSaga.ts
@@ -296,12 +296,6 @@ export function* sessionChannelWatcher({
 
   function* messageAPIWorker(params: MessageAPIEventParams): SagaIterator {
     switch (params.event_type) {
-      case 'messaging.receive':
-        yield put(pubSubChannel, {
-          type: 'messaging.receive',
-          payload: params.params,
-        })
-        break
       case 'messaging.state':
         yield put(
           componentActions.upsert({
@@ -311,12 +305,12 @@ export function* sessionChannelWatcher({
             segments: params.params.segments,
           })
         )
-        yield put(pubSubChannel, {
-          type: 'messaging.state',
-          payload: params.params,
-        })
         break
     }
+    yield put(pubSubChannel, {
+      type: params.event_type,
+      payload: params.params,
+    })
   }
 
   function* swEventWorker(broadcastParams: SwEventParams) {

--- a/packages/core/src/redux/features/session/sessionSaga.ts
+++ b/packages/core/src/redux/features/session/sessionSaga.ts
@@ -298,7 +298,9 @@ export function* sessionChannelWatcher({
     switch (params.event_type) {
       case 'messaging.state':
         // FIXME: temp hack
-        const id = params.params.tags?.find(t => t.startsWith('uuid:'))!.split(':')[1]!
+        const id = params.params.tags
+          ?.find((t) => t.startsWith('uuid:'))!
+          .split(':')[1]!
         yield put(
           componentActions.upsert({
             id,

--- a/packages/core/src/redux/features/session/sessionSaga.ts
+++ b/packages/core/src/redux/features/session/sessionSaga.ts
@@ -297,10 +297,13 @@ export function* sessionChannelWatcher({
   function* messageAPIWorker(params: MessageAPIEventParams): SagaIterator {
     switch (params.event_type) {
       case 'messaging.state':
+        // FIXME: temp hack
+        const id = params.params.tags?.find(t => t.startsWith('uuid:'))!.split(':')[1]!
         yield put(
           componentActions.upsert({
-            id: params.params.message_id,
-            state: params.params.message_state,
+            id,
+            message_id: params.params.message_id,
+            message_state: params.params.message_state,
             reason: params.params.reason,
             segments: params.params.segments,
           })

--- a/packages/core/src/redux/features/session/sessionSaga.ts
+++ b/packages/core/src/redux/features/session/sessionSaga.ts
@@ -303,12 +303,14 @@ export function* sessionChannelWatcher({
         })
         break
       case 'messaging.state':
-        yield put(componentActions.upsert({
-          id: params.params.message_id,
-          state: params.params.message_state,
-          reason: params.params.reason,
-          segments: params.params.segments,
-        }))
+        yield put(
+          componentActions.upsert({
+            id: params.params.message_id,
+            state: params.params.message_state,
+            reason: params.params.reason,
+            segments: params.params.segments,
+          })
+        )
         yield put(pubSubChannel, {
           type: 'messaging.state',
           payload: params.params,
@@ -330,7 +332,7 @@ export function* sessionChannelWatcher({
       return
     }
 
-    if(isMessageEvent(broadcastParams)) {
+    if (isMessageEvent(broadcastParams)) {
       yield fork(messageAPIWorker, broadcastParams)
       return
     }

--- a/packages/core/src/redux/interfaces.ts
+++ b/packages/core/src/redux/interfaces.ts
@@ -10,6 +10,7 @@ import {
 } from '../utils/interfaces'
 import type { VideoAPIEventParams, InternalVideoAPIEvent } from '../types'
 import { MessageAPIEventParams, MessageStates } from '../types/message'
+import { MessageDirection } from 'packages/core/dist/core/src'
 
 interface SWComponent {
   id: string
@@ -35,9 +36,11 @@ export interface WebRTCCall extends SWComponent {
 }
 
 export interface Message extends SWComponent {
-  state?: MessageStates
+  message_id: string,
+  message_state?: MessageStates
   reason?: string
   segments?: number
+  direction: MessageDirection
 }
 
 export type ReduxComponent = WebRTCCall | Message

--- a/packages/core/src/redux/interfaces.ts
+++ b/packages/core/src/redux/interfaces.ts
@@ -9,7 +9,11 @@ import {
   BaseConnectionState,
 } from '../utils/interfaces'
 import type { VideoAPIEventParams, InternalVideoAPIEvent } from '../types'
-import { MessageAPIEventParams, MessageDirections, MessageStates } from '../types/message'
+import {
+  MessageAPIEventParams,
+  MessageDirections,
+  MessageStates,
+} from '../types/message'
 
 interface SWComponent {
   id: string
@@ -35,7 +39,7 @@ export interface WebRTCCall extends SWComponent {
 }
 
 export interface Message extends SWComponent {
-  message_id: string,
+  message_id: string
   message_state?: MessageStates
   reason?: string
   segments?: number

--- a/packages/core/src/redux/interfaces.ts
+++ b/packages/core/src/redux/interfaces.ts
@@ -9,8 +9,7 @@ import {
   BaseConnectionState,
 } from '../utils/interfaces'
 import type { VideoAPIEventParams, InternalVideoAPIEvent } from '../types'
-import { MessageAPIEventParams, MessageStates } from '../types/message'
-import { MessageDirection } from 'packages/core/dist/core/src'
+import { MessageAPIEventParams, MessageDirections, MessageStates } from '../types/message'
 
 interface SWComponent {
   id: string
@@ -40,7 +39,7 @@ export interface Message extends SWComponent {
   message_state?: MessageStates
   reason?: string
   segments?: number
-  direction: MessageDirection
+  direction: MessageDirections
 }
 
 export type ReduxComponent = WebRTCCall | Message

--- a/packages/core/src/redux/interfaces.ts
+++ b/packages/core/src/redux/interfaces.ts
@@ -9,6 +9,7 @@ import {
   BaseConnectionState,
 } from '../utils/interfaces'
 import type { VideoAPIEventParams, InternalVideoAPIEvent } from '../types'
+import { MessageAPIEventParams, MessageStates } from '../types/message'
 
 interface SWComponent {
   id: string
@@ -34,7 +35,9 @@ export interface WebRTCCall extends SWComponent {
 }
 
 export interface Message extends SWComponent {
-  state?: string
+  state?: MessageStates
+  reason?: string
+  segments?: number
 }
 
 export type ReduxComponent = WebRTCCall | Message
@@ -93,6 +96,7 @@ export type MapToPubSubShape<T> = {
 
 export type PubSubAction =
   | MapToPubSubShape<VideoAPIEventParams | InternalVideoAPIEvent>
+  | MapToPubSubShape<MessageAPIEventParams>
   | {
       type: SessionEvents
       payload: undefined

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -1,6 +1,7 @@
 import type { EventEmitter } from '../utils/EventEmitter'
 import type { VideoAPIEventParams, InternalVideoEventNames } from './video'
 import type { SessionEvents, JSONRPCRequest } from '../utils/interfaces'
+import { MessageAPIEventParams } from './message'
 
 export interface SwEvent {
   event_channel: string
@@ -65,6 +66,7 @@ export interface WebRTCMessageParams extends SwEvent {
 export type SwEventParams =
   | VideoAPIEventParams
   | WebRTCMessageParams
+  | MessageAPIEventParams
 
 // prettier-ignore
 export type PubSubChannelEvents =

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -74,4 +74,5 @@ export type PubSubChannelEvents =
   | SessionEvents
 
 export * from './video'
+export * from './message'
 export * from './utils'

--- a/packages/core/src/types/message.ts
+++ b/packages/core/src/types/message.ts
@@ -92,7 +92,7 @@ export interface MessageContract {
   state?: MessageStates
   direction?: MessageDirections
   reason?: string
-  send(): Promise<void>
+  send(): Promise<MessageContract>
 }
 
 export type MessageEvents = MessageReceiveEvent | MessageStateEvent

--- a/packages/core/src/types/message.ts
+++ b/packages/core/src/types/message.ts
@@ -1,4 +1,4 @@
-import { SwEvent, ToInternalMessageEvent } from "."
+import { SwEvent, ToInternalMessageEvent } from '.'
 
 /**
  * public message event types
@@ -11,17 +11,23 @@ export type MessageState = 'state'
  */
 export type MessageEventNames = MessageReceive | MessageState
 
-
 /**
  * List of internal message events
  * @internal
  */
-export type InternalMessageEventNames = ToInternalMessageEvent<MessageEventNames>
+export type InternalMessageEventNames =
+  ToInternalMessageEvent<MessageEventNames>
 
 /**
  * List of all Message states
  */
-export type MessageStates = 'queued' | 'initiated' | 'sent' | 'delivered' | 'undelievered' | 'failed'
+export type MessageStates =
+  | 'queued'
+  | 'initiated'
+  | 'sent'
+  | 'delivered'
+  | 'undelievered'
+  | 'failed'
 
 /**
  * List of Message direction
@@ -93,4 +99,6 @@ export type MessageEvents = MessageReceiveEvent | MessageStateEvent
 
 export type MessageAPIEventParams = MessageEvents
 
-export type MessageEventParams = MessageReceiveEventParams | MessageStateEventParams
+export type MessageEventParams =
+  | MessageReceiveEventParams
+  | MessageStateEventParams

--- a/packages/core/src/types/message.ts
+++ b/packages/core/src/types/message.ts
@@ -71,7 +71,7 @@ export interface MessageReceiveEventParams {
   from_number: string
   to_number: string
   body?: string
-  media?: string
+  media?: string[]
   segments: number
   message_state: MessageStates
 }
@@ -89,7 +89,7 @@ export interface MessageContract {
   tags?: string[]
   tag: string
   segments: number
-  state?: MessageState
+  state?: MessageStates
   direction?: MessageDirections
   reason?: string
   send(): Promise<void>

--- a/packages/core/src/types/message.ts
+++ b/packages/core/src/types/message.ts
@@ -1,0 +1,96 @@
+import { SwEvent, ToInternalMessageEvent } from "."
+
+/**
+ * public message event types
+ */
+export type MessageReceive = 'receive'
+export type MessageState = 'state'
+
+/**
+ * List of public message events
+ */
+export type MessageEventNames = MessageReceive | MessageState
+
+
+/**
+ * List of internal message events
+ * @internal
+ */
+export type InternalMessageEventNames = ToInternalMessageEvent<MessageEventNames>
+
+/**
+ * List of all Message states
+ */
+export type MessageStates = 'queued' | 'initiated' | 'sent' | 'delivered' | 'undelievered' | 'failed'
+
+/**
+ * List of Message direction
+ */
+export type MessageDirections = 'inbound' | 'outbound'
+/**
+ * ==========
+ * ==========
+ * Server-Side Events
+ * ==========
+ * ==========
+ */
+
+/**
+ * 'messaging.state'
+ */
+export interface MessageStateEvent extends SwEvent {
+  event_type: ToInternalMessageEvent<MessageState>
+  params: MessageStateEventParams
+}
+
+export interface MessageStateEventParams extends MessageReceiveEventParams {
+  reason?: string
+}
+
+/**
+ * 'messaging.receive'
+ */
+
+export interface MessageReceiveEvent extends SwEvent {
+  event_type: ToInternalMessageEvent<MessageReceive>
+  params: MessageReceiveEventParams
+}
+
+export interface MessageReceiveEventParams {
+  message_id: string
+  context: string
+  direction: MessageDirections
+  tags?: string[]
+  tag: string
+  from_number: string
+  to_number: string
+  body?: string
+  media?: string
+  segments: number
+  message_state: MessageStates
+}
+
+/**
+ * Public contract for Message
+ */
+export interface MessageContract {
+  id?: string
+  context: string
+  from: string
+  to: string
+  body?: string
+  media?: string[]
+  tags?: string[]
+  tag: string
+  segments: number
+  state?: MessageState
+  direction?: MessageDirections
+  reason?: string
+  send(): Promise<void>
+}
+
+export type MessageEvents = MessageReceiveEvent | MessageStateEvent
+
+export type MessageAPIEventParams = MessageEvents
+
+export type MessageEventParams = MessageReceiveEventParams | MessageStateEventParams

--- a/packages/core/src/types/utils.ts
+++ b/packages/core/src/types/utils.ts
@@ -123,7 +123,10 @@ export interface MemberCommandWithValueParams extends MemberCommandParams {
   value: number
 }
 
-export type RequireAtLeastOne<T extends object, Keys extends keyof T> = Pick<T, Exclude<keyof T, Keys>>
-  & {
+export type RequireAtLeastOne<T extends object, Keys extends keyof T> = Pick<
+  T,
+  Exclude<keyof T, Keys>
+> &
+  {
     [K in Keys]: Required<Pick<T, K>> & Partial<Pick<T, Exclude<Keys, K>>>
   }[Keys]

--- a/packages/core/src/types/utils.ts
+++ b/packages/core/src/types/utils.ts
@@ -17,6 +17,8 @@ export type EntityUpdated<T> = T & {
 
 export type ToInternalVideoEvent<T extends string> = `video.${T}`
 
+export type ToInternalMessageEvent<T extends string> = `messaging.${T}`
+
 type OnlyFunctionPropertyNames<T> = {
   [K in keyof T]: T[K] extends Function ? K : never
 }[keyof T]

--- a/packages/core/src/types/utils.ts
+++ b/packages/core/src/types/utils.ts
@@ -122,3 +122,8 @@ export interface MemberCommandWithVolumeParams extends MemberCommandParams {
 export interface MemberCommandWithValueParams extends MemberCommandParams {
   value: number
 }
+
+export type RequireAtLeastOne<T extends object, Keys extends keyof T> = Pick<T, Exclude<keyof T, Keys>>
+  & {
+    [K in Keys]: Required<Pick<T, K>> & Partial<Pick<T, Exclude<Keys, K>>>
+  }[Keys]

--- a/packages/core/src/types/videoPlayback.ts
+++ b/packages/core/src/types/videoPlayback.ts
@@ -43,7 +43,7 @@ export interface VideoPlaybackContract {
 
   /** Url of the file reproduced by this playback */
   url: string
-  
+
   /** Audio volume at which the playback file is reproduced */
   volume: number
 

--- a/packages/core/src/utils/constants.ts
+++ b/packages/core/src/utils/constants.ts
@@ -45,6 +45,6 @@ export const INTERNAL_GLOBAL_VIDEO_EVENTS = GLOBAL_VIDEO_EVENTS.map(
  * setnr by the server
  * @internal
  */
-export const INTERNAL_GLOBAL_MESSAGE_EVENTS = GLOBAL_MESSAGE_EVENTS.map(
-  (event) => `${PRODUCT_PREFIX_MESSAGE}.${event}` as const
-)
+export const INTERNAL_GLOBAL_MESSAGE_EVENTS = [
+  `${PRODUCT_PREFIX_MESSAGE}.${GLOBAL_MESSAGE_EVENTS[1]}` as const,
+]

--- a/packages/core/src/utils/constants.ts
+++ b/packages/core/src/utils/constants.ts
@@ -20,9 +20,16 @@ export const LOCAL_EVENT_PREFIX = '__local__'
 
 export const PRODUCT_PREFIX_VIDEO = 'video'
 
+export const PRODUCT_PREFIX_MESSAGE = 'messaging'
+
 export const GLOBAL_VIDEO_EVENTS = ['room.started', 'room.ended'] as const
 
-export const PRODUCT_PREFIXES = [PRODUCT_PREFIX_VIDEO] as const
+export const GLOBAL_MESSAGE_EVENTS = ['receive', 'state'] as const
+
+export const PRODUCT_PREFIXES = [
+  PRODUCT_PREFIX_VIDEO,
+  PRODUCT_PREFIX_MESSAGE,
+] as const
 
 /**
  * For internal usage only. These are the fully qualified event names
@@ -31,4 +38,13 @@ export const PRODUCT_PREFIXES = [PRODUCT_PREFIX_VIDEO] as const
  */
 export const INTERNAL_GLOBAL_VIDEO_EVENTS = GLOBAL_VIDEO_EVENTS.map(
   (event) => `${PRODUCT_PREFIX_VIDEO}.${event}` as const
+)
+
+/**
+ * For internal usage only. These are the fully qualified event names
+ * setnr by the server
+ * @internal
+ */
+export const INTERNAL_GLOBAL_MESSAGE_EVENTS = GLOBAL_MESSAGE_EVENTS.map(
+  (event) => `${PRODUCT_PREFIX_MESSAGE}.${event}` as const
 )

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -4,6 +4,8 @@ import {
   INTERNAL_GLOBAL_VIDEO_EVENTS,
   EVENT_NAMESPACE_DIVIDER,
   LOCAL_EVENT_PREFIX,
+  INTERNAL_GLOBAL_MESSAGE_EVENTS,
+  GLOBAL_MESSAGE_EVENTS,
 } from './constants'
 
 export { v4 as uuid } from 'uuid'
@@ -55,18 +57,24 @@ export const isGlobalEvent = (event: string) => {
 
 /** @internal */
 export const isInternalGlobalEvent = (event: string) => {
-  // @ts-ignore
-  return INTERNAL_GLOBAL_VIDEO_EVENTS.includes(event)
+  return [
+    ...INTERNAL_GLOBAL_VIDEO_EVENTS,
+    ...INTERNAL_GLOBAL_MESSAGE_EVENTS,
+    // @ts-ignore
+  ].includes(event)
 }
 
-export const getGlobalEvents = (kind: 'all' | 'video' = 'all') => {
+export const getGlobalEvents = (kind: 'all' | 'video' | 'message' = 'all') => {
   switch (kind) {
     case 'video':
       return GLOBAL_VIDEO_EVENTS
+    case 'message':
+      return GLOBAL_MESSAGE_EVENTS
     default:
       // prettier-ignore
       return [
         ...GLOBAL_VIDEO_EVENTS,
+        ...GLOBAL_MESSAGE_EVENTS,
       ]
   }
 }

--- a/packages/core/src/utils/interfaces.ts
+++ b/packages/core/src/utils/interfaces.ts
@@ -305,6 +305,7 @@ export type EventTransformType =
   | 'roomSessionLayout'
   | 'roomSessionRecording'
   | 'roomSessionPlayback'
+  | 'message'
 /**
  * `EventTransform`s represent our internal pipeline for
  * creating specific instances for each event handler. This

--- a/packages/core/src/utils/interfaces.ts
+++ b/packages/core/src/utils/interfaces.ts
@@ -2,7 +2,9 @@ import type { EventEmitter } from '../utils/EventEmitter'
 import { BaseSession } from '../BaseSession'
 import { SDKStore } from '../redux'
 import {
+  GLOBAL_MESSAGE_EVENTS,
   GLOBAL_VIDEO_EVENTS,
+  INTERNAL_GLOBAL_MESSAGE_EVENTS,
   INTERNAL_GLOBAL_VIDEO_EVENTS,
   PRODUCT_PREFIXES,
 } from './constants'
@@ -45,6 +47,7 @@ export type JSONRPCMethod =
   | 'video.message'
   | RoomMethod
   | VertoMethod
+  | MessageMethods
 
 export interface JSONRPCRequest {
   jsonrpc: '2.0'
@@ -67,6 +70,8 @@ export interface SessionOptions {
   project?: string
   /** SignalWire project token, e.g. `PT9e5660c101cd140a1c93a0197640a369cf5f16975a0079c9` */
   token: string
+  /** SignalWire relay contexts, e.g. `['default']` */
+  contexts?: string[]
   // From `LogLevelDesc` of loglevel to simplify our docs
   /** logging level */
   logLevel?: 'trace' | 'debug' | 'info' | 'warn' | 'error' | 'silent'
@@ -212,6 +217,11 @@ export type RoomMethod =
   | 'video.playback.stop'
   | 'video.playback.set_volume'
 
+/**
+ * List of all Message methods
+ */
+export type MessageMethods = 'messaging.send'
+
 export interface WebSocketClient {
   addEventListener: WebSocket['addEventListener']
   send: WebSocket['send']
@@ -271,6 +281,13 @@ export type EventsPrefix = '' | typeof PRODUCT_PREFIXES[number]
 export type GlobalVideoEvents = typeof GLOBAL_VIDEO_EVENTS[number]
 export type InternalGlobalVideoEvents =
   typeof INTERNAL_GLOBAL_VIDEO_EVENTS[number]
+
+/**
+ * See {@link GLOBAL_MESSAGE_EVENTS} for the full list of Message events.
+ */
+export type GlobalMessageEvents = typeof GLOBAL_MESSAGE_EVENTS[number]
+export type InternalGlobalMessageEvents =
+  typeof INTERNAL_GLOBAL_MESSAGE_EVENTS[number]
 
 /**
  * NOTE: `EventTransformType` is not tied to a constructor but more on

--- a/packages/realtime-api/examples/ts-vanilla-message/index.ts
+++ b/packages/realtime-api/examples/ts-vanilla-message/index.ts
@@ -1,23 +1,30 @@
 import { createClient } from '@signalwire/realtime-api'
 
 const run = async () => {
-  const client = await createClient({
+  // const client = await createClient({
+  //   project: process.env.PROJECT!,
+  //   token: process.env.TOKEN!,
+  //   contexts: ['default'],
+  //   logLevel: 'debug',
+  // })
+  const client2 = await createClient({
     project: process.env.PROJECT!,
     token: process.env.TOKEN!,
     contexts: ['default'],
-    logLevel: 'debug',
+    logLevel: 'trace',
   })
-  client.message.on('state', (msg) => {
-    console.log(`GLOBAL STATE HANDLER >>>>`)
-    console.log(msg.id)
-    console.log(msg.to)
-    console.log(msg.from)
-    console.log(msg.body)
-    console.log(msg.media)
-    console.log(msg.tags)
-    console.log(msg.state)
-  })
-  client.message.on('receive', (message) => {
+
+  // client.message.on('state', (msg) => {
+  //   console.log(`GLOBAL STATE HANDLER >>>>`)
+  //   console.log(msg.id)
+  //   console.log(msg.to)
+  //   console.log(msg.from)
+  //   console.log(msg.body)
+  //   console.log(msg.media)
+  //   console.log(msg.tags)
+  //   console.log(msg.state)
+  // })
+  client2.message.on('receive', (message) => {
     console.log("GLOBAL MESSAGE RECEIVE HANDLER >>>>>")
     console.log(message.id)
     console.log(message.to)
@@ -27,29 +34,31 @@ const run = async () => {
     console.log(message.tags)
     console.log(message.state)
   })
-  await client.connect()
 
-  const message = new client.message.Message({
-    to: '<PHONE_NUMBER_TO_SEND_MESSAGE_TO>',
-    from: '<PHONE_NUMBER_TO_SEND_MESSAGE_FROM>',
-    body: 'hello there',
-    context: 'default',
-  })
+  await client2.connect()
+  // await client.connect()
 
-  console.log(message.from, message.to)
-  message.on('state', (msg) => {
-    console.log("SCOPED STATE EVENT HANDLER >>>>>")
-    console.log(msg.id)
-    console.log(msg.to)
-    console.log(msg.from)
-    console.log(msg.body)
-    console.log(msg.media)
-    console.log(msg.tags)
-    console.log(msg.state)
-    console.log(msg.context)
-  })
+  // const message = new client.message.Message({
+  //   to: '+66613306106',
+  //   from: '+16509000205',
+  //   body: 'Can you call me back?',
+  //   context: 'default',
+  // })
 
-  await message.send()
+  // console.log(message.from, message.to)
+  // message.on('state', (msg) => {
+  //   console.log("SCOPED STATE EVENT HANDLER >>>>>")
+  //   console.log(msg.id)
+  //   console.log(msg.to)
+  //   console.log(msg.from)
+  //   console.log(msg.body)
+  //   console.log(msg.media)
+  //   console.log(msg.tags)
+  //   console.log(msg.state)
+  //   console.log(msg.context)
+  // })
+
+  // await message.send()
 }
 
 run()

--- a/packages/realtime-api/examples/ts-vanilla-message/index.ts
+++ b/packages/realtime-api/examples/ts-vanilla-message/index.ts
@@ -1,64 +1,46 @@
 import { createClient } from '@signalwire/realtime-api'
 
 const run = async () => {
-  // const client = await createClient({
-  //   project: process.env.PROJECT!,
-  //   token: process.env.TOKEN!,
-  //   contexts: ['default'],
-  //   logLevel: 'debug',
-  // })
-  const client2 = await createClient({
+  const client = await createClient({
     project: process.env.PROJECT!,
     token: process.env.TOKEN!,
     contexts: ['default'],
-    logLevel: 'trace',
+    logLevel: 'debug',
   })
 
-  // client.message.on('state', (msg) => {
-  //   console.log(`GLOBAL STATE HANDLER >>>>`)
-  //   console.log(msg.id)
-  //   console.log(msg.to)
-  //   console.log(msg.from)
-  //   console.log(msg.body)
-  //   console.log(msg.media)
-  //   console.log(msg.tags)
-  //   console.log(msg.state)
-  // })
-  client2.message.on('receive', (message) => {
-    console.log("GLOBAL MESSAGE RECEIVE HANDLER >>>>>")
-    console.log(message.id)
-    console.log(message.to)
-    console.log(message.from)
-    console.log(message.body)
-    console.log(message.media)
-    console.log(message.tags)
-    console.log(message.state)
+  client.message.on('state', (msg) => {
+    console.log(`GLOBAL STATE HANDLER >>>>`)
+    console.log(msg.id)
+    console.log(msg.to)
+    console.log(msg.from)
+    console.log(msg.body)
+    console.log(msg.media)
+    console.log(msg.tags)
+    console.log(msg.state)
+  })
+  await client.connect()
+
+  const message = new client.message.Message({
+    to: '<to_ph_number>',
+    from: '<from_ph_number>',
+    body: 'Hello there',
+    context: 'default',
   })
 
-  await client2.connect()
-  // await client.connect()
+  console.log(message.from, message.to)
+  message.on('state', (msg) => {
+    console.log("SCOPED STATE EVENT HANDLER >>>>>")
+    console.log(msg.id)
+    console.log(msg.to)
+    console.log(msg.from)
+    console.log(msg.body)
+    console.log(msg.media)
+    console.log(msg.tags)
+    console.log(msg.state)
+    console.log(msg.context)
+  })
 
-  // const message = new client.message.Message({
-  //   to: '+66613306106',
-  //   from: '+16509000205',
-  //   body: 'Can you call me back?',
-  //   context: 'default',
-  // })
-
-  // console.log(message.from, message.to)
-  // message.on('state', (msg) => {
-  //   console.log("SCOPED STATE EVENT HANDLER >>>>>")
-  //   console.log(msg.id)
-  //   console.log(msg.to)
-  //   console.log(msg.from)
-  //   console.log(msg.body)
-  //   console.log(msg.media)
-  //   console.log(msg.tags)
-  //   console.log(msg.state)
-  //   console.log(msg.context)
-  // })
-
-  // await message.send()
+  await message.send()
 }
 
 run()

--- a/packages/realtime-api/examples/ts-vanilla-message/index.ts
+++ b/packages/realtime-api/examples/ts-vanilla-message/index.ts
@@ -1,0 +1,59 @@
+import { createClient } from '@signalwire/realtime-api'
+
+const run = async () => {
+  const client = await createClient({
+    project: process.env.PROJECT!,
+    token: process.env.TOKEN!,
+    contexts: ['default'],
+    logLevel: 'debug',
+  })
+  client.message.on('state', (msg) => {
+    console.log(`GLOBAL STATE HANDLER >>>>`)
+    console.log(msg.id)
+    console.log(msg.to)
+    console.log(msg.from)
+    console.log(msg.body)
+    console.log(msg.media)
+    console.log(msg.tags)
+    console.log(msg.state)
+  })
+  client.message.on('receive', (message) => {
+    console.log("GLOBAL MESSAGE RECEIVE HANDLER >>>>>")
+    console.log(message.id)
+    console.log(message.to)
+    console.log(message.from)
+    console.log(message.body)
+    console.log(message.media)
+    console.log(message.tags)
+    console.log(message.state)
+  })
+  await client.connect()
+
+  const message = new client.message.Message({
+    to: '<PHONE_NUMBER_TO_SEND_MESSAGE_TO>',
+    from: '<PHONE_NUMBER_TO_SEND_MESSAGE_FROM>',
+    body: 'hello there',
+    context: 'default',
+  })
+
+  console.log(message.from, message.to)
+  message.on('state', (msg) => {
+    console.log("SCOPED STATE EVENT HANDLER >>>>>")
+    console.log(msg.id)
+    console.log(msg.to)
+    console.log(msg.from)
+    console.log(msg.body)
+    console.log(msg.media)
+    console.log(msg.tags)
+    console.log(msg.state)
+    console.log(msg.context)
+  })
+
+  await message.send()
+}
+
+run()
+  .catch(console.error)
+  .finally(() => {
+    console.log('done')
+  })

--- a/packages/realtime-api/examples/ts-vanilla-message/package-lock.json
+++ b/packages/realtime-api/examples/ts-vanilla-message/package-lock.json
@@ -1,0 +1,12 @@
+{
+  "name": "ts-message",
+  "version": "0.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "ts-message",
+      "version": "0.0.0"
+    }
+  }
+}

--- a/packages/realtime-api/examples/ts-vanilla-message/package.json
+++ b/packages/realtime-api/examples/ts-vanilla-message/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "ts-message",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "node --loader ts-node/esm index.ts"
+  }
+}

--- a/packages/realtime-api/src/createClient.ts
+++ b/packages/realtime-api/src/createClient.ts
@@ -20,7 +20,7 @@ export type { RealtimeClient, ClientEvents }
  * @param userOptions.token SignalWire project token, e.g. `PT9e5660c101cd140a1c93a0197640a369cf5f16975a0079c9`
  * @param userOptions.logLevel logging level
  * @returns an instance of a real-time Client.
- * 
+ *
  * @example
  * ```typescript
  * const client = await createClient({
@@ -32,31 +32,32 @@ export type { RealtimeClient, ClientEvents }
 export const createClient: (userOptions: {
   project?: string
   token: string
+  contexts?: string[]
   logLevel?: 'trace' | 'debug' | 'info' | 'warn' | 'error' | 'silent'
 }) => Promise<RealtimeClient> =
-// Note: types are inlined for clarity of documentation
-async (userOptions) => {
-  const baseUserOptions: InternalUserOptions = {
-    ...userOptions,
-    emitter: getEventEmitter<ClientEvents>(),
+  // Note: types are inlined for clarity of documentation
+  async (userOptions) => {
+    const baseUserOptions: InternalUserOptions = {
+      ...userOptions,
+      emitter: getEventEmitter<ClientEvents>(),
+    }
+    const store = configureStore({
+      userOptions: baseUserOptions,
+      SessionConstructor: Session,
+    })
+
+    const client = connect<ClientEvents, Client, RealtimeClient>({
+      store,
+      Component: Client,
+      componentListeners: {
+        errors: 'onError',
+        responses: 'onSuccess',
+        id: 'onClientSubscribed',
+      },
+      sessionListeners: {
+        authStatus: 'onAuth',
+      },
+    })(baseUserOptions)
+
+    return client
   }
-  const store = configureStore({
-    userOptions: baseUserOptions,
-    SessionConstructor: Session,
-  })
-
-  const client = connect<ClientEvents, Client, RealtimeClient>({
-    store,
-    Component: Client,
-    componentListeners: {
-      errors: 'onError',
-      responses: 'onSuccess',
-      id: 'onClientSubscribed',
-    },
-    sessionListeners: {
-      authStatus: 'onAuth',
-    },
-  })(baseUserOptions)
-
-  return client
-}

--- a/packages/realtime-api/src/index.ts
+++ b/packages/realtime-api/src/index.ts
@@ -7,21 +7,21 @@
  *
  * ```javascript
  * const { createClient } = require('@signalwire/realtime-api')
- * 
+ *
  * createClient({
  *   project: '<project-id>',
  *   token: '<project-token>'
  * }).then((client) => {
  *   client.video.on('room.started', async (roomSession) => {
  *     console.log("Room started")
- *   
+ *
  *     roomSession.on('member.joined', async (member) => {
  *       console.log(member)
  *     })
- *   
+ *
  *     await roomSession.subscribe()
  *   });
- * 
+ *
  *   client.connect()
  * });
  * ```

--- a/packages/realtime-api/src/message/Message.test.ts
+++ b/packages/realtime-api/src/message/Message.test.ts
@@ -1,0 +1,6 @@
+describe('', () => {
+  test('', (done) => {
+    expect(true).toBeTruthy()
+    done()
+  })
+})

--- a/packages/realtime-api/src/message/Message.test.ts
+++ b/packages/realtime-api/src/message/Message.test.ts
@@ -1,6 +1,183 @@
-describe('', () => {
-  test('', (done) => {
-    expect(true).toBeTruthy()
-    done()
+import { actions } from '@signalwire/core'
+import { MessageConstructor } from '.'
+import { configureFullStack } from '../testUtils'
+
+describe('Message', () => {
+  const { store, session, emitter } = configureFullStack()
+  const Message = MessageConstructor({
+    store,
+    // events don't match
+    // @ts-ignore
+    emitter,
+  })
+
+  beforeEach(() => {
+    emitter.removeAllListeners()
+  })
+
+  describe('.send() method', () => {
+    it('should resolve message object', (done) => {
+      const messageDeliveredEvent = JSON.parse(
+        '{"jsonrpc":"2.0","id":"0c0bec13-1e5f-4cf7-9350-71cc5bff9c78","method":"signalwire.event","params":{"event_type":"messaging.state","space_id":"4827f42d-720f-47ef-bbc6-c05625186998","project_id":"75abe29b-c789-4c67-b3c7-c14d7371b5cb","context":"test-context","timestamp":1634448429.889162,"params":{"message_id":"mocked-message-uuid","context":"test-context","direction":"outbound","tags":["tag:mocked-uuid","uuid:mocked-uuid","message","outbound","SMS","test-context","+2222","+1111","relay-client"],"from_number":"+1111","to_number":"+2222","body":"hello there","media":[],"segments":1,"message_state":"delivered"}}}'
+      )
+      const message = new Message({
+        to: '+1111',
+        from: '+2222',
+        body: 'test body',
+        context: 'test-context',
+        tags: ['tag1', 'tag2'],
+        media: ['media/url/1', 'media/url/2'],
+      })
+      // @ts-ignore
+      message.execute = jest.fn().mockResolvedValue({
+        message_id: 'mocked-message-uuid',
+        code: '200',
+        message: 'message accepted',
+      })
+
+      message.send().then((result) => {
+        expect(result).toBe(message)
+        expect(message.execute).toHaveBeenLastCalledWith({
+          method: 'messaging.send',
+          params: {
+            to_number: '+1111',
+            from_number: '+2222',
+            body: 'test body',
+            context: 'test-context',
+            tags: expect.arrayContaining(['tag1', 'tag2']),
+            tag: 'mocked-uuid',
+            media: ['media/url/1', 'media/url/2'],
+          },
+        })
+        done()
+      })
+
+      session.dispatch(actions.socketMessageAction(messageDeliveredEvent))
+    })
+  })
+
+  describe('state event', () => {
+    const queuedEvent = JSON.parse(
+      '{"jsonrpc":"2.0","id":"0c0bec13-1e5f-4cf7-9350-71cc5bff9c78","method":"signalwire.event","params":{"event_type":"messaging.state","space_id":"4827f42d-720f-47ef-bbc6-c05625186998","project_id":"75abe29b-c789-4c67-b3c7-c14d7371b5cb","context":"test-context","timestamp":1634448429.889162,"params":{"message_id":"mocked-message-uuid","context":"test-context","direction":"outbound","tags":["tag:mocked-uuid","uuid:mocked-uuid","message","outbound","SMS","test-context","+2222","+1111","relay-client"],"from_number":"+1111","to_number":"+2222","body":"test message","media":[],"segments":1,"message_state":"queued"}}}'
+    )
+    const sentEvent = JSON.parse(
+      '{"jsonrpc":"2.0","id":"0c0bec13-1e5f-4cf7-9350-71cc5bff9c78","method":"signalwire.event","params":{"event_type":"messaging.state","space_id":"4827f42d-720f-47ef-bbc6-c05625186998","project_id":"75abe29b-c789-4c67-b3c7-c14d7371b5cb","context":"test-context","timestamp":1634448429.889162,"params":{"message_id":"mocked-message-uuid","context":"test-context","direction":"outbound","tags":["tag:mocked-uuid","uuid:mocked-uuid","message","outbound","SMS","test-context","+2222","+1111","relay-client"],"from_number":"+1111","to_number":"+2222","body":"test message","media":[],"segments":1,"message_state":"sent"}}}'
+    )
+    const deliveredEvent = JSON.parse(
+      '{"jsonrpc":"2.0","id":"0c0bec13-1e5f-4cf7-9350-71cc5bff9c78","method":"signalwire.event","params":{"event_type":"messaging.state","space_id":"4827f42d-720f-47ef-bbc6-c05625186998","project_id":"75abe29b-c789-4c67-b3c7-c14d7371b5cb","context":"test-context","timestamp":1634448429.889162,"params":{"message_id":"mocked-message-uuid","context":"test-context","direction":"outbound","tags":["tag:mocked-uuid","uuid:mocked-uuid","message","outbound","SMS","test-context","+2222","+1111","relay-client"],"from_number":"+1111","to_number":"+2222","body":"test message","media":[],"segments":1,"message_state":"delivered"}}}'
+    )
+    const failedEvent = JSON.parse(
+      '{"jsonrpc":"2.0","id":"0c0bec13-1e5f-4cf7-9350-71cc5bff9c78","method":"signalwire.event","params":{"event_type":"messaging.state","space_id":"4827f42d-720f-47ef-bbc6-c05625186998","project_id":"75abe29b-c789-4c67-b3c7-c14d7371b5cb","context":"test-context","timestamp":1634448429.889162,"params":{"message_id":"mocked-message-uuid","context":"test-context","direction":"outbound","tags":["tag:mocked-uuid","uuid:mocked-uuid","message","outbound","SMS","test-context","+2222","+1111","relay-client"],"from_number":"+1111","to_number":"+2222","body":"test message","media":[],"segments":1,"message_state":"failed"}}}'
+    )
+    const undeliveredEvent = JSON.parse(
+      '{"jsonrpc":"2.0","id":"0c0bec13-1e5f-4cf7-9350-71cc5bff9c78","method":"signalwire.event","params":{"event_type":"messaging.state","space_id":"4827f42d-720f-47ef-bbc6-c05625186998","project_id":"75abe29b-c789-4c67-b3c7-c14d7371b5cb","context":"test-context","timestamp":1634448429.889162,"params":{"message_id":"mocked-message-uuid","context":"test-context","direction":"outbound","tags":["tag:mocked-uuid","uuid:mocked-uuid","message","outbound","SMS","test-context","+2222","+1111","relay-client"],"from_number":"+1111","to_number":"+2222","body":"test message","media":[],"segments":1,"message_state":"undelivered"}}}'
+    )
+    it('should receive queued, sent, delivered state events with the message object', (done) => {
+      const message = new Message({
+        to: '+2222',
+        from: '+1111',
+        body: 'test message',
+        context: 'test-context',
+      })
+      const stateEventHandler = jest.fn()
+      message.on('state', stateEventHandler)
+
+      session.dispatch(actions.socketMessageAction(queuedEvent))
+      expect(stateEventHandler).toHaveBeenNthCalledWith(1, message)
+      expect(message.state).toBe('queued')
+
+      session.dispatch(actions.socketMessageAction(sentEvent))
+      expect(stateEventHandler).toHaveBeenNthCalledWith(2, message)
+      expect(message.state).toBe('sent')
+
+      session.dispatch(actions.socketMessageAction(deliveredEvent))
+      expect(stateEventHandler).toHaveBeenNthCalledWith(3, message)
+      expect(message.state).toBe('delivered')
+      done()
+    })
+
+    it('should receive queued, sent, delivered state events with the message object', (done) => {
+      const message = new Message({
+        to: '+2222',
+        from: '+1111',
+        body: 'test message',
+        context: 'test-context',
+      })
+      message.execute = jest.fn().mockResolvedValue({
+        message_id: 'mocked-message-uuid',
+        code: '200',
+        message: 'message accepted',
+      })
+      const stateEventHandler = jest.fn()
+      message.on('state', stateEventHandler)
+      message.send().then(() => {
+        expect(message.execute).toHaveBeenCalledWith({
+          method: 'messaging.send',
+          params: {
+            to_number: '+2222',
+            from_number: '+1111',
+            body: 'test message',
+            context: 'test-context',
+            tag: 'mocked-uuid',
+            tags: expect.anything(),
+          },
+        })
+        done()
+      })
+
+      session.dispatch(actions.socketMessageAction(queuedEvent))
+      expect(stateEventHandler).toHaveBeenNthCalledWith(1, message)
+      expect(message.state).toBe('queued')
+
+      session.dispatch(actions.socketMessageAction(sentEvent))
+      expect(stateEventHandler).toHaveBeenNthCalledWith(2, message)
+      expect(message.state).toBe('sent')
+
+      session.dispatch(actions.socketMessageAction(deliveredEvent))
+      expect(stateEventHandler).toHaveBeenNthCalledWith(3, message)
+      expect(message.state).toBe('delivered')
+    })
+
+    it('should receive queued, failed, undelivered state events with the message object', (done) => {
+      const message = new Message({
+        to: '+2222',
+        from: '+1111',
+        body: 'test message',
+        context: 'test-context',
+      })
+      message.execute = jest.fn().mockResolvedValue({
+        message_id: 'mocked-message-uuid',
+        code: '200',
+        message: 'message accepted',
+      })
+      const stateEventHandler = jest.fn()
+      message.on('state', stateEventHandler)
+      message.send().then(() => {
+        expect(message.execute).toHaveBeenCalledWith({
+          method: 'messaging.send',
+          params: {
+            to_number: '+2222',
+            from_number: '+1111',
+            body: 'test message',
+            context: 'test-context',
+            tag: 'mocked-uuid',
+            tags: expect.anything(),
+          },
+        })
+        done()
+      })
+
+      session.dispatch(actions.socketMessageAction(queuedEvent))
+      expect(stateEventHandler).toHaveBeenNthCalledWith(1, message)
+      expect(message.state).toBe('queued')
+
+      session.dispatch(actions.socketMessageAction(failedEvent))
+      expect(stateEventHandler).toHaveBeenNthCalledWith(2, message)
+      expect(message.state).toBe('failed')
+
+      session.dispatch(actions.socketMessageAction(undeliveredEvent))
+      expect(stateEventHandler).toHaveBeenNthCalledWith(3, message)
+      expect(message.state).toBe('undelivered')
+    })
   })
 })

--- a/packages/realtime-api/src/message/Message.ts
+++ b/packages/realtime-api/src/message/Message.ts
@@ -1,0 +1,324 @@
+import {
+  AssertSameType,
+  BaseComponent,
+  BaseComponentOptions,
+  connect,
+  EventsPrefix,
+  EventTransform,
+  InternalGlobalMessageEvents,
+  MessageContract,
+  MessageStateEventParams,
+  uuid,
+} from '@signalwire/core'
+import { MessageComponentEvents } from '../types'
+
+export interface MessageMain
+  extends BaseComponent<MessageComponentEvents>,
+    MessageContract {
+  /**
+   * FIXME: since Message is not a we don't have `subscirbe` method
+   * which inturn will call the `applyEmitterTransform`
+   * this method serve as a workaround for that
+   * (we may refactor this into a new interface similar to ConsumerContract?)
+   * @internal
+   */
+  _applyEmitterTransforms(): void
+}
+
+export interface MessageDoc extends MessageMain {
+  /**
+   * Send the message
+   *
+   * @return `Promise<void>`
+   *
+   * @example
+   * ```javascript
+   * const message = new client.message.Message({
+   *   context: "default",
+   *   to: "+11111111",
+   *   from: "+22222222",
+   *   body: "Hi there",
+   *   media: ["media/url/1", "media/url/2"],
+   *   tags: ["tag1", "tag2"]
+   * })
+   *
+   * message.on('state', (msg) => {
+   *   // msg === message
+   *   // msg.id
+   *   // msg.state
+   *   // msg.body
+   *   // msg.from
+   *   // msg.to
+   *   // msg.media
+   *   // ms.tags
+   *   // msg.reason if the delivery failed
+   * })
+   *
+   * message.send()
+   *
+   * ```
+   */
+  send(): Promise<void>
+}
+/**
+ * Represnt a message, you can obtain this instance by calling createMessage method
+ * and/or subscribing to `state` and `receive` events on {@link MessageNamespace}
+ *
+ * ### Events
+ * You can use this object to subscribe to following events.
+ *
+ * #### Message events
+ * - `state`
+ *
+ * Emitted when there the message's state changes, your event handler will recive
+ * {@link Message} instance
+ *
+ */
+export interface Message extends AssertSameType<MessageMain, MessageDoc> {}
+
+export type MessageOptions = {
+  to: string
+  context: string
+  from: string
+  body?: string
+  media?: string[]
+  tags?: string[]
+}
+
+type MessageState = Pick<
+  MessageStateEventParams,
+  'message_id' | 'message_state' | 'reason' | 'direction' | 'segments'
+>
+
+type InternalMessageOptions = MessageOptions & Partial<MessageState>
+
+const EVENTS_TO_RESOLVE_PROMISE = ['delivered', 'sent', 'undelivered', 'failed']
+export class MessageComponent
+  extends BaseComponent<MessageComponentEvents>
+  implements Message
+{
+  /**
+   * @internal
+   */
+  protected _eventsPrefix: EventsPrefix = 'messaging'
+  /**
+   * @internal
+   */
+  public tag: string = uuid()
+
+  /**
+   * @internal
+   */
+  private _messageOptions?: InternalMessageOptions
+
+  /**
+   * @internal
+   */
+  private _resolve?: () => void
+
+  /**
+   * @internal
+   */
+  setOptions(options: MessageOptions) {
+    this._messageOptions = { ...this.options, ...options }
+  }
+
+  /**
+   * @internal
+   */
+  setState(state: MessageState) {
+    // @ts-expect-error
+    this._messageOptions = { ...this.options, ...state }
+  }
+
+  get id() {
+    return this._messageOptions!.message_id!
+  }
+
+  get direction() {
+    return this._messageOptions!.direction!
+  }
+
+  get tags() {
+    return this._messageOptions!.tags!
+  }
+
+  get to() {
+    return this._messageOptions!.to!
+  }
+
+  get from() {
+    return this._messageOptions!.from!
+  }
+
+  get body() {
+    return this._messageOptions!.body
+  }
+
+  get media() {
+    return this._messageOptions!.media
+  }
+
+  get segments() {
+    return this._messageOptions!.segments!
+  }
+
+  get state() {
+    return this._messageOptions!.message_state!
+  }
+
+  get context() {
+    return this._messageOptions!.context
+  }
+
+  _applyEmitterTransforms() {
+    this.applyEmitterTransforms()
+    // this._attachListeners(this.tag)
+  }
+
+  /**
+   * @internal
+   */
+  onStateChange(state: MessageState) {
+    this.setState({
+      message_id: state.message_id,
+      message_state: state.message_state,
+      reason: state.reason,
+      direction: state.direction,
+      segments: state.segments,
+    })
+    if (EVENTS_TO_RESOLVE_PROMISE.includes(this.state) && this._resolve) {
+      this._resolve()
+      this._resolve = undefined
+    }
+  }
+
+  send() {
+    const {
+      to: to_number,
+      from: from_number,
+      body,
+      tags,
+      media,
+      context,
+    } = this._messageOptions!
+    // FIXME: temporary hack to invoke component listener from redux
+    // until backend is ready to accept `tag`
+    // we might not need to generate new uuid for tag,
+    // we could just __uuid as the tag(?)
+    const modTags = (tags ?? []).concat(
+      `tag:${this.tag}`,
+      `uuid:${this.__uuid}`
+    )
+    const params = {
+      context,
+      to_number,
+      from_number,
+      body,
+      media,
+      tags: modTags,
+      tag: this.tag,
+    }
+    this.execute({
+      method: 'messaging.send',
+      params,
+    })
+    return new Promise<void>((resolve) => {
+      this._resolve = resolve
+    })
+  }
+
+  protected getEmitterTransforms() {
+    return new Map<InternalGlobalMessageEvents, EventTransform>([
+      [
+        'messaging.state',
+        {
+          type: 'message',
+          instanceFactory: () => {
+            return this
+          },
+          payloadTransform: (payload: any) => {
+            const {
+              to_number: to,
+              from_number: from,
+              message_id: id,
+              message_state: state,
+              ...rest
+            } = payload
+            return {
+              to,
+              from,
+              id,
+              state,
+              ...rest,
+            }
+          },
+        },
+      ],
+    ])
+  }
+}
+
+export type CreateMessageOptions =
+  BaseComponentOptions<MessageComponentEvents> & MessageOptions
+
+export const createMessage = (options: CreateMessageOptions): Message => {
+  const { to, from, context, body, media, tags, ...componentOptions } = options
+  const message = connect<
+    MessageComponentEvents,
+    // @ts-ignore
+    MessageComponent,
+    MessageComponent
+  >({
+    store: componentOptions.store,
+    Component: MessageComponent,
+    componentListeners: {
+      message_state: 'onStateChange',
+    },
+    sessionListeners: {
+      // authStatus: 'onAuthStatusChange'
+    },
+  })(componentOptions)
+
+  message.setOptions({
+    context,
+    to,
+    from,
+    body,
+    media,
+    tags,
+  })
+  // return message
+  const proxy = new Proxy<Message>(message, {
+    get: (target: any, prop: any, receiver: any) => {
+      if (prop === '_eventsNamespace') {
+        return message.tag
+      }
+      return Reflect.get(target, prop, receiver)
+    },
+  })
+  return proxy
+}
+/**
+ * @internal
+ */
+export type MessageConstructorType = {
+  new (options: MessageOptions): Message
+}
+
+/**
+ * @internal
+ */
+export const MessageConstructor = (
+  options: BaseComponentOptions<MessageComponentEvents>
+) => {
+  return function (messageOptions: MessageOptions): Message {
+    const message = createMessage({
+      ...options,
+      ...messageOptions,
+    })
+    // FIXME: find better place to call _applyEmitterTransforms
+    message._applyEmitterTransforms()
+    return message
+  } as unknown as MessageConstructorType
+}

--- a/packages/realtime-api/src/message/Message.ts
+++ b/packages/realtime-api/src/message/Message.ts
@@ -58,7 +58,7 @@ export interface MessageDoc extends MessageMain {
    *
    * ```
    */
-  send(): Promise<void>
+  send(): Promise<MessageContract>
 }
 /**
  * Represnt a message, you can obtain this instance by calling createMessage method
@@ -92,7 +92,7 @@ type MessageState = Pick<
 
 type InternalMessageOptions = MessageOptions & Partial<MessageState>
 
-const EVENTS_TO_RESOLVE_PROMISE = ['delivered', 'sent', 'undelivered', 'failed']
+const EVENTS_TO_RESOLVE_PROMISE = ['delivered', 'undelivered']
 export class MessageComponent
   extends BaseComponent<MessageComponentEvents>
   implements Message
@@ -193,7 +193,7 @@ export class MessageComponent
     }
   }
 
-  send() {
+  async send() {
     const {
       to: to_number,
       from: from_number,
@@ -223,9 +223,10 @@ export class MessageComponent
       method: 'messaging.send',
       params,
     })
-    return new Promise<void>((resolve) => {
+    await new Promise<void>((resolve) => {
       this._resolve = resolve
     })
+    return this
   }
 
   protected getEmitterTransforms() {

--- a/packages/realtime-api/src/message/MessageNamespace.test.ts
+++ b/packages/realtime-api/src/message/MessageNamespace.test.ts
@@ -1,0 +1,6 @@
+describe('', () => {
+  test('', (done) => {
+    expect(true).toBeTruthy()
+    done()
+  })
+})

--- a/packages/realtime-api/src/message/MessageNamespace.test.ts
+++ b/packages/realtime-api/src/message/MessageNamespace.test.ts
@@ -1,6 +1,136 @@
-describe('', () => {
-  test('', (done) => {
-    expect(true).toBeTruthy()
-    done()
+import { actions } from '@signalwire/core'
+import { createMessageNamespace, MessageComponent } from '.'
+import { configureFullStack } from '../testUtils'
+
+describe('MessageNamespace', () => {
+  const { store, session, emitter } = configureFullStack()
+  const messageNamespace = createMessageNamespace({
+    store,
+    // @ts-ignore
+    emitter,
+  })
+
+  beforeEach(() => {
+    emitter.removeAllListeners()
+    messageNamespace.removeAllListeners()
+  })
+
+  describe('Message constructor', () => {
+    it('should have Message constructor property', () => {
+      expect(messageNamespace.Message).toBeDefined()
+      const message = new messageNamespace.Message({
+        to: '+2222',
+        from: '+1111',
+        body: 'test message',
+        context: 'test-context',
+      })
+      expect(message).toBeInstanceOf(MessageComponent)
+      expect(message.to).toBe('+2222')
+      expect(message.from).toBe('+1111')
+      expect(message.body).toBe('test message')
+      expect(message.context).toBe('test-context')
+    })
+  })
+
+  describe('events', () => {
+    describe('state event', () => {
+      const queuedEvent = JSON.parse(
+        '{"jsonrpc":"2.0","id":"0c0bec13-1e5f-4cf7-9350-71cc5bff9c78","method":"signalwire.event","params":{"event_type":"messaging.state","space_id":"4827f42d-720f-47ef-bbc6-c05625186998","project_id":"75abe29b-c789-4c67-b3c7-c14d7371b5cb","context":"test-context","timestamp":1634448429.889162,"params":{"message_id":"mocked-message-uuid","context":"test-context","direction":"outbound","tags":["tag:mocked-uuid","uuid:mocked-uuid","message","outbound","SMS","test-context","+2222","+1111","relay-client"],"from_number":"+1111","to_number":"+2222","body":"test message","media":[],"segments":1,"message_state":"queued"}}}'
+      )
+      const sentEvent = JSON.parse(
+        '{"jsonrpc":"2.0","id":"0c0bec13-1e5f-4cf7-9350-71cc5bff9c78","method":"signalwire.event","params":{"event_type":"messaging.state","space_id":"4827f42d-720f-47ef-bbc6-c05625186998","project_id":"75abe29b-c789-4c67-b3c7-c14d7371b5cb","context":"test-context","timestamp":1634448429.889162,"params":{"message_id":"mocked-message-uuid","context":"test-context","direction":"outbound","tags":["tag:mocked-uuid","uuid:mocked-uuid","message","outbound","SMS","test-context","+2222","+1111","relay-client"],"from_number":"+1111","to_number":"+2222","body":"test message","media":[],"segments":1,"message_state":"sent"}}}'
+      )
+      const deliveredEvent = JSON.parse(
+        '{"jsonrpc":"2.0","id":"0c0bec13-1e5f-4cf7-9350-71cc5bff9c78","method":"signalwire.event","params":{"event_type":"messaging.state","space_id":"4827f42d-720f-47ef-bbc6-c05625186998","project_id":"75abe29b-c789-4c67-b3c7-c14d7371b5cb","context":"test-context","timestamp":1634448429.889162,"params":{"message_id":"mocked-message-uuid","context":"test-context","direction":"outbound","tags":["tag:mocked-uuid","uuid:mocked-uuid","message","outbound","SMS","test-context","+2222","+1111","relay-client"],"from_number":"+1111","to_number":"+2222","body":"test message","media":[],"segments":1,"message_state":"delivered"}}}'
+      )
+      const failedEvent = JSON.parse(
+        '{"jsonrpc":"2.0","id":"0c0bec13-1e5f-4cf7-9350-71cc5bff9c78","method":"signalwire.event","params":{"event_type":"messaging.state","space_id":"4827f42d-720f-47ef-bbc6-c05625186998","project_id":"75abe29b-c789-4c67-b3c7-c14d7371b5cb","context":"test-context","timestamp":1634448429.889162,"params":{"message_id":"mocked-message-uuid","context":"test-context","direction":"outbound","tags":["tag:mocked-uuid","uuid:mocked-uuid","message","outbound","SMS","test-context","+2222","+1111","relay-client"],"from_number":"+1111","to_number":"+2222","body":"test message","media":[],"segments":1,"message_state":"failed"}}}'
+      )
+      const undeliveredEvent = JSON.parse(
+        '{"jsonrpc":"2.0","id":"0c0bec13-1e5f-4cf7-9350-71cc5bff9c78","method":"signalwire.event","params":{"event_type":"messaging.state","space_id":"4827f42d-720f-47ef-bbc6-c05625186998","project_id":"75abe29b-c789-4c67-b3c7-c14d7371b5cb","context":"test-context","timestamp":1634448429.889162,"params":{"message_id":"mocked-message-uuid","context":"test-context","direction":"outbound","tags":["tag:mocked-uuid","uuid:mocked-uuid","message","outbound","SMS","test-context","+2222","+1111","relay-client"],"from_number":"+1111","to_number":"+2222","body":"test message","media":[],"segments":1,"message_state":"undelivered"}}}'
+      )
+      it('should receive state event for messages with state: "queue", and message object', (done) => {
+        messageNamespace.on('state', (message) => {
+          expect(message.id).toBe('mocked-message-uuid')
+          expect(message.to).toBe('+2222')
+          expect(message.from).toBe('+1111')
+          expect(message.body).toBe('test message')
+          expect(message.state).toBe('queued')
+          expect(message.context).toBe('test-context')
+          done()
+        })
+        session.dispatch(actions.socketMessageAction(queuedEvent))
+      })
+
+      it('should receive state event for messages with state: "sent", and message object',(done) => {
+        messageNamespace.on('state', (message) => {
+          expect(message.id).toBe('mocked-message-uuid')
+          expect(message.to).toBe('+2222')
+          expect(message.from).toBe('+1111')
+          expect(message.body).toBe('test message')
+          expect(message.state).toBe('sent')
+          expect(message.context).toBe('test-context')
+          done()
+        })
+        session.dispatch(actions.socketMessageAction(sentEvent))
+      })
+
+      it('should receive state event for messages with state: "delivered", and message object', (done) => {
+        messageNamespace.on('state', (message) => {
+          expect(message.id).toBe('mocked-message-uuid')
+          expect(message.to).toBe('+2222')
+          expect(message.from).toBe('+1111')
+          expect(message.body).toBe('test message')
+          expect(message.state).toBe('delivered')
+          expect(message.context).toBe('test-context')
+          done()
+        })
+        session.dispatch(actions.socketMessageAction(deliveredEvent))
+      })
+
+      it('should receive state event for messages with state: "failed", and message object', (done) => {
+        messageNamespace.on('state', (message) => {
+          expect(message.id).toBe('mocked-message-uuid')
+          expect(message.to).toBe('+2222')
+          expect(message.from).toBe('+1111')
+          expect(message.body).toBe('test message')
+          expect(message.state).toBe('failed')
+          expect(message.context).toBe('test-context')
+          done()
+        })
+        session.dispatch(actions.socketMessageAction(failedEvent))
+      })
+
+      it('should receive state event for messages with state: "undelivered", and message object', (done) => {
+        messageNamespace.on('state', (message) => {
+          expect(message.id).toBe('mocked-message-uuid')
+          expect(message.to).toBe('+2222')
+          expect(message.from).toBe('+1111')
+          expect(message.body).toBe('test message')
+          expect(message.state).toBe('undelivered')
+          expect(message.context).toBe('test-context')
+          done()
+        })
+        session.dispatch(actions.socketMessageAction(undeliveredEvent))
+      })
+    })
+
+    describe('receive event', () => {
+      const receiveEvent = JSON.parse(
+        '{"jsonrpc":"2.0","id":"50536846-f664-4060-bdd4-301cf95e54f3","method":"signalwire.event","params":{"event_type":"messaging.receive","space_id":"4827f42d-720f-47ef-bbc6-c05625186998","project_id":"75abe29b-c789-4c67-b3c7-c14d7371b5cb","context":"test-context","timestamp":1634450988.1005094,"params":{"message_id":"mocked-message-uuid","context":"test-context","direction":"inbound","tags":["message","inbound","SMS","default","+2222","+1111","relay-client"],"from_number":"+1111","to_number":"+2222","body":"test message","media":null,"segments":1,"message_state":"received"}}}'
+      )
+      it('should receive "receive" events with message object', (done) => {
+        messageNamespace.on('receive', (message) => {
+          expect(message.id).toBe('mocked-message-uuid')
+          expect(message.to).toBe('+2222')
+          expect(message.from).toBe('+1111')
+          expect(message.body).toBe('test message')
+          expect(message.state).toBe('received')
+          expect(message.context).toBe('test-context')
+          done()
+        })
+        session.dispatch(actions.socketMessageAction(receiveEvent))
+      })
+    })
   })
 })

--- a/packages/realtime-api/src/message/MessageNamespace.ts
+++ b/packages/realtime-api/src/message/MessageNamespace.ts
@@ -1,0 +1,114 @@
+import {
+  BaseComponent,
+  BaseComponentOptions,
+  connect,
+  EventsPrefix,
+  EventTransform,
+  InternalGlobalMessageEvents,
+  MessageStateEventParams,
+  SessionState,
+} from '@signalwire/core'
+import { RelayMessageAPIEvents } from '../types'
+import { MessageComponent, MessageConstructor } from './Message'
+
+export class MessageNamespace extends BaseComponent<RelayMessageAPIEvents> {
+  protected _eventsPrefix: EventsPrefix = 'messaging'
+
+  constructor(options: BaseComponentOptions<RelayMessageAPIEvents>) {
+    super(options)
+    this._attachListeners('')
+    this.applyEmitterTransforms()
+  }
+
+  get Message() {
+    return MessageConstructor({
+      store: this.options.store,
+      // Emitter is now typed but we share it across objects
+      // so types won't match
+      // @ts-expect-error
+      emitter: this.options.emitter,
+    })
+  }
+
+  onAuthStatusChange(session: SessionState) {
+    if (session.authStatus === 'authorized') {
+      this._attachListeners('')
+      this.applyEmitterTransforms()
+    }
+  }
+
+  protected getEmitterTransforms() {
+    return new Map<
+      InternalGlobalMessageEvents | InternalGlobalMessageEvents[],
+      EventTransform
+    >([
+      [
+        ['messaging.receive', 'messaging.state'],
+        {
+          type: 'message',
+          instanceFactory: (payload: MessageStateEventParams) => {
+            const {
+              from_number: from,
+              to_number: to,
+              body,
+              media,
+              tags,
+              tag,
+              context,
+              message_id,
+              message_state,
+              direction,
+              segments,
+              reason,
+            } = payload
+            const message = new this.Message({
+              from,
+              to,
+              body,
+              media,
+              tags,
+              context,
+            }) as MessageComponent
+            message.tag = tag
+            message.setState({
+              message_id,
+              message_state,
+              direction,
+              segments,
+              reason,
+            })
+            return message
+          },
+          payloadTransform: ({
+            message_id: id,
+            message_state: state,
+            from_number: from,
+            to_number: to,
+            ...rest
+          }: MessageStateEventParams) => {
+            return { to, from, state, id, ...rest }
+          },
+        },
+      ],
+    ])
+  }
+}
+
+export const createMessageNamespace = (
+  options: BaseComponentOptions<RelayMessageAPIEvents>
+): MessageNamespace => {
+  const msgNamespace = connect<
+    RelayMessageAPIEvents,
+    MessageNamespace,
+    MessageNamespace
+  >({
+    store: options.store,
+    Component: MessageNamespace,
+    componentListeners: {},
+    sessionListeners: {
+      authStatus: 'onAuthStatusChange',
+    },
+  })(options)
+
+  return msgNamespace
+}

--- a/packages/realtime-api/src/message/MessageNamespace.ts
+++ b/packages/realtime-api/src/message/MessageNamespace.ts
@@ -4,7 +4,6 @@ import {
   connect,
   EventsPrefix,
   EventTransform,
-  InternalGlobalMessageEvents,
   MessageStateEventParams,
   SessionState,
 } from '@signalwire/core'
@@ -38,10 +37,7 @@ export class MessageNamespace extends BaseComponent<RelayMessageAPIEvents> {
   }
 
   protected getEmitterTransforms() {
-    return new Map<
-      InternalGlobalMessageEvents | InternalGlobalMessageEvents[],
-      EventTransform
-    >([
+    return new Map<string | string[], EventTransform>([
       [
         ['messaging.receive', 'messaging.state'],
         {

--- a/packages/realtime-api/src/message/index.ts
+++ b/packages/realtime-api/src/message/index.ts
@@ -1,0 +1,2 @@
+export * from './Message'
+export * from './MessageNamespace'

--- a/packages/realtime-api/src/setupTests.ts
+++ b/packages/realtime-api/src/setupTests.ts
@@ -1,3 +1,10 @@
+jest.mock('uuid', () => {
+  return {
+    ...(jest.requireActual('uuid') as any),
+    v4: () => 'mocked-uuid',
+  }
+})
+
 jest.mock('@signalwire/core', () => {
   return {
     ...(jest.requireActual('@signalwire/core') as any),

--- a/packages/realtime-api/src/types/index.ts
+++ b/packages/realtime-api/src/types/index.ts
@@ -1,1 +1,2 @@
 export * from './video'
+export * from './message'

--- a/packages/realtime-api/src/types/message.ts
+++ b/packages/realtime-api/src/types/message.ts
@@ -1,0 +1,22 @@
+import { GlobalMessageEvents, MessageState } from '@signalwire/core'
+import { Message } from '../message/Message'
+
+export type MessageEventHandler = (message: Message) => void
+
+export type RelayMessageAPIEventHandlerMappings = Record<
+  GlobalMessageEvents,
+  MessageEventHandler
+>
+
+export type RelayMessageAPIEvents = {
+  [K in keyof RelayMessageAPIEventHandlerMappings]: RelayMessageAPIEventHandlerMappings[K]
+}
+
+export type MessageComponentEventHanlderMappings = Record<
+  Extract<GlobalMessageEvents, MessageState>,
+  MessageEventHandler
+>
+
+export type MessageComponentEvents = {
+  [K in keyof MessageComponentEventHanlderMappings]: MessageComponentEventHanlderMappings[K]
+}

--- a/packages/realtime-api/typedoc.md.js
+++ b/packages/realtime-api/typedoc.md.js
@@ -11,5 +11,5 @@ module.exports = {
   plugin: ['@signalwire/typedoc-readme-api-theme'],
   pageSlugPrefix: 'rt-',
   entryDocument: 'rt-exports.md',
-  entryTitle: 'Realtime API'
+  entryTitle: 'Realtime API',
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,6 +24,7 @@
       "@signalwire/core": ["packages/core/src"],
       "@signalwire/webrtc": ["packages/webrtc/src"],
       "@signalwire/node": ["packages/node/src"],
+      "@signalwire/realtime-api": ["packages/realtime-api/src"],
     },
     "composite": true,
     "declarationMap": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,7 +23,8 @@
       "@signalwire/js": ["packages/js/src"],
       "@signalwire/core": ["packages/core/src"],
       "@signalwire/webrtc": ["packages/webrtc/src"],
-      "@signalwire/node": ["packages/node/src"]
+      "@signalwire/node": ["packages/node/src"],
+      "@signalwire/realtime-api": ["packages/realtime-api/src"],
     },
     "composite": true,
     "declarationMap": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,7 +24,6 @@
       "@signalwire/core": ["packages/core/src"],
       "@signalwire/webrtc": ["packages/webrtc/src"],
       "@signalwire/node": ["packages/node/src"],
-      "@signalwire/realtime-api": ["packages/realtime-api/src"],
     },
     "composite": true,
     "declarationMap": true,


### PR DESCRIPTION
@edolix I still need to write some tests, but otherwise the functionalities are done. cloud you please review the code? The differences between Consumer and Component make it a bit hard to decide where to call `applyEmitterTransforms`  but for now I have a work around for that, also in the `BaseComponent`'s `_setEmitterTransform` i removed the check `!this.eventNames().include(internalEvent)` since I need emitter transform to be able to call before adding event listener on Message object. It would be great to have some feedback from you. Thanks.