### PR TITLE
Allow to attach/detach Sagas to a BaseComponent

### DIFF
--- a/packages/core/src/BaseComponent.ts
+++ b/packages/core/src/BaseComponent.ts
@@ -767,5 +767,6 @@ export class BaseComponent<
     this._runningWorkers.forEach((task) => {
       task.cancel()
     })
+    this._runningWorkers = []
   }
 }

--- a/packages/core/src/BaseConsumer.ts
+++ b/packages/core/src/BaseConsumer.ts
@@ -46,6 +46,7 @@ export class BaseConsumer<
 
         try {
           this.applyEmitterTransforms()
+          this.attachCustomSagas()
           await this.execute(execParams)
         } catch (error) {
           return reject(error)

--- a/packages/core/src/BaseConsumer.ts
+++ b/packages/core/src/BaseConsumer.ts
@@ -46,7 +46,7 @@ export class BaseConsumer<
 
         try {
           this.applyEmitterTransforms()
-          this.attachCustomSagas()
+          this.attachWorkers()
           await this.execute(execParams)
         } catch (error) {
           return reject(error)

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -51,6 +51,7 @@ export type {
   CustomSaga,
 } from './redux/interfaces'
 export * as actions from './redux/actions'
+export * as sagaHelpers from './redux/utils/sagaHelpers'
 export * as sagaEffects from 'redux-saga/effects'
 export type { SagaIterator, Task, Saga } from '@redux-saga/types'
 export * as Rooms from './rooms'

--- a/packages/core/src/redux/features/session/sessionSaga.test.ts
+++ b/packages/core/src/redux/features/session/sessionSaga.test.ts
@@ -61,7 +61,7 @@ describe('sessionChannelWatcher', () => {
         })
         .run()
         .finally(() => {
-          expect(dispatchedActions).toHaveLength(3)
+          expect(dispatchedActions).toHaveLength(4)
         })
     })
 
@@ -117,7 +117,7 @@ describe('sessionChannelWatcher', () => {
         })
         .run()
         .finally(() => {
-          expect(dispatchedActions).toHaveLength(3)
+          expect(dispatchedActions).toHaveLength(4)
         })
     })
 
@@ -173,7 +173,7 @@ describe('sessionChannelWatcher', () => {
         })
         .run()
         .finally(() => {
-          expect(dispatchedActions).toHaveLength(3)
+          expect(dispatchedActions).toHaveLength(4)
         })
     })
 
@@ -229,7 +229,7 @@ describe('sessionChannelWatcher', () => {
         })
         .run()
         .finally(() => {
-          expect(dispatchedActions).toHaveLength(3)
+          expect(dispatchedActions).toHaveLength(4)
         })
     })
 
@@ -277,7 +277,7 @@ describe('sessionChannelWatcher', () => {
         })
         .run()
         .finally(() => {
-          expect(dispatchedActions).toHaveLength(1)
+          expect(dispatchedActions).toHaveLength(2)
         })
     })
 
@@ -322,7 +322,7 @@ describe('sessionChannelWatcher', () => {
         })
         .run()
         .finally(() => {
-          expect(dispatchedActions).toHaveLength(1)
+          expect(dispatchedActions).toHaveLength(2)
         })
     })
 
@@ -393,7 +393,7 @@ describe('sessionChannelWatcher', () => {
         })
         .run()
         .finally(() => {
-          expect(dispatchedActions).toHaveLength(2)
+          expect(dispatchedActions).toHaveLength(3)
         })
     })
   })
@@ -453,7 +453,7 @@ describe('sessionChannelWatcher', () => {
           )
           .run()
           .finally(() => {
-            expect(dispatchedActions).toHaveLength(2)
+            expect(dispatchedActions).toHaveLength(3)
           })
       })
     })
@@ -511,7 +511,7 @@ describe('sessionChannelWatcher', () => {
           )
           .run()
           .finally(() => {
-            expect(dispatchedActions).toHaveLength(2)
+            expect(dispatchedActions).toHaveLength(3)
           })
       })
 
@@ -568,7 +568,7 @@ describe('sessionChannelWatcher', () => {
           )
           .run()
           .finally(() => {
-            expect(dispatchedActions).toHaveLength(2)
+            expect(dispatchedActions).toHaveLength(3)
           })
       })
     })
@@ -629,7 +629,7 @@ describe('sessionChannelWatcher', () => {
           )
           .run()
           .finally(() => {
-            expect(dispatchedActions).toHaveLength(2)
+            expect(dispatchedActions).toHaveLength(3)
           })
       })
     })
@@ -680,7 +680,7 @@ describe('sessionChannelWatcher', () => {
           )
           .run()
           .finally(() => {
-            expect(dispatchedActions).toHaveLength(1)
+            expect(dispatchedActions).toHaveLength(2)
           })
       })
     })
@@ -771,7 +771,7 @@ describe('sessionChannelWatcher', () => {
           )
           .run()
           .finally(() => {
-            expect(dispatchedActions).toHaveLength(1)
+            expect(dispatchedActions).toHaveLength(2)
           })
       })
 
@@ -826,7 +826,7 @@ describe('sessionChannelWatcher', () => {
           )
           .run()
           .finally(() => {
-            expect(dispatchedActions).toHaveLength(1)
+            expect(dispatchedActions).toHaveLength(2)
           })
       })
     })

--- a/packages/core/src/redux/features/session/sessionSaga.test.ts
+++ b/packages/core/src/redux/features/session/sessionSaga.test.ts
@@ -61,7 +61,7 @@ describe('sessionChannelWatcher', () => {
         })
         .run()
         .finally(() => {
-          expect(dispatchedActions).toHaveLength(4)
+          expect(dispatchedActions).toHaveLength(3)
         })
     })
 
@@ -117,7 +117,7 @@ describe('sessionChannelWatcher', () => {
         })
         .run()
         .finally(() => {
-          expect(dispatchedActions).toHaveLength(4)
+          expect(dispatchedActions).toHaveLength(3)
         })
     })
 
@@ -173,7 +173,7 @@ describe('sessionChannelWatcher', () => {
         })
         .run()
         .finally(() => {
-          expect(dispatchedActions).toHaveLength(4)
+          expect(dispatchedActions).toHaveLength(3)
         })
     })
 
@@ -229,7 +229,7 @@ describe('sessionChannelWatcher', () => {
         })
         .run()
         .finally(() => {
-          expect(dispatchedActions).toHaveLength(4)
+          expect(dispatchedActions).toHaveLength(3)
         })
     })
 
@@ -277,7 +277,7 @@ describe('sessionChannelWatcher', () => {
         })
         .run()
         .finally(() => {
-          expect(dispatchedActions).toHaveLength(2)
+          expect(dispatchedActions).toHaveLength(1)
         })
     })
 
@@ -322,7 +322,7 @@ describe('sessionChannelWatcher', () => {
         })
         .run()
         .finally(() => {
-          expect(dispatchedActions).toHaveLength(2)
+          expect(dispatchedActions).toHaveLength(1)
         })
     })
 
@@ -393,7 +393,7 @@ describe('sessionChannelWatcher', () => {
         })
         .run()
         .finally(() => {
-          expect(dispatchedActions).toHaveLength(3)
+          expect(dispatchedActions).toHaveLength(2)
         })
     })
   })
@@ -453,7 +453,7 @@ describe('sessionChannelWatcher', () => {
           )
           .run()
           .finally(() => {
-            expect(dispatchedActions).toHaveLength(3)
+            expect(dispatchedActions).toHaveLength(2)
           })
       })
     })
@@ -511,7 +511,7 @@ describe('sessionChannelWatcher', () => {
           )
           .run()
           .finally(() => {
-            expect(dispatchedActions).toHaveLength(3)
+            expect(dispatchedActions).toHaveLength(2)
           })
       })
 
@@ -568,7 +568,7 @@ describe('sessionChannelWatcher', () => {
           )
           .run()
           .finally(() => {
-            expect(dispatchedActions).toHaveLength(3)
+            expect(dispatchedActions).toHaveLength(2)
           })
       })
     })
@@ -629,7 +629,7 @@ describe('sessionChannelWatcher', () => {
           )
           .run()
           .finally(() => {
-            expect(dispatchedActions).toHaveLength(3)
+            expect(dispatchedActions).toHaveLength(2)
           })
       })
     })
@@ -680,7 +680,7 @@ describe('sessionChannelWatcher', () => {
           )
           .run()
           .finally(() => {
-            expect(dispatchedActions).toHaveLength(2)
+            expect(dispatchedActions).toHaveLength(1)
           })
       })
     })
@@ -771,7 +771,7 @@ describe('sessionChannelWatcher', () => {
           )
           .run()
           .finally(() => {
-            expect(dispatchedActions).toHaveLength(2)
+            expect(dispatchedActions).toHaveLength(1)
           })
       })
 
@@ -826,7 +826,7 @@ describe('sessionChannelWatcher', () => {
           )
           .run()
           .finally(() => {
-            expect(dispatchedActions).toHaveLength(2)
+            expect(dispatchedActions).toHaveLength(1)
           })
       })
     })

--- a/packages/core/src/redux/features/session/sessionSaga.ts
+++ b/packages/core/src/redux/features/session/sessionSaga.ts
@@ -341,8 +341,9 @@ export function* sessionChannelWatcher({
      * Put actions with `event_type` to trigger all the children sagas
      * This should replace all the isWebrtcEvent/isVideoEvent guards below
      * since we'll move that logic on a separate package.
+     * TODO: commented for now since it's no-op
      */
-    yield put({ type: broadcastParams.event_type, payload: broadcastParams })
+    // yield put({ type: broadcastParams.event_type, payload: broadcastParams })
 
     if (isWebrtcEvent(broadcastParams)) {
       yield fork(vertoWorker, {

--- a/packages/core/src/redux/features/session/sessionSaga.ts
+++ b/packages/core/src/redux/features/session/sessionSaga.ts
@@ -337,6 +337,13 @@ export function* sessionChannelWatcher({
   }
 
   function* swEventWorker(broadcastParams: SwEventParams) {
+    /**
+     * Put actions with `event_type` to trigger all the children sagas
+     * This should replace all the isWebrtcEvent/isVideoEvent guards below
+     * since we'll move that logic on a separate package.
+     */
+    yield put({ type: broadcastParams.event_type, payload: broadcastParams })
+
     if (isWebrtcEvent(broadcastParams)) {
       yield fork(vertoWorker, {
         jsonrpc: broadcastParams.params,

--- a/packages/core/src/redux/index.ts
+++ b/packages/core/src/redux/index.ts
@@ -52,3 +52,4 @@ const configureStore = (options: ConfigureStoreOptions) => {
 
 export { connect, configureStore }
 export * from './actions'
+export * from './utils/sagaHelpers'

--- a/packages/core/src/redux/rootSaga.ts
+++ b/packages/core/src/redux/rootSaga.ts
@@ -58,17 +58,17 @@ export function* initSessionSaga(
   const pubSubChannel: PubSubChannel = yield call(channel)
 
   /**
-   * Start all the custom sagas on startup
+   * Start all the custom workers on startup
    */
   let customTasks: Task[] = []
-  if (userOptions.customSagas?.length) {
+  if (userOptions.customWorkers?.length) {
     try {
-      const effects = userOptions.customSagas.map((saga) => {
+      const effects = userOptions.customWorkers.map((saga) => {
         return call(createRestartableSaga(saga))
       })
       customTasks = yield all(effects)
     } catch (error) {
-      logger.error('Error running custom sagas', error)
+      logger.error('Error running custom workers', error)
     }
   }
 

--- a/packages/core/src/redux/rootSaga.ts
+++ b/packages/core/src/redux/rootSaga.ts
@@ -61,9 +61,9 @@ export function* initSessionSaga(
    * Start all the custom workers on startup
    */
   let customTasks: Task[] = []
-  if (userOptions.customWorkers?.length) {
+  if (userOptions.workers?.length) {
     try {
-      const effects = userOptions.customWorkers.map((saga) => {
+      const effects = userOptions.workers.map((saga) => {
         return call(createRestartableSaga(saga))
       })
       customTasks = yield all(effects)

--- a/packages/core/src/redux/rootSaga.ts
+++ b/packages/core/src/redux/rootSaga.ts
@@ -1,7 +1,8 @@
 import { Task, SagaIterator } from '@redux-saga/types'
 import { channel, EventChannel } from 'redux-saga'
-import { fork, call, take, put, delay } from 'redux-saga/effects'
+import { fork, call, take, put, delay, all } from 'redux-saga/effects'
 import { SessionConstructor, InternalUserOptions } from '../utils/interfaces'
+import { logger } from '../utils'
 import { BaseSession } from '../BaseSession'
 import {
   executeActionWatcher,
@@ -30,6 +31,7 @@ import {
 } from './actions'
 import { AuthError } from '../CustomErrors'
 import { PubSubChannel } from './interfaces'
+import { createRestartableSaga } from './utils/sagaHelpers'
 
 interface StartSagaOptions {
   session: BaseSession
@@ -55,6 +57,21 @@ export function* initSessionSaga(
    */
   const pubSubChannel: PubSubChannel = yield call(channel)
 
+  /**
+   * Start all the custom sagas on startup
+   */
+  let customTasks: Task[] = []
+  if (userOptions.customSagas?.length) {
+    try {
+      const effects = userOptions.customSagas.map((saga) => {
+        return call(createRestartableSaga(saga))
+      })
+      customTasks = yield all(effects)
+    } catch (error) {
+      logger.error('Error running custom sagas', error)
+    }
+  }
+
   yield fork(sessionChannelWatcher, {
     session,
     sessionChannel,
@@ -76,6 +93,7 @@ export function* initSessionSaga(
   yield take(destroyAction.type)
   pubSubChannel.close()
   sessionChannel.close()
+  customTasks.forEach((task) => task.cancel())
 }
 
 export function* socketClosedWorker({

--- a/packages/core/src/redux/utils/sagaHelpers.ts
+++ b/packages/core/src/redux/utils/sagaHelpers.ts
@@ -1,0 +1,29 @@
+import { call, spawn } from '@redux-saga/core/effects'
+import { logger } from '../../utils'
+
+export const createRestartableSaga = (saga: any) => {
+  return function* () {
+    spawn(function* () {
+      while (true) {
+        try {
+          logger.debug('Run a restartable saga')
+          yield call(saga)
+          logger.debug('One of the restartable saga has ended. Restarting..')
+        } catch (error) {
+          logger.error('Restartable Saga Error', error)
+        }
+      }
+    })
+  }
+}
+
+export const createCatchableSaga = (saga: any) => {
+  return function* () {
+    try {
+      logger.debug('Run a catchable saga')
+      yield call(saga)
+    } catch (error) {
+      logger.error('Catchable Saga Error', error)
+    }
+  }
+}

--- a/packages/core/src/redux/utils/sagaHelpers.ts
+++ b/packages/core/src/redux/utils/sagaHelpers.ts
@@ -1,4 +1,4 @@
-import { call, spawn } from '@redux-saga/core/effects'
+import { call, spawn } from 'redux-saga/effects'
 import { logger } from '../../utils'
 
 export const createRestartableSaga = (saga: any) => {

--- a/packages/core/src/utils/interfaces.ts
+++ b/packages/core/src/utils/interfaces.ts
@@ -84,7 +84,7 @@ export interface InternalUserOptions extends UserOptions {
    * emitter should be allowed to handle
    */
   emitter: EventEmitter<any>
-  customWorkers?: SDKWorker[]
+  workers?: SDKWorker[]
 }
 
 /**

--- a/packages/core/src/utils/interfaces.ts
+++ b/packages/core/src/utils/interfaces.ts
@@ -75,6 +75,8 @@ export interface SessionOptions {
 export interface UserOptions extends SessionOptions {
   /** @internal */
   devTools?: boolean
+  /** @internal */
+  customSagas?: any[] // FIXME: typings and maybe rename (?)
 }
 
 export interface InternalUserOptions extends UserOptions {

--- a/packages/core/src/utils/interfaces.ts
+++ b/packages/core/src/utils/interfaces.ts
@@ -1,3 +1,4 @@
+import type { SagaIterator } from '@redux-saga/types'
 import type { EventEmitter } from '../utils/EventEmitter'
 import { BaseSession } from '../BaseSession'
 import { SDKStore } from '../redux'
@@ -75,8 +76,6 @@ export interface SessionOptions {
 export interface UserOptions extends SessionOptions {
   /** @internal */
   devTools?: boolean
-  /** @internal */
-  customSagas?: any[] // FIXME: typings and maybe rename (?)
 }
 
 export interface InternalUserOptions extends UserOptions {
@@ -85,6 +84,7 @@ export interface InternalUserOptions extends UserOptions {
    * emitter should be allowed to handle
    */
   emitter: EventEmitter<any>
+  customWorkers?: SDKWorker[]
 }
 
 /**
@@ -358,3 +358,7 @@ export interface EventTransform {
 }
 
 export type BaseEventHandler = (...args: any[]) => void
+
+// TODO: Add worker params
+export interface SDKWorkerParams {}
+export type SDKWorker = (params?: SDKWorkerParams) => SagaIterator<any>

--- a/packages/core/src/utils/logger.ts
+++ b/packages/core/src/utils/logger.ts
@@ -17,6 +17,7 @@ logger.methodFactory = (methodName, logLevel, loggerName) => {
 }
 
 const level =
+  // @ts-ignore
   'development' === process.env.NODE_ENV
     ? logger.levels.DEBUG
     : logger.getLevel()

--- a/packages/js/src/BaseRoomSession.ts
+++ b/packages/js/src/BaseRoomSession.ts
@@ -80,8 +80,8 @@ export class RoomSessionConnection
   }
 
   /** @internal */
-  protected getCustomSagas() {
-    return new Map([['video', { saga: videoWorker }]])
+  protected override getWorkers() {
+    return new Map([['video', { worker: videoWorker }]])
   }
 
   /** @internal */

--- a/packages/js/src/BaseRoomSession.ts
+++ b/packages/js/src/BaseRoomSession.ts
@@ -9,6 +9,8 @@ import {
   BaseConnectionContract,
   toLocalEvent,
   toExternalJSON,
+  sagaEffects,
+  SagaIterator,
 } from '@signalwire/core'
 import {
   getDisplayMedia,
@@ -43,6 +45,16 @@ import {
   RoomSessionDevice,
 } from './RoomSessionDevice'
 
+// TODO: Remove before merge
+export function* videoWorker(): SagaIterator {
+  while (true) {
+    const action = yield sagaEffects.take((action: any) =>
+      action.type.startsWith('video.')
+    )
+    console.debug('>>> videoWorker', action)
+  }
+}
+
 export interface BaseRoomSession<T>
   extends RoomMethods,
     RoomSessionConnectionContract,
@@ -65,6 +77,11 @@ export class RoomSessionConnection
 
   get deviceList() {
     return Array.from(this._deviceList)
+  }
+
+  /** @internal */
+  protected getCustomSagas() {
+    return new Map([['video', { saga: videoWorker }]])
   }
 
   /** @internal */

--- a/packages/js/src/BaseRoomSession.ts
+++ b/packages/js/src/BaseRoomSession.ts
@@ -45,16 +45,6 @@ import {
   RoomSessionDevice,
 } from './RoomSessionDevice'
 
-// TODO: Remove before merge
-export function* videoWorker(): SagaIterator {
-  while (true) {
-    const action = yield sagaEffects.take((action: any) =>
-      action.type.startsWith('video.')
-    )
-    console.debug('>>> videoWorker', action)
-  }
-}
-
 export interface BaseRoomSession<T>
   extends RoomMethods,
     RoomSessionConnectionContract,
@@ -77,11 +67,6 @@ export class RoomSessionConnection
 
   get deviceList() {
     return Array.from(this._deviceList)
-  }
-
-  /** @internal */
-  protected override getWorkers() {
-    return new Map([['video', { worker: videoWorker }]])
   }
 
   /** @internal */

--- a/packages/webrtc/src/BaseConnection.ts
+++ b/packages/webrtc/src/BaseConnection.ts
@@ -96,6 +96,7 @@ export class BaseConnection<EventTypes extends EventEmitter.ValidEventTypes>
     logger.debug('New Call with Options:', this.options)
 
     this.applyEmitterTransforms({ local: true })
+    this.attachCustomSagas()
   }
 
   get id() {

--- a/packages/webrtc/src/BaseConnection.ts
+++ b/packages/webrtc/src/BaseConnection.ts
@@ -96,7 +96,7 @@ export class BaseConnection<EventTypes extends EventEmitter.ValidEventTypes>
     logger.debug('New Call with Options:', this.options)
 
     this.applyEmitterTransforms({ local: true })
-    this.attachCustomSagas()
+    this.attachWorkers()
   }
 
   get id() {


### PR DESCRIPTION
This PR is starting point to split the `core` package in smaller packages where, each one, will provide specific Sagas to handle inbound events and/or provide side-effects.
Right now i used a similar logic to the `Emitter Transforms` but for Sagas. A BaseComponent can define its own `customSagas` that will run until the component is destroyed. 
Within each Saga we can `take` and `put` actions to/from the store and also `select` (if we need).

- [x] Fix typings
- [x] Review naming