### PR TITLE
Resolve RoomSession `join()` race condition

### DIFF
--- a/.changeset/brave-rocks-sing.md
+++ b/.changeset/brave-rocks-sing.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/js': patch
+---
+
+Fix possible race condition on RoomSession.join() method.

--- a/packages/js/examples/heroku/index.js
+++ b/packages/js/examples/heroku/index.js
@@ -244,6 +244,10 @@ window.connect = () => {
     .then((result) => {
       console.log('>> Room Joined', result)
 
+      roomObj.getLayouts().then((layouts) => {
+        console.log('>> Layouts', layouts)
+      })
+
       enumerateDevices()
         .then(initDeviceOptions)
         .catch((error) => {

--- a/packages/js/src/RoomSession.ts
+++ b/packages/js/src/RoomSession.ts
@@ -120,15 +120,21 @@ export const RoomSession = function (roomOptions: RoomSessionOptions) {
     client.disconnect()
   })
 
-  const join = async () => {
-    try {
-      await client.connect()
-      await room.join()
-    } catch (e) {
-      logger.error(e)
-      throw e
-    }
-    return room
+  const join = () => {
+    return new Promise(async (resolve, reject) => {
+      try {
+        await client.connect()
+
+        room.on('room.subscribed', () => {
+          resolve(room)
+        })
+
+        await room.join()
+      } catch (error) {
+        logger.error('RoomSession Join', error)
+        reject(error)
+      }
+    })
   }
 
   return new Proxy<Omit<RoomSession, 'new'>>(room, {

--- a/packages/js/src/RoomSession.ts
+++ b/packages/js/src/RoomSession.ts
@@ -125,7 +125,7 @@ export const RoomSession = function (roomOptions: RoomSessionOptions) {
       try {
         await client.connect()
 
-        room.on('room.subscribed', () => {
+        room.once('room.subscribed', () => {
           resolve(room)
         })
 


### PR DESCRIPTION
This PR solves a possible race condition between the `RoomSession.join()` method and the subsequent methods that require a `room_session_id`.

- [x] Resolve the promise using the events (and not signaling only)