### PR TITLE
Handle the audio track regardless of `rootElement`

### DIFF
--- a/.changeset/silent-hornets-thank.md
+++ b/.changeset/silent-hornets-thank.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/js': patch
+---
+
+Always attach the audio track regardless the `rootElement` option.

--- a/packages/js/src/BaseRoomSession.ts
+++ b/packages/js/src/BaseRoomSession.ts
@@ -9,8 +9,6 @@ import {
   BaseConnectionContract,
   toLocalEvent,
   toExternalJSON,
-  sagaEffects,
-  SagaIterator,
 } from '@signalwire/core'
 import {
   getDisplayMedia,

--- a/packages/js/src/Client.ts
+++ b/packages/js/src/Client.ts
@@ -6,7 +6,10 @@ import {
 } from '@signalwire/core'
 import type { CustomSaga } from '@signalwire/core'
 import { ConnectionOptions } from '@signalwire/webrtc'
-import { makeMediaElementsSaga } from './features/mediaElements/mediaElementsSagas'
+import {
+  makeVideoElementSaga,
+  makeAudioElementSaga,
+} from './features/mediaElements/mediaElementsSagas'
 import { RoomSession } from './RoomSession'
 import {
   createBaseRoomSessionObject,
@@ -45,16 +48,24 @@ export class ClientAPI<
         const customSagas: Array<CustomSaga<RoomSessionConnection>> = []
 
         /**
+         * By default the SDK will attach the audio to
+         * an Audio element (regardless of "rootElement")
+         */
+        customSagas.push(
+          makeAudioElementSaga({
+            speakerId: options.speakerId,
+          })
+        )
+
+        /**
          * If the user provides a `roomElement` we'll
-         * automatically handle the Audio and Video elements
-         * for them
+         * automatically handle the Video element for them
          */
         if (rootElement) {
           customSagas.push(
-            makeMediaElementsSaga({
+            makeVideoElementSaga({
               rootElement,
               applyLocalVideoOverlay,
-              speakerId: options.speakerId,
             })
           )
         }


### PR DESCRIPTION
This PR changes how the SDK handle audio and video tracks in the `js` package. The `audio` track will be automatically attached to an `Audio` element even without the `rootElement` option.
