### PR TITLE
Release tasks tweaks

### DIFF
--- a/scripts/sw-release/common.js
+++ b/scripts/sw-release/common.js
@@ -189,7 +189,7 @@ const publishTaskFactory = (options) => {
                     tasks.push(
                       await executer(
                         'npm',
-                        ['publish', '--dry-run', ...options.npmOptions],
+                        ['publish', ...options.npmOptions],
                         {
                           cwd: pathname,
                         }

--- a/scripts/sw-release/modes/production.js
+++ b/scripts/sw-release/modes/production.js
@@ -1,10 +1,5 @@
 import { isCleanGitStatus } from '@sw-internal/common'
-import {
-  getBuildTask,
-  getInstallDependenciesTask,
-  getTestTask,
-  publishTaskFactory,
-} from '../common.js'
+import { getBuildTask, getTestTask, publishTaskFactory } from '../common.js'
 
 const getProductionTasks = ({ flags, executer, dryRun }) => {
   return [
@@ -21,7 +16,6 @@ const getProductionTasks = ({ flags, executer, dryRun }) => {
         }
       },
     },
-    ...getInstallDependenciesTask({ flags, dryRun, executer }),
     ...getBuildTask({ dryRun, executer }),
     ...getTestTask({ dryRun, executer }),
     ...publishTaskFactory({


### PR DESCRIPTION
Right after `changeset version`, all the dependencies are not valid and NPM returns 404 (as they have not been released yet). I removed the `install` process while releasing a production version.

And also, removed the `dry-run` flag.