### PR TITLE
Ability to opt-in/out of logging WS Traffic

### DIFF
--- a/.changeset/sour-peas-rhyme.md
+++ b/.changeset/sour-peas-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/core': patch
+---
+
+Add option to opt-in/out of the WebSocket logging messages

--- a/packages/core/src/BaseComponent.ts
+++ b/packages/core/src/BaseComponent.ts
@@ -8,6 +8,7 @@ import {
   instanceProxyFactory,
   NESTED_FIELDS_TO_PROCESS,
   getLogger,
+  _setDebugOptions,
 } from './utils'
 import { executeAction } from './redux'
 import {
@@ -167,7 +168,13 @@ export class BaseComponent<
    */
   private _runningWorkers: Task[] = []
 
-  constructor(public options: BaseComponentOptions<EventTypes>) {}
+  constructor(public options: BaseComponentOptions<EventTypes>) {
+    // @ts-expect-error
+    const { debug } = options
+    if (debug) {
+      _setDebugOptions(debug)
+    }
+  }
 
   /** @internal */
   set destroyer(d: () => void) {

--- a/packages/core/src/BaseComponent.ts
+++ b/packages/core/src/BaseComponent.ts
@@ -8,7 +8,6 @@ import {
   instanceProxyFactory,
   NESTED_FIELDS_TO_PROCESS,
   getLogger,
-  _setDebugOptions,
 } from './utils'
 import { executeAction } from './redux'
 import {
@@ -168,13 +167,7 @@ export class BaseComponent<
    */
   private _runningWorkers: Task[] = []
 
-  constructor(public options: BaseComponentOptions<EventTypes>) {
-    // @ts-expect-error
-    const { debug } = options
-    if (debug) {
-      _setDebugOptions(debug)
-    }
-  }
+  constructor(public options: BaseComponentOptions<EventTypes>) {}
 
   /** @internal */
   set destroyer(d: () => void) {

--- a/packages/core/src/BaseSession.ts
+++ b/packages/core/src/BaseSession.ts
@@ -200,7 +200,7 @@ export class BaseSession {
       promise = Promise.resolve()
     }
 
-    this.logger.wsTraffic(msg)
+    this.logger.wsTraffic({ type: 'send', payload: msg })
     this._socket!.send(JSON.stringify(msg))
 
     return timeoutPromise(
@@ -264,7 +264,7 @@ export class BaseSession {
 
   protected _onSocketMessage(event: MessageEvent) {
     const payload: any = safeParseJson(event.data)
-    this.logger.wsTraffic(payload)
+    this.logger.wsTraffic({ type: 'recv', payload })
     const request = this._requests.get(payload.id)
     if (request) {
       const { rpcRequest, resolve, reject } = request

--- a/packages/core/src/BaseSession.ts
+++ b/packages/core/src/BaseSession.ts
@@ -200,7 +200,7 @@ export class BaseSession {
       promise = Promise.resolve()
     }
 
-    this.logger.trace('SEND: \n', JSON.stringify(msg, null, 2), '\n')
+    this.logger.wsTraffic(msg)
     this._socket!.send(JSON.stringify(msg))
 
     return timeoutPromise(
@@ -264,7 +264,7 @@ export class BaseSession {
 
   protected _onSocketMessage(event: MessageEvent) {
     const payload: any = safeParseJson(event.data)
-    this.logger.trace('RECV: \n', JSON.stringify(payload, null, 2), '\n')
+    this.logger.wsTraffic(payload)
     const request = this._requests.get(payload.id)
     if (request) {
       const { rpcRequest, resolve, reject } = request

--- a/packages/core/src/redux/rootSaga.ts
+++ b/packages/core/src/redux/rootSaga.ts
@@ -2,7 +2,7 @@ import { Task, SagaIterator } from '@redux-saga/types'
 import { channel, EventChannel } from 'redux-saga'
 import { fork, call, take, put, delay, all } from 'redux-saga/effects'
 import { SessionConstructor, InternalUserOptions } from '../utils/interfaces'
-import { getLogger } from '../utils'
+import { getLogger, setDebugOptions } from '../utils'
 import { BaseSession } from '../BaseSession'
 import {
   executeActionWatcher,
@@ -214,6 +214,10 @@ interface RootSagaOptions {
 
 export default (options: RootSagaOptions) => {
   return function* root(userOptions: InternalUserOptions): SagaIterator {
+    if (userOptions.debug) {
+      setDebugOptions(userOptions.debug)
+    }
+
     yield fork(executeQueueWatcher)
 
     /**

--- a/packages/core/src/testUtils.ts
+++ b/packages/core/src/testUtils.ts
@@ -2,20 +2,21 @@ import { channel } from 'redux-saga'
 import { configureStore } from './redux'
 import { PubSubChannel } from './redux/interfaces'
 import { BaseSession } from './BaseSession'
-import { RPCConnectResult, SDKLogger } from './utils/interfaces'
+import { RPCConnectResult, InternalSDKLogger } from './utils/interfaces'
 import { EventEmitter } from './utils/EventEmitter'
 
 const PROJECT_ID = '8f0a119a-cda7-4497-a47d-c81493b824d4'
 const TOKEN = '<VRT>'
 
-export const mockLogger: SDKLogger = {
+export const createMockedLogger = (): InternalSDKLogger => ({
   fatal: jest.fn(),
   error: jest.fn(),
   warn: jest.fn(),
   info: jest.fn(),
   debug: jest.fn(),
   trace: jest.fn(),
-}
+  wsTraffic: jest.fn(),
+})
 
 /**
  * Helper method to configure a Store w/o Saga middleware.

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -5,7 +5,7 @@ import {
   EVENT_NAMESPACE_DIVIDER,
   LOCAL_EVENT_PREFIX,
 } from './constants'
-export { setLogger, getLogger } from './logger'
+export { setLogger, getLogger, _setDebugOptions } from './logger'
 
 export { v4 as uuid } from 'uuid'
 export * from './parseRPCResponse'

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -5,7 +5,7 @@ import {
   EVENT_NAMESPACE_DIVIDER,
   LOCAL_EVENT_PREFIX,
 } from './constants'
-export { setLogger, getLogger, _setDebugOptions } from './logger'
+export { setLogger, getLogger, setDebugOptions } from './logger'
 
 export { v4 as uuid } from 'uuid'
 export * from './parseRPCResponse'

--- a/packages/core/src/utils/interfaces.ts
+++ b/packages/core/src/utils/interfaces.ts
@@ -78,12 +78,15 @@ export interface SessionOptions {
    * @internal
    * */
   _onRefreshToken?(): void
-  debug?: any
 }
 
 export interface UserOptions extends SessionOptions {
   /** @internal */
   devTools?: boolean
+  /** @internal */
+  debug?: {
+    logWsTraffic?: boolean
+  }
 }
 
 export interface InternalUserOptions extends UserOptions {

--- a/packages/core/src/utils/interfaces.ts
+++ b/packages/core/src/utils/interfaces.ts
@@ -387,3 +387,7 @@ export interface SDKLogger {
   trace: LogFn
   level: string // TODO:
 }
+
+export interface InternalSDKLogger extends SDKLogger {
+  wsTraffic: (payload: JSONRPCResponse | JSONRPCRequest) => void
+}

--- a/packages/core/src/utils/interfaces.ts
+++ b/packages/core/src/utils/interfaces.ts
@@ -385,4 +385,5 @@ export interface SDKLogger {
   info: LogFn
   debug: LogFn
   trace: LogFn
+  level: string // TODO:
 }

--- a/packages/core/src/utils/interfaces.ts
+++ b/packages/core/src/utils/interfaces.ts
@@ -78,6 +78,7 @@ export interface SessionOptions {
    * @internal
    * */
   _onRefreshToken?(): void
+  debug?: any
 }
 
 export interface UserOptions extends SessionOptions {

--- a/packages/core/src/utils/interfaces.ts
+++ b/packages/core/src/utils/interfaces.ts
@@ -385,9 +385,13 @@ export interface SDKLogger {
   info: LogFn
   debug: LogFn
   trace: LogFn
-  level: string // TODO:
+}
+
+export interface WsTrafficOptions {
+  type: 'send' | 'recv'
+  payload: JSONRPCResponse | JSONRPCRequest
 }
 
 export interface InternalSDKLogger extends SDKLogger {
-  wsTraffic: (payload: JSONRPCResponse | JSONRPCRequest) => void
+  wsTraffic: (options: WsTrafficOptions) => void
 }

--- a/packages/core/src/utils/logger.test.ts
+++ b/packages/core/src/utils/logger.test.ts
@@ -1,5 +1,6 @@
-import { getLogger, setLogger } from './logger'
-import { mockLogger } from '../testUtils'
+import { getLogger, setLogger, setDebugOptions } from './logger'
+import { createMockedLogger } from '../testUtils'
+import { InternalSDKLogger } from '..'
 
 describe('logger', () => {
   describe('getLogger', () => {
@@ -16,7 +17,8 @@ describe('logger', () => {
     })
 
     it('should allow us to pass a customer logger', () => {
-      setLogger(mockLogger)
+      const mockedLogger = createMockedLogger()
+      setLogger(mockedLogger)
       const logger = getLogger()
 
       logger.info('info')
@@ -25,12 +27,84 @@ describe('logger', () => {
       logger.trace('trace')
       logger.warn('warn')
 
-      expect(mockLogger.info).toHaveBeenCalledWith('info')
-      expect(mockLogger.debug).toHaveBeenCalledWith('debug')
-      expect(mockLogger.error).toHaveBeenCalledWith('error')
-      // This method is currently being intercepted by a Proxy.
-      // expect(mockLogger.trace).toHaveBeenCalledWith('trace')
-      expect(mockLogger.warn).toHaveBeenCalledWith('warn')
+      expect(mockedLogger.info).toHaveBeenCalledWith('info')
+      expect(mockedLogger.debug).toHaveBeenCalledWith('debug')
+      expect(mockedLogger.error).toHaveBeenCalledWith('error')
+      expect(mockedLogger.trace).toHaveBeenCalledWith('trace')
+      expect(mockedLogger.warn).toHaveBeenCalledWith('warn')
+    })
+  })
+
+  describe('WS Traffic', () => {
+    let mockedLogger: InternalSDKLogger
+    beforeEach(() => {
+      mockedLogger = createMockedLogger()
+      setLogger(mockedLogger)
+    })
+    afterEach(() => {
+      setLogger(null)
+      setDebugOptions(null)
+    })
+
+    it('should be a noop unless `debug.logWsTraffic: true`', () => {
+      const logger = getLogger()
+
+      logger.wsTraffic({ type: 'send', payload: {} as any })
+
+      expect(mockedLogger.info).not.toHaveBeenCalled()
+    })
+
+    it('should expose a `wsTraffic` method', () => {
+      setDebugOptions({
+        logWsTraffic: true,
+      })
+      const logger = getLogger()
+
+      const payload = {
+        jsonrpc: '2.0' as const,
+        id: 'uuid',
+        method: 'signalwire.event' as const,
+        params: {
+          key: 'value',
+        },
+      }
+
+      logger.wsTraffic({ type: 'send', payload })
+      logger.wsTraffic({ type: 'recv', payload })
+
+      expect(mockedLogger.info).toHaveBeenNthCalledWith(
+        1,
+        `SEND: \n`,
+        JSON.stringify(payload, null, 2),
+        '\n'
+      )
+
+      expect(mockedLogger.info).toHaveBeenNthCalledWith(
+        2,
+        `RECV: \n`,
+        JSON.stringify(payload, null, 2),
+        '\n'
+      )
+    })
+
+    it('should not stringify ping events', () => {
+      setDebugOptions({
+        logWsTraffic: true,
+      })
+      const logger = getLogger()
+
+      const payload = {
+        jsonrpc: '2.0' as const,
+        id: 'uuid',
+        method: 'signalwire.ping' as const,
+        params: {
+          key: 'value',
+        },
+      }
+
+      logger.wsTraffic({ type: 'send', payload })
+
+      expect(mockedLogger.info).toHaveBeenCalledWith(`SEND: \n`, payload, '\n')
     })
   })
 })

--- a/packages/core/src/utils/logger.test.ts
+++ b/packages/core/src/utils/logger.test.ts
@@ -28,7 +28,8 @@ describe('logger', () => {
       expect(mockLogger.info).toHaveBeenCalledWith('info')
       expect(mockLogger.debug).toHaveBeenCalledWith('debug')
       expect(mockLogger.error).toHaveBeenCalledWith('error')
-      expect(mockLogger.trace).toHaveBeenCalledWith('trace')
+      // This method is currently being intercepted by a Proxy.
+      // expect(mockLogger.trace).toHaveBeenCalledWith('trace')
       expect(mockLogger.warn).toHaveBeenCalledWith('warn')
     })
   })

--- a/packages/core/src/utils/logger.ts
+++ b/packages/core/src/utils/logger.ts
@@ -30,6 +30,11 @@ const setLogger = (logger: SDKLogger | null) => {
   userLogger = logger
 }
 
+let debugOptions: any = {}
+const _setDebugOptions = (options: any) => {
+  Object.assign(debugOptions, options)
+}
+
 const trace = (...params: Parameters<SDKLogger['trace']>) => {
   const logger = userLogger ?? (defaultLogger as any as SDKLogger)
 
@@ -37,8 +42,10 @@ const trace = (...params: Parameters<SDKLogger['trace']>) => {
   return logger.info(...params)
 }
 
-const getLogger = (): SDKLogger => {
+const getLogger = (opts?: any): SDKLogger => {
   const logger = userLogger ?? (defaultLogger as any as SDKLogger)
+
+  console.log('debugOptions', { debugOptions, opts })
 
   return new Proxy<SDKLogger>(logger, {
     get(target, prop: keyof SDKLogger, receiver) {
@@ -51,4 +58,4 @@ const getLogger = (): SDKLogger => {
   })
 }
 
-export { setLogger, getLogger }
+export { setLogger, getLogger, _setDebugOptions }

--- a/packages/core/src/utils/logger.ts
+++ b/packages/core/src/utils/logger.ts
@@ -31,7 +31,7 @@ const setLogger = (logger: SDKLogger | null) => {
 }
 
 let debugOptions: any = {}
-const _setDebugOptions = (options: any) => {
+const setDebugOptions = (options: any) => {
   Object.assign(debugOptions, options)
 }
 
@@ -58,4 +58,4 @@ const getLogger = (opts?: any): SDKLogger => {
   })
 }
 
-export { setLogger, getLogger, _setDebugOptions }
+export { setLogger, getLogger, setDebugOptions }

--- a/packages/core/src/utils/logger.ts
+++ b/packages/core/src/utils/logger.ts
@@ -48,7 +48,7 @@ const getLoggerInstance = (): SDKLogger => {
   return userLogger ?? (defaultLogger as any as SDKLogger)
 }
 
-// TODO: find a better place to place this.
+// TODO: find a better place to put this.
 const WS_MESSAGES_PREFIX = ['RECV:', 'SEND:']
 const isWsTraffic = (msg: string) => {
   return WS_MESSAGES_PREFIX.some((wsPrefix) => msg.startsWith(wsPrefix))
@@ -59,9 +59,11 @@ const trace = (...params: Parameters<SDKLogger['trace']>): void => {
   const { logWsTraffic } = debugOptions || {}
 
   if (isWsTraffic(params[0])) {
-    // If the user set `logWsTraffic: true` we'll
+    /**
+     * If the user sets `logWsTraffic: true` then we'll
+     * upgrade it to a `info` level.
+     */
     if (logWsTraffic) {
-      // TODO: pick the appropiate fn based o
       return logger.info(...params)
     } else {
       return undefined

--- a/packages/core/src/utils/logger.ts
+++ b/packages/core/src/utils/logger.ts
@@ -37,6 +37,10 @@ const setLogger = (logger: SDKLogger | null) => {
 
 let debugOptions: UserOptions['debug'] = {}
 const setDebugOptions = (options: any) => {
+  if (options == null) {
+    debugOptions = {}
+    return
+  }
   Object.assign(debugOptions, options)
 }
 

--- a/packages/core/src/utils/logger.ts
+++ b/packages/core/src/utils/logger.ts
@@ -30,8 +30,25 @@ const setLogger = (logger: SDKLogger | null) => {
   userLogger = logger
 }
 
+const trace = (...params: Parameters<SDKLogger['trace']>) => {
+  const logger = userLogger ?? (defaultLogger as any as SDKLogger)
+
+  // TODO: add conditionals based on flags.
+  return logger.info(...params)
+}
+
 const getLogger = (): SDKLogger => {
-  return userLogger ?? (defaultLogger as any as SDKLogger)
+  const logger = userLogger ?? (defaultLogger as any as SDKLogger)
+
+  return new Proxy<SDKLogger>(logger, {
+    get(target, prop: keyof SDKLogger, receiver) {
+      if (prop === 'trace') {
+        return trace
+      }
+
+      return Reflect.get(target, prop, receiver)
+    },
+  })
 }
 
 export { setLogger, getLogger }

--- a/packages/core/src/utils/logger.ts
+++ b/packages/core/src/utils/logger.ts
@@ -1,9 +1,18 @@
 import log from 'loglevel'
-import { SDKLogger } from '..'
+import type { SDKLogger, UserOptions } from '..'
 
 const datetime = () =>
   new Date().toISOString().replace('T', ' ').replace('Z', '')
-const defaultLogger = log.getLogger('signalwire')
+const defaultLoggerInstance = log.getLogger('signalwire')
+const defaultLogger = new Proxy(defaultLoggerInstance, {
+  get(target, prop: keyof SDKLogger, receiver) {
+    if (prop === 'level') {
+      return defaultLoggerInstance.getLevel()
+    }
+
+    return Reflect.get(target, prop, receiver)
+  },
+})
 
 const originalFactory = defaultLogger.methodFactory
 defaultLogger.methodFactory = (methodName, logLevel, loggerName) => {
@@ -30,22 +39,40 @@ const setLogger = (logger: SDKLogger | null) => {
   userLogger = logger
 }
 
-let debugOptions: any = {}
+let debugOptions: UserOptions['debug'] = {}
 const setDebugOptions = (options: any) => {
   Object.assign(debugOptions, options)
 }
 
-const trace = (...params: Parameters<SDKLogger['trace']>) => {
-  const logger = userLogger ?? (defaultLogger as any as SDKLogger)
-
-  // TODO: add conditionals based on flags.
-  return logger.info(...params)
+const getLoggerInstance = (): SDKLogger => {
+  return userLogger ?? (defaultLogger as any as SDKLogger)
 }
 
-const getLogger = (opts?: any): SDKLogger => {
-  const logger = userLogger ?? (defaultLogger as any as SDKLogger)
+// TODO: find a better place to place this.
+const WS_MESSAGES_PREFIX = ['RECV:', 'SEND:']
+const isWsTraffic = (msg: string) => {
+  return WS_MESSAGES_PREFIX.some((wsPrefix) => msg.startsWith(wsPrefix))
+}
 
-  console.log('debugOptions', { debugOptions, opts })
+const trace = (...params: Parameters<SDKLogger['trace']>): void => {
+  const logger = getLoggerInstance()
+  const { logWsTraffic } = debugOptions || {}
+
+  if (isWsTraffic(params[0])) {
+    // If the user set `logWsTraffic: true` we'll
+    if (logWsTraffic) {
+      // TODO: pick the appropiate fn based o
+      return logger.info(...params)
+    } else {
+      return undefined
+    }
+  }
+
+  return logger.trace(...params)
+}
+
+const getLogger = (): SDKLogger => {
+  const logger = getLoggerInstance()
 
   return new Proxy<SDKLogger>(logger, {
     get(target, prop: keyof SDKLogger, receiver) {

--- a/packages/core/src/utils/logger.ts
+++ b/packages/core/src/utils/logger.ts
@@ -18,12 +18,12 @@ defaultLogger.methodFactory = (methodName, logLevel, loggerName) => {
   }
 }
 
-const level =
+const defaultLoggerLevel =
   // @ts-ignore
   'development' === process.env.NODE_ENV
     ? defaultLogger.levels.DEBUG
     : defaultLogger.getLevel()
-defaultLogger.setLevel(level)
+defaultLogger.setLevel(defaultLoggerLevel)
 
 let userLogger: SDKLogger | null
 const setLogger = (logger: SDKLogger | null) => {

--- a/packages/realtime-api/examples/ts-vanilla-websockets/index.ts
+++ b/packages/realtime-api/examples/ts-vanilla-websockets/index.ts
@@ -14,7 +14,7 @@ async function run() {
       project: process.env.PROJECT as string,
       token: process.env.TOKEN as string,
       debug: {
-        wsTraffic: true,
+        logWsTraffic: true,
       },
     })
 

--- a/packages/realtime-api/examples/ts-vanilla-websockets/index.ts
+++ b/packages/realtime-api/examples/ts-vanilla-websockets/index.ts
@@ -13,6 +13,9 @@ async function run() {
       // host: 'relay.swire.io',
       project: process.env.PROJECT as string,
       token: process.env.TOKEN as string,
+      debug: {
+        wsTraffic: true,
+      },
     })
 
     client.video.on('room.started', async (roomSession) => {

--- a/packages/realtime-api/src/createClient.ts
+++ b/packages/realtime-api/src/createClient.ts
@@ -20,7 +20,7 @@ export type { RealtimeClient, ClientEvents }
  * @param userOptions.token SignalWire project token, e.g. `PT9e5660c101cd140a1c93a0197640a369cf5f16975a0079c9`
  * @param userOptions.logLevel logging level
  * @returns an instance of a real-time Client.
- * 
+ *
  * @example
  * ```typescript
  * const client = await createClient({
@@ -33,30 +33,33 @@ export const createClient: (userOptions: {
   project?: string
   token: string
   logLevel?: 'trace' | 'debug' | 'info' | 'warn' | 'error' | 'silent'
-}) => Promise<RealtimeClient> =
-// Note: types are inlined for clarity of documentation
-async (userOptions) => {
-  const baseUserOptions: InternalUserOptions = {
-    ...userOptions,
-    emitter: getEventEmitter<ClientEvents>(),
+  debug?: {
+    wsTraffic?: boolean
   }
-  const store = configureStore({
-    userOptions: baseUserOptions,
-    SessionConstructor: Session,
-  })
+}) => Promise<RealtimeClient> =
+  // Note: types are inlined for clarity of documentation
+  async (userOptions) => {
+    const baseUserOptions: InternalUserOptions = {
+      ...userOptions,
+      emitter: getEventEmitter<ClientEvents>(),
+    }
+    const store = configureStore({
+      userOptions: baseUserOptions,
+      SessionConstructor: Session,
+    })
 
-  const client = connect<ClientEvents, Client, RealtimeClient>({
-    store,
-    Component: Client,
-    componentListeners: {
-      errors: 'onError',
-      responses: 'onSuccess',
-      id: 'onClientSubscribed',
-    },
-    sessionListeners: {
-      authStatus: 'onAuth',
-    },
-  })(baseUserOptions)
+    const client = connect<ClientEvents, Client, RealtimeClient>({
+      store,
+      Component: Client,
+      componentListeners: {
+        errors: 'onError',
+        responses: 'onSuccess',
+        id: 'onClientSubscribed',
+      },
+      sessionListeners: {
+        authStatus: 'onAuth',
+      },
+    })(baseUserOptions)
 
-  return client
-}
+    return client
+  }

--- a/packages/realtime-api/src/createClient.ts
+++ b/packages/realtime-api/src/createClient.ts
@@ -33,9 +33,6 @@ export const createClient: (userOptions: {
   project?: string
   token: string
   logLevel?: 'trace' | 'debug' | 'info' | 'warn' | 'error' | 'silent'
-  debug?: {
-    wsTraffic?: boolean
-  }
 }) => Promise<RealtimeClient> =
   // Note: types are inlined for clarity of documentation
   async (userOptions) => {


### PR DESCRIPTION
The code in this changeset includes a new API for having more control over what things get logged. As a starting point we're only exposing a single flag named `logWsTraffic` that would let us to opt-in/out of the WebSocket messages.