### PR TITLE
Handle internal responses with results and error code

### DIFF
--- a/.changeset/large-maps-hide.md
+++ b/.changeset/large-maps-hide.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/core': patch
+---
+
+[internal] Update parsing RPC responses

--- a/packages/core/src/utils/parseRPCResponse.test.ts
+++ b/packages/core/src/utils/parseRPCResponse.test.ts
@@ -92,5 +92,14 @@ describe('parseRPCResponse', () => {
         result: { data: 'test' },
       })
     })
+
+    it('should handle nested "result" fields with error', () => {
+      const response = JSON.parse(
+        '{"jsonrpc":"2.0","id":"uuid","result":{"requester_nodeid":"node1","requester_identity":"node1","responder_nodeid":"node2","responder_identity":"node2","result":{"code":"500","message":"Server error"}}}'
+      )
+      expect(parseRPCResponse({ request, response })).toEqual({
+        error: { code: '500', message: 'Server error' },
+      })
+    })
   })
 })

--- a/packages/core/src/utils/parseRPCResponse.ts
+++ b/packages/core/src/utils/parseRPCResponse.ts
@@ -51,9 +51,13 @@ const parseResponse = (
     return { result }
   }
   if (nestedResult) {
-    if (nestedResult.jsonrpc) {
+    const { jsonrpc, code } = nestedResult
+    if (jsonrpc) {
       // This is a verto message
       return parseResponse(nestedResult, node_id)
+    }
+    if (code && code !== '200') {
+      return { error: nestedResult }
     }
     return { result: nestedResult }
   }


### PR DESCRIPTION
This PR add a case when parsing RPC responses with nested results and `code` different than "200". In these cases it should return an `error` instead of `result`.