### PR TITLE
Remove getter definition in interfaces

### DIFF
--- a/.changeset/wise-ducks-hammer.md
+++ b/.changeset/wise-ducks-hammer.md
@@ -1,0 +1,6 @@
+---
+'@signalwire/core': patch
+'@signalwire/js': patch
+---
+
+Fix definition types

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -35,37 +35,37 @@ export interface BaseConnectionContract<
   EventTypes extends EventEmitter.ValidEventTypes
 > extends EmitterContract<EventTypes> {
   /** The id of the video device, or null if not available */
-  get cameraId(): string | null
+  readonly cameraId: string | null
   /** The label of the video device, or null if not available */
-  get cameraLabel(): string | null
+  readonly cameraLabel: string | null
   /**
    * Provides access to the local audio
    * [MediaStreamTrack](https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamTrack).
    */
-  get localAudioTrack(): MediaStreamTrack | null
+  readonly localAudioTrack: MediaStreamTrack | null
   /** Provides access to the local [MediaStream](https://developer.mozilla.org/en-US/docs/Web/API/MediaStream) */
-  get localStream(): MediaStream | undefined
+  readonly localStream: MediaStream | undefined
   /**
    * Provides access to the local video
    * [MediaStreamTrack](https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamTrack).
    */
-  get localVideoTrack(): MediaStreamTrack | null
+  readonly localVideoTrack: MediaStreamTrack | null
   /** The id of the audio input device, or null if not available */
-  get microphoneId(): string | null
+  readonly microphoneId: string | null
   /** The label of the audio input device, or null if not available */
-  get microphoneLabel(): string | null
+  readonly microphoneLabel: string | null
   /**
    * Provides access to the remote [MediaStream](https://developer.mozilla.org/en-US/docs/Web/API/MediaStream)
    */
-  get remoteStream(): MediaStream | undefined
+  readonly remoteStream: MediaStream | undefined
   /** The unique identifier for the room */
-  get roomId(): string
+  readonly roomId: string
   /** The unique identifier for the room session */
-  get roomSessionId(): string
+  readonly roomSessionId: string
   /** Whether the connection is currently active */
-  get active(): boolean
+  readonly active: boolean
   /** The id of the current member within the room */
-  get memberId(): string
+  readonly memberId: string
 
   updateCamera(constraints: MediaTrackConstraints): Promise<void>
   updateMicrophone(constraints: MediaTrackConstraints): Promise<void>

--- a/packages/js/src/RoomSession.docs.ts
+++ b/packages/js/src/RoomSession.docs.ts
@@ -19,57 +19,57 @@ export interface RoomSessionDocs<T>
   restoreOutboundVideo(): void
 
   /** Whether the connection is currently active */
-  get active(): boolean
+  readonly active: boolean
 
   /** The id of the video device, or null if not available */
-  get cameraId(): string | null
+  readonly cameraId: string | null
 
   /** The label of the video device, or null if not available */
-  get cameraLabel(): string | null
+  readonly cameraLabel: string | null
 
   /**
    * Contains any additional devices added via {@link addCamera},
    * {@link addMicrophone}, or {@link addDevice}.
    */
-  get deviceList(): RoomSessionDevice[]
+  readonly deviceList: RoomSessionDevice[]
 
   /**
    * Provides access to the local audio
    * [MediaStreamTrack](https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamTrack).
    */
-  get localAudioTrack(): MediaStreamTrack | null
+  readonly localAudioTrack: MediaStreamTrack | null
 
   /** Provides access to the local [MediaStream](https://developer.mozilla.org/en-US/docs/Web/API/MediaStream) */
-  get localStream(): MediaStream | undefined
+  readonly localStream: MediaStream | undefined
 
   /**
    * Provides access to the local video
    * [MediaStreamTrack](https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamTrack).
    */
-  get localVideoTrack(): MediaStreamTrack | null
+  readonly localVideoTrack: MediaStreamTrack | null
 
   /** The id of the current member within the room */
-  get memberId(): string
+  readonly memberId: string
 
   /** The id of the audio input device, or null if not available */
-  get microphoneId(): string | null
+  readonly microphoneId: string | null
 
   /** The label of the audio input device, or null if not available */
-  get microphoneLabel(): string | null
+  readonly microphoneLabel: string | null
 
   /**
    * Provides access to the remote [MediaStream](https://developer.mozilla.org/en-US/docs/Web/API/MediaStream)
    */
-  get remoteStream(): MediaStream | undefined
+  readonly remoteStream: MediaStream | undefined
 
   /** The unique identifier for the room */
-  get roomId(): string
+  readonly roomId: string
 
   /** The unique identifier for the room session */
-  get roomSessionId(): string
+  readonly roomSessionId: string
 
   /** Contains any local screen shares added to the room via {@link startScreenShare}. */
-  get screenShareList(): RoomSessionScreenShare[]
+  readonly screenShareList: RoomSessionScreenShare[]
 
   /**
    * Joins the room session.


### PR DESCRIPTION
TS doesn't complain about it and it generate the d.ts files with getter/setter but it won't work when used by the consumers.