### PR TITLE
Make sessionChannelWatcher more resilient

### DIFF
--- a/.changeset/angry-seahorses-smoke.md
+++ b/.changeset/angry-seahorses-smoke.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/core': patch
+---
+
+Make internal watcher/workers more resilient to errors

--- a/packages/core/src/redux/utils/sagaHelpers.ts
+++ b/packages/core/src/redux/utils/sagaHelpers.ts
@@ -1,7 +1,8 @@
+import { Saga } from '@redux-saga/core'
 import { call, spawn } from '@redux-saga/core/effects'
 import { getLogger } from '../../utils'
 
-export const createRestartableSaga = (saga: any) => {
+export const createRestartableSaga = (saga: Saga) => {
   return function* () {
     spawn(function* () {
       while (true) {
@@ -19,13 +20,18 @@ export const createRestartableSaga = (saga: any) => {
   }
 }
 
-export const createCatchableSaga = (saga: any) => {
-  return function* () {
+const defaultCatchHandler = (error: any) =>
+  getLogger().error('Catchable Saga Error', error)
+
+export const createCatchableSaga = <Args = any>(
+  saga: Saga,
+  errorHandler = defaultCatchHandler
+) => {
+  return function* (...params: Args[]) {
     try {
-      getLogger().debug('Run a catchable saga')
-      yield call(saga)
+      yield call(saga, ...params)
     } catch (error) {
-      getLogger().error('Catchable Saga Error', error)
+      errorHandler(error)
     }
   }
 }


### PR DESCRIPTION
Using `createCatchableSaga` helper method to avoid block the watcher/worker pattern on the sessionChannel.