### PR TITLE
Fix Redirect Destination logic for a BaseConnection

### DIFF
--- a/.changeset/swift-geese-cheer.md
+++ b/.changeset/swift-geese-cheer.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/webrtc': patch
+---
+
+Fix logic to handle the `redirectDestination` case where the SDK should resend the invite to a specific node.

--- a/packages/webrtc/src/BaseConnection.ts
+++ b/packages/webrtc/src/BaseConnection.ts
@@ -569,8 +569,9 @@ export class BaseConnection<EventTypes extends EventEmitter.ValidEventTypes>
     } = params
     this.cause = byeCause
     this.causeCode = byeCauseCode
-    if (redirectDestination && this.trying && this.peer.localSdp) {
-      this.logger.warn('Execute invite again')
+    if (redirectDestination && this.peer.localSdp) {
+      this.logger.debug('Redirect Destination to:', redirectDestination)
+      this.nodeId = redirectDestination
       return this.executeInvite(this.peer.localSdp)
     }
     return this.setState('hangup')


### PR DESCRIPTION
This PR fixes the logic for the `redirectDestination` where the server can ask the SDK to resend the invite to another node.