### PR TITLE
Fix layer not found on layout.changed

### DIFF
--- a/.changeset/happy-tigers-move.md
+++ b/.changeset/happy-tigers-move.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/js': patch
+---
+
+[fix] Hide the local video overlay element when the user's video is not in the layout

--- a/packages/js/src/utils/videoElement.ts
+++ b/packages/js/src/utils/videoElement.ts
@@ -132,7 +132,7 @@ const makeLayoutChangedHandler =
 
 const makeDisplayChangeFn = (display: 'block' | 'none') => {
   return (domId: string) => {
-    const el = document.getElementById(domId)
+    const el = document.getElementById(_addSDKPrefix(domId))
     if (el) {
       el.style.display = display
     }

--- a/packages/js/src/utils/videoElement.ts
+++ b/packages/js/src/utils/videoElement.ts
@@ -85,19 +85,21 @@ const makeLayoutChangedHandler =
   async ({ layout, myMemberId, localStream }: LayoutChangedHandlerParams) => {
     try {
       const { layers = [] } = layout
-      const layer = layers.find(({ member_id }) => member_id === myMemberId)
-
-      if (!layer) {
-        return getLogger().debug(
-          'Current Layer Not Found',
-          JSON.stringify(layout)
-        )
-      }
+      const location = layers.find(({ member_id }) => member_id === myMemberId)
 
       const myLayerKey = _addSDKPrefix(myMemberId)
       let myLayer = layerMap.get(myLayerKey)
+      if (!location) {
+        if (myLayer) {
+          getLogger().debug('Current layer not visible')
+          myLayer.style.display = 'none'
+        }
+
+        return
+      }
+
       if (!myLayer) {
-        myLayer = await _buildLayer({ element, location: layer })
+        myLayer = await _buildLayer({ element, location })
         myLayer.id = myLayerKey
 
         const localVideo = buildVideo()
@@ -117,7 +119,8 @@ const makeLayoutChangedHandler =
         return
       }
 
-      const { top, left, width, height } = _getLocationStyles(layer)
+      const { top, left, width, height } = _getLocationStyles(location)
+      myLayer.style.display = 'block'
       myLayer.style.top = top
       myLayer.style.left = left
       myLayer.style.width = width


### PR DESCRIPTION
On `layout.changed`, when _my_ video is not in the layout, hide the local video overlay element. 

This PR also includes a fix to show/hide the overlay element on `video_muted`