### PR TITLE
Improve Client connect

### DIFF
--- a/.changeset/odd-dancers-pump.md
+++ b/.changeset/odd-dancers-pump.md
@@ -1,6 +1,7 @@
 ---
 '@signalwire/core': patch
 '@signalwire/js': patch
+'@signalwire/realtime-api': patch
 ---
 
 Improve logic for connecting the client.

--- a/.changeset/odd-dancers-pump.md
+++ b/.changeset/odd-dancers-pump.md
@@ -1,0 +1,6 @@
+---
+'@signalwire/core': patch
+'@signalwire/js': patch
+---
+
+Improve logic for connecting the client.

--- a/packages/core/src/BaseComponent.ts
+++ b/packages/core/src/BaseComponent.ts
@@ -697,7 +697,17 @@ export class BaseComponent<
       case 'authorized':
         return Promise.resolve(this)
 
+      /**
+       * `unknown` is the initial state of the auth reducer
+       * so if we've got this far it means it's the first
+       * time the user is calling `connect`.
+       */
       case 'unknown':
+      /**
+       * `authorizing` means that the user is calling
+       * `connect` again while we're in the process of
+       * authorizing the session.
+       */
       case 'authorizing':
         return new Promise((resolve, reject) => {
           const unsubscribe = this.store.subscribe(() => {

--- a/packages/core/src/redux/features/session/sessionSelectors.ts
+++ b/packages/core/src/redux/features/session/sessionSelectors.ts
@@ -11,3 +11,7 @@ export const getSession = (store: SDKState) => {
 export const getAuthStatus = ({ session }: SDKState) => {
   return session.authStatus
 }
+
+export const getAuthError = ({ session }: SDKState) => {
+  return session.authError
+}

--- a/packages/js/src/createClient.test.ts
+++ b/packages/js/src/createClient.test.ts
@@ -1,0 +1,116 @@
+import WS from 'jest-websocket-mock'
+import { AuthError } from '@signalwire/core'
+import { createClient } from './createClient'
+
+describe('createClient', () => {
+  const host = 'ws://localhost:1234'
+  const token = '<jwt>'
+  const authError = {
+    code: -32002,
+    message:
+      'Authentication service failed with status ProtocolError, 401 Unauthorized: {}',
+  }
+
+  let server: WS
+  let consoleMock: jest.SpyInstance
+  beforeEach(async () => {
+    consoleMock = jest
+      .spyOn(global.console, 'error')
+      .mockImplementation(() => {})
+
+    server = new WS(host)
+    server.on('connection', (socket) => {
+      socket.on('message', (data: any) => {
+        const parsedData = JSON.parse(data)
+
+        if (
+          parsedData.method === 'signalwire.connect' &&
+          parsedData.params.authentication.jwt_token === '<invalid-token>'
+        ) {
+          socket.send(
+            JSON.stringify({
+              jsonrpc: '2.0',
+              id: parsedData.id,
+              error: authError,
+            })
+          )
+        }
+
+        socket.send(
+          JSON.stringify({
+            jsonrpc: '2.0',
+            id: parsedData.id,
+            result: {},
+          })
+        )
+      })
+    })
+  })
+
+  afterEach(() => {
+    consoleMock.mockRestore()
+    WS.clean()
+  })
+
+  it('should throw an error when invalid credentials are provided', async () => {
+    expect.assertions(1)
+
+    const client = createClient({
+      host,
+      token: '<invalid-token>',
+    })
+
+    try {
+      await client.connect()
+    } catch (e) {
+      expect(e).toBeInstanceOf(AuthError)
+    }
+  })
+
+  it('should resolve `connect()` when the client is authorized', async () => {
+    expect.assertions(1)
+
+    const client = createClient({
+      host,
+      token,
+    })
+
+    // @ts-expect-error
+    client._waitUntilSessionAuthorized().then((c) => {
+      expect(c).toEqual(client)
+    })
+
+    await client.connect()
+  })
+
+  it('should automatically resolve (without hitting the network) when calling `.connect()` if the session was already authorized', async () => {
+    const h = 'ws://localhost:2222'
+    const s = new WS(h)
+
+    let messageHandler
+    s.on('connection', (socket) => {
+      messageHandler = jest.fn((data: any) => {
+        const parsedData = JSON.parse(data)
+
+        socket.send(
+          JSON.stringify({
+            jsonrpc: '2.0',
+            id: parsedData.id,
+            result: {},
+          })
+        )
+      })
+
+      socket.on('message', messageHandler)
+    })
+
+    const client = createClient({
+      host: h,
+      token,
+    })
+
+    await Promise.all([client.connect(), client.connect(), client.connect()])
+
+    expect(messageHandler).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/js/src/createClient.ts
+++ b/packages/js/src/createClient.ts
@@ -69,7 +69,6 @@ export const createClient = <RoomSessionType>(userOptions: UserOptions) => {
     componentListeners: {
       errors: 'onError',
       responses: 'onSuccess',
-      id: 'onClientSubscribed',
     },
   })(baseUserOptions)
 

--- a/packages/realtime-api/__mocks__/ws.js
+++ b/packages/realtime-api/__mocks__/ws.js
@@ -1,0 +1,1 @@
+export { WebSocket as default } from 'mock-socket'

--- a/packages/realtime-api/src/createClient.test.ts
+++ b/packages/realtime-api/src/createClient.test.ts
@@ -1,0 +1,113 @@
+import WS from 'jest-websocket-mock'
+import { AuthError } from '@signalwire/core'
+import { createClient } from './createClient'
+
+describe('createClient', () => {
+  const host = 'ws://localhost:4567'
+  const token = '<jwt>'
+  const authError = {
+    code: -32002,
+    message:
+      'Authentication service failed with status ProtocolError, 401 Unauthorized: {}',
+  }
+
+  let server: WS
+  beforeEach(async () => {
+    server = new WS(host)
+
+    server.on('connection', (socket) => {
+      socket.on('message', (data: any) => {
+        const parsedData = JSON.parse(data)
+        if (
+          parsedData.method === 'signalwire.connect' &&
+          parsedData.params.authentication.token === '<invalid-token>'
+        ) {
+          socket.send(
+            JSON.stringify({
+              jsonrpc: '2.0',
+              id: parsedData.id,
+              error: authError,
+            })
+          )
+        }
+
+        socket.send(
+          JSON.stringify({
+            jsonrpc: '2.0',
+            id: parsedData.id,
+            result: {},
+          })
+        )
+      })
+    })
+  })
+
+  afterEach(() => {
+    server.close()
+  })
+
+  it('should throw an error when invalid credentials are provided', async () => {
+    expect.assertions(1)
+
+    const client = await createClient({
+      // @ts-expect-error
+      host,
+      token: '<invalid-token>',
+    })
+
+    try {
+      await client.connect()
+    } catch (e) {
+      expect(e).toBeInstanceOf(AuthError)
+    }
+  })
+
+  it('should resolve `connect()` when the client is authorized', async () => {
+    expect.assertions(1)
+
+    const client = await createClient({
+      // @ts-expect-error
+      host,
+      token,
+    })
+
+    // @ts-expect-error
+    client._waitUntilSessionAuthorized().then((c) => {
+      expect(c).toEqual(client)
+    })
+
+    await client.connect()
+  })
+
+  it('should automatically resolve (without hitting the network) when calling `.connect()` if the session was already authorized', async () => {
+    const h = 'ws://localhost:2222'
+    const s = new WS(h)
+
+    let messageHandler
+    s.on('connection', (socket) => {
+      messageHandler = jest.fn((data: any) => {
+        const parsedData = JSON.parse(data)
+
+        socket.send(
+          JSON.stringify({
+            jsonrpc: '2.0',
+            id: parsedData.id,
+            result: {},
+          })
+        )
+      })
+
+      socket.on('message', messageHandler)
+    })
+
+    const client = await createClient({
+      // @ts-expect-error
+      host: h,
+      token,
+    })
+
+    await Promise.all([client.connect(), client.connect(), client.connect()])
+
+    expect(messageHandler).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/realtime-api/src/createClient.ts
+++ b/packages/realtime-api/src/createClient.ts
@@ -51,7 +51,6 @@ export const createClient: (userOptions: {
       componentListeners: {
         errors: 'onError',
         responses: 'onSuccess',
-        id: 'onClientSubscribed',
       },
       sessionListeners: {
         authStatus: 'onAuth',


### PR DESCRIPTION
The code in this changeset includes:

* Improved logic for connecting the client. We now have more granularity over what to do with `connect` depending on the session's auth status.
* Simplified the event listeners attachments. This was done by removing some unneeded indirection with the use of `onClientSubscribed` + our redux hooks and simply calling the `attachListeners` on the client's constructor. I'll do the same for the chat API in another PR.