### PR TITLE
ChatMessage instance to event listeners

### DIFF
--- a/.changeset/proud-sloths-begin.md
+++ b/.changeset/proud-sloths-begin.md
@@ -1,0 +1,6 @@
+---
+'@signalwire/core': patch
+'@signalwire/js': patch
+---
+
+[internal] Pass ChatMessage instances to 'message' event handlers

--- a/packages/core/src/chat/BaseChat.ts
+++ b/packages/core/src/chat/BaseChat.ts
@@ -20,8 +20,8 @@ export type BaseChatApiEventsHandlerMapping = Record<
   (message: any) => void
 >
 
-export type BaseChatApiEvents = {
-  [k in keyof BaseChatApiEventsHandlerMapping]: BaseChatApiEventsHandlerMapping[k]
+export type BaseChatApiEvents<T = BaseChatApiEventsHandlerMapping> = {
+  [k in keyof T]: T[k]
 }
 
 // TODO:

--- a/packages/core/src/chat/BaseChat.ts
+++ b/packages/core/src/chat/BaseChat.ts
@@ -1,30 +1,37 @@
 import {
   BaseComponentOptions,
   BaseConsumer,
-  ChatMethods,
   connect,
   extendComponent,
   JSONRPCSubscribeMethod,
   toExternalJSON,
   InternalChatChannel,
   EventTransform,
-  ChatChannelMessageEvent,
 } from '..'
 import { ChatMessage } from './ChatMessage'
 import * as chatMethods from './methods'
 import * as workers from './workers'
+import type {
+  ChatChannelMessageEvent,
+  ChatMethods,
+  ChatMessageEventName,
+  ChatEventNames,
+} from '../types/chat'
 
 export type BaseChatApiEventsHandlerMapping = Record<
-  'message',
+  ChatMessageEventName,
   (message: ChatMessage) => void
 >
 
+/**
+ * @privateRemarks
+ *
+ * Each package will have the option to either extend this
+ * type or provide their own event mapping.
+ */
 export type BaseChatApiEvents<T = BaseChatApiEventsHandlerMapping> = {
   [k in keyof T]: T[k]
 }
-
-// TODO:
-type ChatTransformsEvents = 'message'
 
 const toInternalChatChannels = (channels: string[]): InternalChatChannel[] => {
   return channels.map((name) => {
@@ -66,10 +73,7 @@ export class BaseChatConsumer extends BaseConsumer<BaseChatApiEvents> {
 
   /** @internal */
   protected getEmitterTransforms() {
-    return new Map<
-      ChatTransformsEvents | ChatTransformsEvents[],
-      EventTransform
-    >([
+    return new Map<ChatEventNames | ChatEventNames[], EventTransform>([
       [
         ['message'],
         {
@@ -98,7 +102,7 @@ export const BaseChatAPI = extendComponent<BaseChatConsumer, ChatMethods>(
 )
 
 export const createBaseChatObject = <ChatType>(
-  params: BaseComponentOptions<ChatTransformsEvents>
+  params: BaseComponentOptions<ChatEventNames>
 ) => {
   const chat = connect<BaseChatApiEvents, BaseChatConsumer, ChatType>({
     store: params.store,

--- a/packages/core/src/chat/BaseChat.ts
+++ b/packages/core/src/chat/BaseChat.ts
@@ -10,13 +10,13 @@ import {
   EventTransform,
   ChatChannelMessageEvent,
 } from '..'
-import { BaseChatMessage } from './BaseChatMessage'
+import { ChatMessage } from './ChatMessage'
 import * as chatMethods from './methods'
 import * as workers from './workers'
 
 export type BaseChatApiEventsHandlerMapping = Record<
   'message',
-  (message: any) => void
+  (message: ChatMessage) => void
 >
 
 export type BaseChatApiEvents<T = BaseChatApiEventsHandlerMapping> = {
@@ -75,7 +75,7 @@ export class BaseChatConsumer extends BaseConsumer<BaseChatApiEvents> {
         {
           type: 'chatMessage',
           instanceFactory: (payload: ChatChannelMessageEvent) => {
-            return new BaseChatMessage(toExternalJSON(payload.params))
+            return new ChatMessage(toExternalJSON(payload.params))
           },
           payloadTransform: (payload: ChatChannelMessageEvent) => {
             return toExternalJSON(payload.params)

--- a/packages/core/src/chat/BaseChat.ts
+++ b/packages/core/src/chat/BaseChat.ts
@@ -9,7 +9,6 @@ import {
   InternalChatChannel,
   EventTransform,
   ChatChannelMessageEvent,
-  EventEmitter,
 } from '..'
 import { BaseChatMessage } from './BaseChatMessage'
 import * as chatMethods from './methods'
@@ -35,9 +34,7 @@ const toInternalChatChannels = (channels: string[]): InternalChatChannel[] => {
   })
 }
 
-export class BaseChatConsumer<
-  T extends EventEmitter.ValidEventTypes = BaseChatApiEvents
-> extends BaseConsumer<T> {
+export class BaseChatConsumer extends BaseConsumer<BaseChatApiEvents> {
   protected override _eventsPrefix = 'chat' as const
   protected override subscribeMethod: JSONRPCSubscribeMethod = 'chat.subscribe'
 
@@ -93,29 +90,19 @@ export class BaseChatConsumer<
   }
 }
 
-export const BaseChatAPI = <
-  ChatApiEvents extends EventEmitter.ValidEventTypes = BaseChatApiEvents
->() =>
-  extendComponent<BaseChatConsumer<ChatApiEvents>, ChatMethods>(
-    BaseChatConsumer,
-    {
-      publish: chatMethods.publish,
-    }
-  )
+export const BaseChatAPI = extendComponent<BaseChatConsumer, ChatMethods>(
+  BaseChatConsumer,
+  {
+    publish: chatMethods.publish,
+  }
+)
 
-export const createBaseChatObject = <
-  ChatType,
-  ChatApiEvents extends EventEmitter.ValidEventTypes = BaseChatApiEvents
->(
+export const createBaseChatObject = <ChatType>(
   params: BaseComponentOptions<ChatTransformsEvents>
 ) => {
-  const chat = connect<
-    ChatApiEvents,
-    BaseChatConsumer<ChatApiEvents>,
-    ChatType
-  >({
+  const chat = connect<BaseChatApiEvents, BaseChatConsumer, ChatType>({
     store: params.store,
-    Component: BaseChatAPI<ChatApiEvents>(),
+    Component: BaseChatAPI,
     componentListeners: {
       errors: 'onError',
       responses: 'onSuccess',

--- a/packages/core/src/chat/BaseChatMessage.ts
+++ b/packages/core/src/chat/BaseChatMessage.ts
@@ -1,0 +1,29 @@
+import { ChatMessageContract } from '..'
+
+export class BaseChatMessage implements ChatMessageContract {
+  constructor(public payload: ChatMessageContract) {}
+
+  get id(): string {
+    return this.payload.id
+  }
+
+  get senderId(): string {
+    return this.payload.senderId
+  }
+
+  get channel(): string {
+    return this.payload.channel
+  }
+
+  get message(): string {
+    return this.payload.message
+  }
+
+  get meta(): any {
+    return this.payload.meta
+  }
+
+  get timestamp(): number {
+    return this.payload.timestamp
+  }
+}

--- a/packages/core/src/chat/ChatMessage.ts
+++ b/packages/core/src/chat/ChatMessage.ts
@@ -23,7 +23,7 @@ export class ChatMessage implements ChatMessageContract {
     return this.payload.meta
   }
 
-  get timestamp(): number {
-    return this.payload.timestamp
+  get publishedAt(): Date {
+    return this.payload.publishedAt
   }
 }

--- a/packages/core/src/chat/ChatMessage.ts
+++ b/packages/core/src/chat/ChatMessage.ts
@@ -1,6 +1,6 @@
 import { ChatMessageContract } from '..'
 
-export class BaseChatMessage implements ChatMessageContract {
+export class ChatMessage implements ChatMessageContract {
   constructor(public payload: ChatMessageContract) {}
 
   get id(): string {

--- a/packages/core/src/chat/index.ts
+++ b/packages/core/src/chat/index.ts
@@ -1,2 +1,3 @@
 export * from './methods'
 export * from './BaseChat'
+export * from './BaseChatMessage'

--- a/packages/core/src/chat/index.ts
+++ b/packages/core/src/chat/index.ts
@@ -1,3 +1,3 @@
 export * from './methods'
 export * from './BaseChat'
-export * from './BaseChatMessage'
+export * from './ChatMessage'

--- a/packages/core/src/types/chat.ts
+++ b/packages/core/src/types/chat.ts
@@ -2,10 +2,11 @@ import { OnlyStateProperties, OnlyFunctionProperties, SwEvent } from '..'
 import { MapToPubSubShape } from '../redux/interfaces'
 import { PRODUCT_PREFIX_CHAT } from '../utils/constants'
 
-export type ChatNamespace = typeof PRODUCT_PREFIX_CHAT
 type ToInternalChatEvent<T extends string> = `${ChatNamespace}.${T}`
+export type ChatNamespace = typeof PRODUCT_PREFIX_CHAT
 
-type ChannelMessageEvent = 'channel.message'
+export type ChatMessageEventName = 'message'
+export type ChatEventNames = ChatMessageEventName
 
 export interface ChatPublishParams {
   message: any
@@ -43,6 +44,8 @@ export interface InternalChatChannel {
  * ==========
  */
 
+type ChannelMessageEventName = 'channel.message'
+
 /**
  * 'chat.channel.message'
  */
@@ -56,7 +59,7 @@ export interface ChatChannelMessageEventParams {
 }
 
 export interface ChatChannelMessageEvent extends SwEvent {
-  event_type: ToInternalChatEvent<ChannelMessageEvent>
+  event_type: ToInternalChatEvent<ChannelMessageEventName>
   params: ChatChannelMessageEventParams
 }
 

--- a/packages/core/src/types/chat.ts
+++ b/packages/core/src/types/chat.ts
@@ -22,7 +22,7 @@ export interface ChatMessageContract {
   senderId: string
   channel: string
   message: any
-  timestamp: number
+  publishedAt: Date
   meta?: any
 }
 
@@ -55,7 +55,7 @@ export interface ChatChannelMessageEventParams {
   message: string
   channel: string
   meta?: any
-  timestamp: number
+  publishedAt: number
 }
 
 export interface ChatChannelMessageEvent extends SwEvent {

--- a/packages/core/src/types/chat.ts
+++ b/packages/core/src/types/chat.ts
@@ -26,6 +26,15 @@ export interface ChatContract {
   publish(params: ChatPublishParams): any
 }
 
+export interface ChatMessageContract {
+  id: string
+  senderId: string
+  channel: string
+  message: any
+  timestamp: number
+  meta?: any
+}
+
 export type ChatEntity = OnlyStateProperties<ChatContract>
 export type ChatMethods = Omit<
   OnlyFunctionProperties<ChatContract>,
@@ -48,8 +57,12 @@ export interface InternalChatChannel {
  * 'chat.channel.message'
  */
 export interface ChatChannelMessageEventParams {
+  id: string
+  sender_id: string
   message: string
   channel: string
+  meta?: any
+  timestamp: number
 }
 
 export interface ChatChannelMessageEvent extends SwEvent {

--- a/packages/core/src/types/chat.ts
+++ b/packages/core/src/types/chat.ts
@@ -5,16 +5,7 @@ import { PRODUCT_PREFIX_CHAT } from '../utils/constants'
 export type ChatNamespace = typeof PRODUCT_PREFIX_CHAT
 type ToInternalChatEvent<T extends string> = `${ChatNamespace}.${T}`
 
-type ChannelMessage = 'channel.message'
-
-export type ChatApiEventsHandlerMapping = Record<
-  'message',
-  (message: any) => void
->
-
-export type ChatApiEvents = {
-  [k in keyof ChatApiEventsHandlerMapping]: ChatApiEventsHandlerMapping[k]
-}
+type ChannelMessageEvent = 'channel.message'
 
 export interface ChatPublishParams {
   message: any
@@ -25,7 +16,6 @@ export interface ChatContract {
   subscribe(channels: string[]): any
   publish(params: ChatPublishParams): any
 }
-
 export interface ChatMessageContract {
   id: string
   senderId: string
@@ -66,7 +56,7 @@ export interface ChatChannelMessageEventParams {
 }
 
 export interface ChatChannelMessageEvent extends SwEvent {
-  event_type: ToInternalChatEvent<ChannelMessage>
+  event_type: ToInternalChatEvent<ChannelMessageEvent>
   params: ChatChannelMessageEventParams
 }
 

--- a/packages/core/src/types/utils.ts
+++ b/packages/core/src/types/utils.ts
@@ -90,6 +90,22 @@ export interface DefaultPublicToInternalTypeMapping {
   endedAt?: number
 }
 
+export interface DefaultInternalToPublicTypeMapping {}
+
+export type ConverToExternalTypes<
+  Property extends string,
+  DefaultType,
+  TypesMap extends Partial<
+    Record<string, any>
+  > = DefaultInternalToPublicTypeMapping
+> = Property extends IsTimestampProperty<Property>
+  ? // We're basically checking that `Property` exists inside
+    // of `TypesMap`, if not we'll default to Date
+    TypesMap[Property] extends TypesMap[keyof TypesMap]
+    ? TypesMap[Property]
+    : Date
+  : DefaultType
+
 /**
  * For user convenience, sometimes we expose properties with
  * a different type than the one used by the server. A good

--- a/packages/core/src/types/videoMember.ts
+++ b/packages/core/src/types/videoMember.ts
@@ -66,7 +66,6 @@ type VideoMemberUpdatableProps = AssertSameType<
   }
 >
 
-// @ts-expect-error
 export const MEMBER_UPDATABLE_PROPS: VideoMemberUpdatableProps = toExternalJSON(
   INTERNAL_MEMBER_UPDATABLE_PROPS
 )

--- a/packages/core/src/types/videoPlayback.ts
+++ b/packages/core/src/types/videoPlayback.ts
@@ -43,15 +43,15 @@ export interface VideoPlaybackContract {
 
   /** Url of the file reproduced by this playback */
   url: string
-  
+
   /** Audio volume at which the playback file is reproduced */
   volume: number
 
   /** Start time, if available */
-  startedAt: number
+  startedAt: Date
 
   /** End time, if available */
-  endedAt?: number
+  endedAt?: Date
 
   /** Pauses the playback. */
   pause(): Promise<void>

--- a/packages/core/src/utils/interfaces.ts
+++ b/packages/core/src/utils/interfaces.ts
@@ -291,6 +291,8 @@ export type GlobalVideoEvents = typeof GLOBAL_VIDEO_EVENTS[number]
 export type InternalGlobalVideoEvents =
   typeof INTERNAL_GLOBAL_VIDEO_EVENTS[number]
 
+type ChatTransformType = 'chatMessage'
+
 /**
  * NOTE: `EventTransformType` is not tied to a constructor but more on
  * the event payloads.
@@ -307,6 +309,7 @@ export type EventTransformType =
   | 'roomSessionLayout'
   | 'roomSessionRecording'
   | 'roomSessionPlayback'
+  | ChatTransformType
 /**
  * `EventTransform`s represent our internal pipeline for
  * creating specific instances for each event handler. This

--- a/packages/core/src/utils/toExternalJSON.ts
+++ b/packages/core/src/utils/toExternalJSON.ts
@@ -1,4 +1,4 @@
-import { SnakeToCamelCase } from '../types/utils'
+import { SnakeToCamelCase, ConverToExternalTypes } from '../types/utils'
 
 const toDateObject = (timestamp?: number) => {
   if (typeof timestamp === 'undefined') {
@@ -40,7 +40,9 @@ const isTimestampProperty = (prop: string) => {
 }
 
 type ToExternalJSONResult<T> = {
-  [K in keyof T as SnakeToCamelCase<Extract<K, string>>]: T[K]
+  [Property in NonNullable<keyof T> as SnakeToCamelCase<
+    Extract<Property, string>
+  >]: ConverToExternalTypes<Extract<Property, string>, T[Property]>
 }
 
 /**

--- a/packages/core/src/utils/toExternalJSON.ts
+++ b/packages/core/src/utils/toExternalJSON.ts
@@ -1,3 +1,5 @@
+import { SnakeToCamelCase } from '../types/utils'
+
 const toDateObject = (timestamp?: number) => {
   if (typeof timestamp === 'undefined') {
     return timestamp
@@ -35,6 +37,10 @@ const DEFAULT_OPTIONS = {
  */
 const isTimestampProperty = (prop: string) => {
   return prop.endsWith('At')
+}
+
+type ToExternalJSONResult<T> = {
+  [K in keyof T as SnakeToCamelCase<Extract<K, string>>]: T[K]
 }
 
 /**
@@ -89,7 +95,7 @@ export const toExternalJSON = <T>(
     }
 
     return reducer
-  }, {} as Record<string, unknown>) as T
+  }, {} as Record<string, unknown>) as ToExternalJSONResult<T>
 }
 
 /**

--- a/packages/js/examples/chat/index.js
+++ b/packages/js/examples/chat/index.js
@@ -7,8 +7,7 @@ window.connect = async ({ channels, host, token }) => {
   })
 
   chat.on('message', (args) => {
-    const { timestamp } = args
-    const { message, channel } = args.params
+    const { message, channel, timestamp } = args
     const messageEl = document.createElement('div')
     messageEl.classList.add('message', 'bg-indigo-200', 'p-2')
     messageEl.innerHTML = `

--- a/packages/js/src/chat/Chat.ts
+++ b/packages/js/src/chat/Chat.ts
@@ -3,9 +3,11 @@ import type {
   ChatContract,
   ConsumerContract,
   UserOptions,
-  ChatApiEvents,
+  Chat as ChatNamespace,
 } from '@signalwire/core'
 import { createClient } from '../createClient'
+
+export interface ChatApiEvents extends ChatNamespace.BaseChatApiEvents {}
 
 export interface ChatFullState extends Chat {}
 interface ChatMain


### PR DESCRIPTION
The code in this changeset includes:

* When listening to `chat.on('message', ..)` the event handler will now receive an instance of `ChatMessage` instead of the raw payload.
* Minor improvement over the typings of `toExternalJSON` to better reflect what's its output.