### PR TITLE
Chat `unsubscribe`

### DIFF
--- a/.changeset/real-years-tickle.md
+++ b/.changeset/real-years-tickle.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/js': minor
+---
+
+[internal] Add ability to unsubscribe from one or more Chat channels

--- a/.changeset/spicy-bottles-pay.md
+++ b/.changeset/spicy-bottles-pay.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/core': patch
+---
+
+Add ability to get the session's auth status from BaseComponent subclasses

--- a/packages/core/src/BaseComponent.ts
+++ b/packages/core/src/BaseComponent.ts
@@ -19,6 +19,7 @@ import {
   EventTransformType,
   EventTransform,
   SDKWorker,
+  SessionAuthStatus,
 } from './utils/interfaces'
 import { EventEmitter } from './utils/EventEmitter'
 import { SDKState } from './redux/interfaces'
@@ -687,6 +688,10 @@ export class BaseComponent<
    */
   protected getEmitterTransforms(): Map<string | string[], EventTransform> {
     return new Map()
+  }
+
+  protected get _sessionAuthStatus(): SessionAuthStatus {
+    return getAuthStatus(this.store.getState())
   }
 
   /** @internal */

--- a/packages/core/src/BaseComponent.ts
+++ b/packages/core/src/BaseComponent.ts
@@ -690,6 +690,7 @@ export class BaseComponent<
     return new Map()
   }
 
+  /** @internal */
   protected get _sessionAuthStatus(): SessionAuthStatus {
     return getAuthStatus(this.store.getState())
   }

--- a/packages/core/src/BaseConsumer.ts
+++ b/packages/core/src/BaseConsumer.ts
@@ -53,7 +53,9 @@ export class BaseConsumer<
           return reject(error)
         }
       } else {
-        this.logger.warn('`run()` was called without any listeners attached.')
+        this.logger.warn(
+          '`subscribe()` was called without any listeners attached.'
+        )
       }
 
       return resolve(undefined)

--- a/packages/core/src/chat/BaseChat.ts
+++ b/packages/core/src/chat/BaseChat.ts
@@ -56,10 +56,6 @@ export class BaseChatConsumer extends BaseConsumer<BaseChatApiEvents> {
     this._attachListeners('')
   }
 
-  protected getWorkers() {
-    return new Map([['chat', { worker: workers.chatWorker }]])
-  }
-
   private _setSubscribeParams(channels: string[]) {
     this.subscribeParams = {
       ...this.subscribeParams,
@@ -67,19 +63,8 @@ export class BaseChatConsumer extends BaseConsumer<BaseChatApiEvents> {
     }
   }
 
-  async subscribe(channels?: string | string[]) {
-    const _channels =
-      !channels || Array.isArray(channels) ? channels : [channels]
-
-    if (!Array.isArray(_channels) || _channels.length === 0) {
-      throw new Error(
-        'Please specify one or more channels when calling .subscribe()'
-      )
-    }
-
-    this._setSubscribeParams(_channels)
-
-    return await super.subscribe()
+  protected getWorkers() {
+    return new Map([['chat', { worker: workers.chatWorker }]])
   }
 
   /** @internal */
@@ -98,6 +83,21 @@ export class BaseChatConsumer extends BaseConsumer<BaseChatApiEvents> {
         },
       ],
     ])
+  }
+
+  async subscribe(channels?: string | string[]) {
+    const _channels =
+      !channels || Array.isArray(channels) ? channels : [channels]
+
+    if (!Array.isArray(_channels) || _channels.length === 0) {
+      throw new Error(
+        'Please specify one or more channels when calling .subscribe()'
+      )
+    }
+
+    this._setSubscribeParams(_channels)
+
+    return await super.subscribe()
   }
 }
 

--- a/packages/core/src/chat/BaseChat.ts
+++ b/packages/core/src/chat/BaseChat.ts
@@ -56,10 +56,28 @@ export class BaseChatConsumer extends BaseConsumer<BaseChatApiEvents> {
     this._attachListeners('')
   }
 
-  private _setSubscribeParams(channels: string[]) {
+  private _getChannelsParam(
+    channels: string | string[] | undefined,
+    method: 'subscribe' | 'unsubscribe'
+  ) {
+    const _channels =
+      !channels || Array.isArray(channels) ? channels : [channels]
+
+    if (!Array.isArray(_channels) || _channels.length === 0) {
+      throw new Error(
+        `Please specify one or more channels when calling .${method}()`
+      )
+    }
+
+    return {
+      channels: toInternalChatChannels(_channels),
+    }
+  }
+
+  private _setSubscribeParams(params: Record<string, any>) {
     this.subscribeParams = {
       ...this.subscribeParams,
-      channels: toInternalChatChannels(channels),
+      ...params,
     }
   }
 
@@ -86,16 +104,11 @@ export class BaseChatConsumer extends BaseConsumer<BaseChatApiEvents> {
   }
 
   async subscribe(channels?: string | string[]) {
-    const _channels =
-      !channels || Array.isArray(channels) ? channels : [channels]
-
-    if (!Array.isArray(_channels) || _channels.length === 0) {
-      throw new Error(
-        'Please specify one or more channels when calling .subscribe()'
-      )
+    const params = {
+      ...this._getChannelsParam(channels, 'subscribe'),
     }
 
-    this._setSubscribeParams(_channels)
+    this._setSubscribeParams(params)
 
     return await super.subscribe()
   }

--- a/packages/core/src/chat/BaseChat.ts
+++ b/packages/core/src/chat/BaseChat.ts
@@ -45,6 +45,17 @@ export class BaseChatConsumer extends BaseConsumer<BaseChatApiEvents> {
   protected override _eventsPrefix = 'chat' as const
   protected override subscribeMethod: JSONRPCSubscribeMethod = 'chat.subscribe'
 
+  constructor(options: BaseComponentOptions<BaseChatApiEvents>) {
+    super(options)
+
+    /**
+     * Since we don't need a namespace for these events
+     * we'll attach them as soon as the Client has been
+     * registered in the Redux store.
+     */
+    this._attachListeners('')
+  }
+
   protected getWorkers() {
     return new Map([['chat', { worker: workers.chatWorker }]])
   }
@@ -88,10 +99,6 @@ export class BaseChatConsumer extends BaseConsumer<BaseChatApiEvents> {
       ],
     ])
   }
-
-  onChatInitialized() {
-    this._attachListeners('')
-  }
 }
 
 export const BaseChatAPI = extendComponent<BaseChatConsumer, ChatMethods>(
@@ -110,7 +117,6 @@ export const createBaseChatObject = <ChatType>(
     componentListeners: {
       errors: 'onError',
       responses: 'onSuccess',
-      id: 'onChatInitialized',
     },
   })(params)
 

--- a/packages/core/src/chat/BaseChat.ts
+++ b/packages/core/src/chat/BaseChat.ts
@@ -7,6 +7,7 @@ import {
   toExternalJSON,
   InternalChatChannel,
   EventTransform,
+  ExecuteParams,
 } from '..'
 import { ChatMessage } from './ChatMessage'
 import * as chatMethods from './methods'
@@ -111,6 +112,37 @@ export class BaseChatConsumer extends BaseConsumer<BaseChatApiEvents> {
     this._setSubscribeParams(params)
 
     return await super.subscribe()
+  }
+
+  async unsubscribe(channels: string | string[]) {
+    const params = {
+      ...this._getChannelsParam(channels, 'unsubscribe'),
+    }
+
+    return new Promise(async (resolve, reject) => {
+      const subscriptions = this.getSubscriptions()
+      if (subscriptions.length > 0) {
+        const execParams: ExecuteParams = {
+          method: 'chat.unsubscribe',
+          params: {
+            ...params,
+            events: subscriptions,
+          },
+        }
+
+        try {
+          await this.execute(execParams)
+        } catch (error) {
+          return reject(error)
+        }
+      } else {
+        this.logger.warn(
+          '`unsubscribe()` was called without any listeners attached.'
+        )
+      }
+
+      return resolve(undefined)
+    })
   }
 }
 

--- a/packages/core/src/chat/methods.ts
+++ b/packages/core/src/chat/methods.ts
@@ -1,6 +1,6 @@
-import type { ChatPublishParams } from '../types/chat'
+import type { ChatPublishParams, ChatJSONRPCMethod } from '../types/chat'
 import type { BaseChatConsumer } from './BaseChat'
-import { ExecuteExtendedOptions, ChatMethod } from '../utils/interfaces'
+import type { ExecuteExtendedOptions } from '../utils/interfaces'
 
 interface ChatMethodPropertyDescriptor<T, ParamsType>
   extends PropertyDescriptor {
@@ -13,7 +13,7 @@ type ChatMethodDescriptor<
 > = ChatMethodPropertyDescriptor<T, ParamsType> & ThisType<BaseChatConsumer>
 
 const createChatMethod = <InputType, OutputType = InputType>(
-  method: ChatMethod,
+  method: ChatJSONRPCMethod,
   options: ExecuteExtendedOptions<InputType, OutputType> = {}
 ): ChatMethodDescriptor<OutputType> => ({
   value: function (params: ChatMethodParams = {}): Promise<OutputType> {

--- a/packages/core/src/types/chat.ts
+++ b/packages/core/src/types/chat.ts
@@ -1,5 +1,5 @@
-import { OnlyStateProperties, OnlyFunctionProperties, SwEvent } from '..'
-import { MapToPubSubShape } from '../redux/interfaces'
+import type { OnlyStateProperties, OnlyFunctionProperties, SwEvent } from '..'
+import type { MapToPubSubShape } from '../redux/interfaces'
 import { PRODUCT_PREFIX_CHAT } from '../utils/constants'
 
 type ToInternalChatEvent<T extends string> = `${ChatNamespace}.${T}`
@@ -31,10 +31,6 @@ export type ChatMethods = Omit<
   OnlyFunctionProperties<ChatContract>,
   'subscribe'
 >
-
-export interface InternalChatChannel {
-  name: string
-}
 
 /**
  * ==========
@@ -68,3 +64,9 @@ export type ChatEvent = ChatChannelMessageEvent
 export type ChatEventParams = ChatChannelMessageEventParams
 
 export type ChatAction = MapToPubSubShape<ChatEvent>
+
+export interface InternalChatChannel {
+  name: string
+}
+
+export type ChatJSONRPCMethod = 'chat.subscribe' | 'chat.publish'

--- a/packages/core/src/types/chat.ts
+++ b/packages/core/src/types/chat.ts
@@ -70,3 +70,5 @@ export interface InternalChatChannel {
 }
 
 export type ChatJSONRPCMethod = 'chat.subscribe' | 'chat.publish'
+
+export type ChatTransformType = 'chatMessage'

--- a/packages/core/src/types/chat.ts
+++ b/packages/core/src/types/chat.ts
@@ -8,14 +8,16 @@ export type ChatNamespace = typeof PRODUCT_PREFIX_CHAT
 export type ChatMessageEventName = 'message'
 export type ChatEventNames = ChatMessageEventName
 
+export type ChatChannel = string | string[]
+
 export interface ChatPublishParams {
   message: any
   channel: string
   meta?: any
 }
 export interface ChatContract {
-  subscribe(channels: string[]): any
-  unsubscribe(channels: string[]): any
+  subscribe(channels: ChatChannel[]): any
+  unsubscribe(channels: ChatChannel[]): any
   publish(params: ChatPublishParams): any
 }
 export interface ChatMessageContract {

--- a/packages/core/src/types/chat.ts
+++ b/packages/core/src/types/chat.ts
@@ -15,6 +15,7 @@ export interface ChatPublishParams {
 }
 export interface ChatContract {
   subscribe(channels: string[]): any
+  unsubscribe(channels: string[]): any
   publish(params: ChatPublishParams): any
 }
 export interface ChatMessageContract {
@@ -29,7 +30,7 @@ export interface ChatMessageContract {
 export type ChatEntity = OnlyStateProperties<ChatContract>
 export type ChatMethods = Omit<
   OnlyFunctionProperties<ChatContract>,
-  'subscribe'
+  'subscribe' | 'unsubscribe'
 >
 
 /**
@@ -69,6 +70,9 @@ export interface InternalChatChannel {
   name: string
 }
 
-export type ChatJSONRPCMethod = 'chat.subscribe' | 'chat.publish'
+export type ChatJSONRPCMethod =
+  | 'chat.subscribe'
+  | 'chat.publish'
+  | 'chat.unsubscribe'
 
 export type ChatTransformType = 'chatMessage'

--- a/packages/core/src/utils/interfaces.ts
+++ b/packages/core/src/utils/interfaces.ts
@@ -10,7 +10,7 @@ import {
 import type { CustomSaga, PubSubChannel } from '../redux/interfaces'
 import type { URL as NodeURL } from 'node:url'
 import { InternalRPCMethods } from '../internal'
-import { ChatJSONRPCMethod } from '..'
+import { ChatJSONRPCMethod, ChatTransformType } from '..'
 
 type JSONRPCParams = Record<string, any>
 type JSONRPCResult = Record<string, any>
@@ -289,8 +289,6 @@ export type EventsPrefix = '' | typeof PRODUCT_PREFIXES[number]
 export type GlobalVideoEvents = typeof GLOBAL_VIDEO_EVENTS[number]
 export type InternalGlobalVideoEvents =
   typeof INTERNAL_GLOBAL_VIDEO_EVENTS[number]
-
-type ChatTransformType = 'chatMessage'
 
 /**
  * NOTE: `EventTransformType` is not tied to a constructor but more on

--- a/packages/core/src/utils/interfaces.ts
+++ b/packages/core/src/utils/interfaces.ts
@@ -10,6 +10,7 @@ import {
 import type { CustomSaga, PubSubChannel } from '../redux/interfaces'
 import type { URL as NodeURL } from 'node:url'
 import { InternalRPCMethods } from '../internal'
+import { ChatJSONRPCMethod } from '..'
 
 type JSONRPCParams = Record<string, any>
 type JSONRPCResult = Record<string, any>
@@ -48,7 +49,7 @@ export type JSONRPCMethod =
   | RoomMethod
   | VertoMethod
   | InternalRPCMethods
-  | ChatMethod
+  | ChatJSONRPCMethod
 
 export type JSONRPCSubscribeMethod = Extract<
   JSONRPCMethod,
@@ -197,8 +198,6 @@ export type SessionAuthError = {
   code: number
   error: string
 }
-
-export type ChatMethod = 'chat.subscribe' | 'chat.publish'
 
 /**
  * List of all Room methods

--- a/packages/js/examples/chat/index.html
+++ b/packages/js/examples/chat/index.html
@@ -15,6 +15,7 @@
   </head>
   <body class="bg-gray-200">
     <main class="max-w-xl mx-auto">
+      <div class="opacity-20 pointer-events-none"></div>
       <div id="chat-join">
         <div class="mt-6 px-4 py-5 bg-white space-y-6 sm:p-6">
           <form id="chat-connect">

--- a/packages/js/examples/chat/index.js
+++ b/packages/js/examples/chat/index.js
@@ -30,12 +30,22 @@ window.connect = async ({ channels, host, token }) => {
   const formEl = document.getElementById('chat-box')
   const channelSelectorEl = document.getElementById('chat-channels-selector')
 
+  window.disconnect = (channel) => {
+    const el = document.querySelector(`.chat-messages-channel-${channel}`)
+    el.classList.add('opacity-20', 'pointer-events-none')
+
+    chat.unsubscribe(channel)
+  }
+
   channels.forEach((channel) => {
     messagesContainerEl.insertAdjacentHTML(
       'beforeend',
       `<div
         class="chat-messages-channel-${channel} mt-6 px-4 py-5 bg-white space-y-6 sm:p-6"
        >
+        <div class="font-bold">
+          <button onclick="disconnect('${channel}')">Unsubscribe</button>
+        </div>
         <p class="text-gray-700 text-xl font-extrabold tracking-tight mt-2">
           Channel: ${channel}
         </p>

--- a/packages/js/src/chat/Chat.test.ts
+++ b/packages/js/src/chat/Chat.test.ts
@@ -116,4 +116,41 @@ describe('Chat Object', () => {
       })
     })
   })
+
+  describe('Unsubscribe', () => {
+    it('should convert channels into the internal channel notation when calling .unsubscribe()', async () => {
+      const chat = new Chat({
+        host,
+        token,
+      })
+
+      chat.on('message', () => {})
+      await chat.subscribe(['test1', 'test2', 'test3'])
+      await chat.unsubscribe(['test1', 'test2', 'test3'])
+
+      const unsubscribeMsg = JSON.parse(server.messages[1].toString())
+      expect(unsubscribeMsg.params.channels).toStrictEqual([
+        { name: 'test1' },
+        { name: 'test2' },
+        { name: 'test3' },
+      ])
+    })
+
+    it('should throw if the user call .unsubscribe() before the session is authorized', async () => {
+      const chat = new Chat({
+        host,
+        token,
+      })
+
+      chat.on('message', () => {})
+
+      try {
+        await chat.unsubscribe(['test1'])
+      } catch (err) {
+        expect(err.message).toBe(
+          'You must be authenticated to unsubscribe from a channel'
+        )
+      }
+    })
+  })
 })

--- a/packages/js/src/chat/Chat.test.ts
+++ b/packages/js/src/chat/Chat.test.ts
@@ -136,6 +136,24 @@ describe('Chat Object', () => {
       ])
     })
 
+    it('should allow the user to .unsubscribe() from any subgroup of subscribed channels', async () => {
+      expect.assertions(4)
+      const chat = new Chat({
+        host,
+        token,
+      })
+
+      chat.on('message', () => {})
+
+      await chat.subscribe(['test1', 'test2', 'test3'])
+      expect(await chat.unsubscribe(['test1', 'test3'])).toBeUndefined()
+      expect(await chat.unsubscribe(['test1', 'test2'])).toBeUndefined()
+      expect(await chat.unsubscribe(['test2', 'test3'])).toBeUndefined()
+      expect(
+        await chat.unsubscribe(['test1', 'test2', 'test3'])
+      ).toBeUndefined()
+    })
+
     it('should throw if the user calls .unsubscribe() before the session is authorized', async () => {
       expect.assertions(1)
       const chat = new Chat({

--- a/packages/js/src/chat/Chat.ts
+++ b/packages/js/src/chat/Chat.ts
@@ -27,6 +27,10 @@ export const Chat = function (chatOptions: ChatOptions) {
 
     return await client.chat.subscribe(channels)
   }
+  const unsubscribe: Chat['unsubscribe'] = async (params) => {
+    // TODO: check if the client is connected
+    return await client.chat.unsubscribe(params)
+  }
   const publish: Chat['publish'] = async (params) => {
     await client.connect()
 
@@ -37,6 +41,8 @@ export const Chat = function (chatOptions: ChatOptions) {
     get(target: Chat, prop: keyof Chat, receiver: any) {
       if (prop === 'subscribe') {
         return subscribe
+      } else if (prop === 'unsubscribe') {
+        return unsubscribe
       } else if (prop === 'publish') {
         return publish
       }

--- a/packages/js/src/chat/Chat.ts
+++ b/packages/js/src/chat/Chat.ts
@@ -25,24 +25,18 @@ export const Chat = function (chatOptions: ChatOptions) {
   const subscribe: Chat['subscribe'] = async (channels) => {
     await client.connect()
 
-    return await client.chat.subscribe(channels)
-  }
-  const unsubscribe: Chat['unsubscribe'] = async (params) => {
-    // TODO: check if the client is connected
-    return await client.chat.unsubscribe(params)
+    return client.chat.subscribe(channels)
   }
   const publish: Chat['publish'] = async (params) => {
     await client.connect()
 
-    return await client.chat.publish(params)
+    return client.chat.publish(params)
   }
 
   return new Proxy<Chat>(client.chat, {
     get(target: Chat, prop: keyof Chat, receiver: any) {
       if (prop === 'subscribe') {
         return subscribe
-      } else if (prop === 'unsubscribe') {
-        return unsubscribe
       } else if (prop === 'publish') {
         return publish
       }


### PR DESCRIPTION
The code in this changeset includes:

#### `chat.unsubscribe`:
I took the liberty to prototype a couple of API decisions regarding when to throw an `Error` while unsubscribing from one or more channels. This POC will `throw` under the following conditions:
1. Call to `unsubscribe` before being authenticated.
2. Call to `unsubscribe` with no subscribed channels.
3. Call to `unsubscribe` with channels the user didn't subscribe to. The idea here is to throw if at least one of the unsubscribed channels is invalid. Example:
*subscribed to:* `["ch1", "ch2", "ch3", "ch4"]`
*unsubscribe from:* `["ch1", "ch5"]`

#### Minor Improvements
* Simplified how the listeners were attached in the BaseChat instance. This removes a bit of indirections since now we no longer depends in the internal hook of our custom `connect`
* Did some cleanup like removing unnecessary `await`s, old names being used in `console.logs`, etc 