### PR TITLE
RoomSession: improve member methods signature

### DIFF
--- a/.changeset/hip-papayas-smile.md
+++ b/.changeset/hip-papayas-smile.md
@@ -1,0 +1,6 @@
+---
+'@signalwire/core': patch
+'@signalwire/js': patch
+---
+
+RoomSession: Improve TypeScript signature for member methods with optional properties

--- a/packages/core/src/types/videoRoomSession.ts
+++ b/packages/core/src/types/videoRoomSession.ts
@@ -59,10 +59,10 @@ export interface VideoRoomSessionContract {
   /** Whether muted videos are shown in the room layout. See {@link setHideVideoMuted} */
   hideVideoMuted: boolean
 
-  audioMute(params: MemberCommandParams): Rooms.AudioMuteMember
-  audioUnmute(params: MemberCommandParams): Rooms.AudioUnmuteMember
-  videoMute(params: MemberCommandParams): Rooms.VideoMuteMember
-  videoUnmute(params: MemberCommandParams): Rooms.VideoUnmuteMember
+  audioMute(params?: MemberCommandParams): Rooms.AudioMuteMember
+  audioUnmute(params?: MemberCommandParams): Rooms.AudioUnmuteMember
+  videoMute(params?: MemberCommandParams): Rooms.VideoMuteMember
+  videoUnmute(params?: MemberCommandParams): Rooms.VideoUnmuteMember
   /** @deprecated Use {@link setInputVolume} instead. */
   setMicrophoneVolume(
     params: MemberCommandWithVolumeParams
@@ -74,8 +74,8 @@ export interface VideoRoomSessionContract {
     params: MemberCommandWithValueParams
   ): Rooms.SetInputSensitivityMember
   getMembers(): Rooms.GetMembers
-  deaf(params: MemberCommandParams): Rooms.DeafMember
-  undeaf(params: MemberCommandParams): Rooms.UndeafMember
+  deaf(params?: MemberCommandParams): Rooms.DeafMember
+  undeaf(params?: MemberCommandParams): Rooms.UndeafMember
   /** @deprecated Use {@link setOutputVolume} instead. */
   setSpeakerVolume(
     params: MemberCommandWithVolumeParams

--- a/packages/js/src/RoomSession.docs.ts
+++ b/packages/js/src/RoomSession.docs.ts
@@ -334,7 +334,7 @@ interface RoomMemberMethodsInterfaceDocs {
    * await room.audioMute({memberId: id})
    * ```
    */
-  audioMute(params: { memberId?: string }): Promise<void>
+  audioMute(params?: { memberId?: string }): Promise<void>
 
   /**
    * Unmutes the microphone if it had been previously muted. You can use this
@@ -362,7 +362,7 @@ interface RoomMemberMethodsInterfaceDocs {
    * await room.audioUnmute({memberId: id})
    * ```
    */
-  audioUnmute(params: { memberId?: string }): Promise<void>
+  audioUnmute(params?: { memberId?: string }): Promise<void>
 
   /**
    * Puts the video on mute. Participants will see a mute image instead of the
@@ -391,7 +391,7 @@ interface RoomMemberMethodsInterfaceDocs {
    * await room.videoMute({memberId: id})
    * ```
    */
-  videoMute(params: { memberId?: string }): Promise<void>
+  videoMute(params?: { memberId?: string }): Promise<void>
 
   /**
    * Unmutes the video if it had been previously muted. Participants will
@@ -420,7 +420,7 @@ interface RoomMemberMethodsInterfaceDocs {
    * await room.videoUnmute({memberId: id})
    * ```
    */
-  videoUnmute(params: { memberId?: string }): Promise<void>
+  videoUnmute(params?: { memberId?: string }): Promise<void>
 
   /**
    * Sets the input volume level (e.g. for the microphone). You can use this
@@ -578,7 +578,7 @@ interface RoomControlMethodsInterfaceDocs {
    * await room.deaf({memberId: id})
    * ```
    */
-  deaf(params: { memberId?: string }): Promise<void>
+  deaf(params?: { memberId?: string }): Promise<void>
 
   /**
    * Unmutes the incoming audio. The affected participant will start hearing
@@ -612,7 +612,7 @@ interface RoomControlMethodsInterfaceDocs {
    * await room.undeaf({memberId: id})
    * ```
    */
-  undeaf(params: { memberId?: string }): Promise<void>
+  undeaf(params?: { memberId?: string }): Promise<void>
 
   /**
    * Sets the output volume level (e.g., for the speaker). You can use this


### PR DESCRIPTION
The code in this changeset improves the signature of the RoomSession's methods expecting `MemberCommandParams`. Previously, when calling `audioMute` the user needed to pass at least an empty object `room.audioMute({})` since the signature was expecting 1 param. 