### PR TITLE
Change Chat namespace export

### DIFF
--- a/packages/js/examples/chat/index.js
+++ b/packages/js/examples/chat/index.js
@@ -1,7 +1,7 @@
-import { Chat } from '@signalwire/js'
+import { __sw__PubSub } from '@signalwire/js'
 
 window.connect = async ({ channels, host, token }) => {
-  const chat = new Chat({
+  const chat = new __sw__PubSub.Chat({
     host,
     token,
   })

--- a/packages/js/src/chat/Chat.ts
+++ b/packages/js/src/chat/Chat.ts
@@ -5,6 +5,7 @@ import type {
   UserOptions,
   Chat as ChatNamespace,
 } from '@signalwire/core'
+import { getLogger } from '@signalwire/core'
 import { createClient } from '../createClient'
 
 export interface ChatApiEvents extends ChatNamespace.BaseChatApiEvents {}
@@ -21,6 +22,12 @@ export interface Chat extends AssertSameType<ChatMain, ChatDocs> {}
 export interface ChatOptions extends UserOptions {}
 
 export const Chat = function (chatOptions: ChatOptions) {
+  if ('development' !== process.env.NODE_ENV) {
+    getLogger().warn(
+      '`Chat` is still under development and may change in the future without prior notice.'
+    )
+  }
+
   const client = createClient<Chat>(chatOptions)
   const subscribe: Chat['subscribe'] = async (channels) => {
     await client.connect()

--- a/packages/js/src/index.ts
+++ b/packages/js/src/index.ts
@@ -97,4 +97,4 @@ export type {
   RoomSessionObjectEvents as RoomObjectEvents,
 } from './utils/interfaces'
 
-export * from './chat/Chat'
+export * as __sw__PubSub from './chat/Chat'

--- a/packages/js/src/index.ts
+++ b/packages/js/src/index.ts
@@ -97,4 +97,5 @@ export type {
   RoomSessionObjectEvents as RoomObjectEvents,
 } from './utils/interfaces'
 
+/** @internal */
 export * as __sw__PubSub from './chat/Chat'


### PR DESCRIPTION
The code in this changeset includes:

* Changed how we export the `Chat` namespace to avoid possible misuses while the module is still under development
* Added a `warn` when the `Chat` constructor is used in non-dev environments