### PR TITLE
Remove unused autoConnect option from the codebase

### DIFF
--- a/packages/js/examples/ts-vanilla/index.ts
+++ b/packages/js/examples/ts-vanilla/index.ts
@@ -6,7 +6,6 @@ window._makeClient = async ({ token, emitter }) => {
     const client = await Video.createClient({
       host: 'relay.swire.io',
       token,
-      autoConnect: false,
       emitter,
     })
 

--- a/packages/js/src/createClient.ts
+++ b/packages/js/src/createClient.ts
@@ -16,30 +16,10 @@ import { JWTSession } from './JWTSession'
  * Create a client
  *
  * @example
- * With autoConnect true the client is ready to be used.
  * ```js
  * try {
- *   const client = await Video.createClient({
- *     token: '<YourToken>',
- *   })
- *
- *   // Your client is already connected..
- * } catch (error) {
- *   console.error('Auth Error', error)
- * }
- * ```
- *
- * @example
- * With autoConnect false you can attach additional handlers.
- * ```js
- * try {
- *   const client = await Video.createClient({
+ *   const client = Video.createClient({
  *     token: '<YourJWT>',
- *     autoConnect: false,
- *   })
- *
- *   client.on('socket.closed', () => {
- *     // The WebSocket connection is closed
  *   })
  *
  *   await client.connect()

--- a/packages/realtime-api/src/createClient.ts
+++ b/packages/realtime-api/src/createClient.ts
@@ -10,7 +10,7 @@ import { Client, RealtimeClient } from './Client'
 import { Session } from './Session'
 
 /** @internal */
-export interface CreateClientOptions extends Omit<UserOptions, 'autoConnect'> {}
+export interface CreateClientOptions extends UserOptions {}
 export type { RealtimeClient, ClientEvents }
 
 /**


### PR DESCRIPTION
We decided to remove the `autoConnect` option but i found some places where we still reference it. 