### PR TITLE
Proxy `toString` interceptor

### DIFF
--- a/.changeset/large-beers-protect.md
+++ b/.changeset/large-beers-protect.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/core': patch
+---
+
+[internal] add toString interceptor to BaseComponent's proxies and instanceProxyFactory

--- a/packages/core/src/BaseComponent.ts
+++ b/packages/core/src/BaseComponent.ts
@@ -340,7 +340,14 @@ export class BaseComponent<
       )
       const proxiedObj = new Proxy(cachedInstance, {
         get(target: any, prop: any, receiver: any) {
-          if (
+          if (prop === 'toString') {
+            const property = target[prop]
+
+            return typeof property === 'function'
+              ? // TODO: define serializer.
+                () => JSON.stringify(transformedPayload)
+              : property
+          } else if (
             prop === '_eventsNamespace' &&
             transform.getInstanceEventNamespace
           ) {

--- a/packages/core/src/utils/eventTransformUtils.test.ts
+++ b/packages/core/src/utils/eventTransformUtils.test.ts
@@ -83,4 +83,12 @@ describe('instanceProxyFactory', () => {
     expect(_instanceByTransformType.size).toBe(2)
     expect(_instanceByTransformType.get('otherKey')).toBe(mockInstance)
   })
+
+  it('should be serializable', async () => {
+    const proxy = instanceProxyFactory({ transform, payload })
+
+    expect(proxy.toString()).toMatchInlineSnapshot(
+      `"{\\"id\\":\\"random\\",\\"snakeCase\\":\\"foo\\",\\"camelCase\\":\\"baz\\",\\"otherTest\\":true,\\"counter\\":0}"`
+    )
+  })
 })

--- a/packages/core/src/utils/eventTransformUtils.ts
+++ b/packages/core/src/utils/eventTransformUtils.ts
@@ -1,4 +1,5 @@
 import { EventTransform, EventTransformType } from './interfaces'
+import { proxyFactory } from './proxyUtils'
 
 interface InstanceProxyFactoryParams {
   transform: EventTransform
@@ -65,21 +66,11 @@ export const instanceProxyFactory = ({
   })
 
   const transformedPayload = transform.payloadTransform(payload)
-  const proxiedObj = new Proxy(cachedInstance, {
-    get(target: any, prop: any, receiver: any) {
-      if (prop === '_eventsNamespace' && transform.getInstanceEventNamespace) {
-        return transform.getInstanceEventNamespace(payload)
-      }
-      if (prop === 'eventChannel' && transform.getInstanceEventChannel) {
-        return transform.getInstanceEventChannel(payload)
-      }
-
-      if (prop in transformedPayload) {
-        return transformedPayload[prop]
-      }
-
-      return Reflect.get(target, prop, receiver)
-    },
+  const proxiedObj = proxyFactory({
+    transform,
+    payload,
+    instance: cachedInstance,
+    transformedPayload,
   })
 
   return proxiedObj

--- a/packages/core/src/utils/proxyUtils.ts
+++ b/packages/core/src/utils/proxyUtils.ts
@@ -1,0 +1,55 @@
+import { EventTransform } from '..'
+
+/**
+ * Used for serializing Proxies when calling
+ * Proxy.toString()
+ */
+const proxyToString = <T>({
+  property,
+  payload,
+}: {
+  property: Function | T
+  payload: unknown
+}) => {
+  return typeof property === 'function'
+    ? () => JSON.stringify(payload)
+    : property
+}
+
+interface ProxyFactoryOptions {
+  instance: any
+  transform: EventTransform
+  payload: unknown
+  transformedPayload: any
+}
+
+export const proxyFactory = ({
+  instance,
+  transform,
+  payload,
+  transformedPayload,
+}: ProxyFactoryOptions) => {
+  const proxiedObj = new Proxy(instance, {
+    get(target: any, prop: any, receiver: any) {
+      if (prop === 'toString') {
+        return proxyToString({
+          property: target[prop],
+          payload: transformedPayload,
+        })
+      } else if (
+        prop === '_eventsNamespace' &&
+        transform.getInstanceEventNamespace
+      ) {
+        return transform.getInstanceEventNamespace(payload)
+      } else if (prop === 'eventChannel' && transform.getInstanceEventChannel) {
+        return transform.getInstanceEventChannel(payload)
+      } else if (prop in transformedPayload) {
+        return transformedPayload[prop]
+      }
+
+      return Reflect.get(target, prop, receiver)
+    },
+  })
+
+  return proxiedObj
+}


### PR DESCRIPTION
The code in this changeset includes:

* `toString` interceptor for our Proxy instances so users can get a better representation of the instance's state. For now we're only serializing state, in future PRs we can include methods to better reflect the instance's shape but I would like us to review this first to avoid breaking changes.
* Unified proxy creation in `BaseComponent` and `instanceProxyFactory` since they were identical.