### PR TITLE
Improve error messages with AssertSameType

### DIFF
--- a/packages/core/src/types/utils.ts
+++ b/packages/core/src/types/utils.ts
@@ -29,6 +29,8 @@ export type OnlyFunctionProperties<T> = Pick<T, OnlyFunctionPropertyNames<T>>
 
 export type OnlyStateProperties<T> = Pick<T, OnlyStatePropertyNames<T>>
 
+type ShapeOf<T> = Record<keyof T, any>
+
 /**
  * This type is `never` if the two type parameters don't match. If they match,
  * it is equal to one of the two types.
@@ -75,11 +77,7 @@ export type OnlyStateProperties<T> = Pick<T, OnlyStatePropertyNames<T>>
  * compile-time error. If they are equal, `RoomSession` will refer to the
  * documented version of the methods.
  */
-export type AssertSameType<ExpectedType, Output> = ExpectedType extends Output
-  ? Output extends ExpectedType
-    ? Output
-    : never
-  : never
+export type AssertSameType<ExpectedType extends ShapeOf<Output>, Output extends ShapeOf<ExpectedType>> = Output
 
 export type IsTimestampProperty<Property> = Property extends `${string}At`
   ? Property

--- a/packages/core/src/types/utils.ts
+++ b/packages/core/src/types/utils.ts
@@ -29,7 +29,7 @@ export type OnlyFunctionProperties<T> = Pick<T, OnlyFunctionPropertyNames<T>>
 
 export type OnlyStateProperties<T> = Pick<T, OnlyStatePropertyNames<T>>
 
-type ShapeOf<T> = Record<keyof T, T[keyof T]>
+type ShapeOf<T> = Omit<T, never>
 
 /**
  * This type fails to be evaluated if the two type parameters don't match. If

--- a/packages/core/src/types/utils.ts
+++ b/packages/core/src/types/utils.ts
@@ -32,8 +32,8 @@ export type OnlyStateProperties<T> = Pick<T, OnlyStatePropertyNames<T>>
 type ShapeOf<T> = Record<keyof T, any>
 
 /**
- * This type is `never` if the two type parameters don't match. If they match,
- * it is equal to one of the two types.
+ * This type fails to be evaluated if the two type parameters don't match. If
+ * they match, it is equal to one of the two types.
  *
  * Motivation: we use this type for documentation purposes. Some of the types
  * and interfaces that we want to publicly expose have several layers of

--- a/packages/core/src/types/utils.ts
+++ b/packages/core/src/types/utils.ts
@@ -29,7 +29,7 @@ export type OnlyFunctionProperties<T> = Pick<T, OnlyFunctionPropertyNames<T>>
 
 export type OnlyStateProperties<T> = Pick<T, OnlyStatePropertyNames<T>>
 
-type ShapeOf<T> = Record<keyof T, any>
+type ShapeOf<T> = Record<keyof T, T[keyof T]>
 
 /**
  * This type fails to be evaluated if the two type parameters don't match. If

--- a/packages/core/src/types/utils.ts
+++ b/packages/core/src/types/utils.ts
@@ -77,7 +77,10 @@ type ShapeOf<T> = Record<keyof T, any>
  * compile-time error. If they are equal, `RoomSession` will refer to the
  * documented version of the methods.
  */
-export type AssertSameType<ExpectedType extends ShapeOf<Output>, Output extends ShapeOf<ExpectedType>> = Output
+export type AssertSameType<
+  ExpectedType extends ShapeOf<Output>,
+  Output extends ShapeOf<ExpectedType>
+> = Output
 
 export type IsTimestampProperty<Property> = Property extends `${string}At`
   ? Property


### PR DESCRIPTION
This PR improves the error messages given by TS when the AssertSameType fails.

Commenting out a member of RoomSessionDevice in the docs. Before:

    An interface can only extend an object type or intersection of object types with statically known members

Now:

    Type 'RoomSessionDeviceDocs' does not satisfy the constraint 'ShapeOf<RoomSessionDeviceMain>'.
    Property 'join' is missing in type 'RoomSessionDeviceDocs' but required
        in type 'ShapeOf<RoomSessionDeviceMain>'.