### PR TITLE
Store cleanup

### DIFF
--- a/.changeset/tall-emus-change.md
+++ b/.changeset/tall-emus-change.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/core': patch
+---
+
+[internal] Add ability to cleanup unused components from the store

--- a/packages/core/src/redux/connect.ts
+++ b/packages/core/src/redux/connect.ts
@@ -1,6 +1,5 @@
 import { ReduxComponent, SessionState, CustomSaga } from './interfaces'
 import { SDKStore } from './'
-import { componentActions } from './features'
 import { getComponent } from './features/component/componentSelectors'
 import { getSession } from './features/session/sessionSelectors'
 import type { BaseComponent } from '../BaseComponent'
@@ -54,10 +53,7 @@ export const connect = <
 
     const storeUnsubscribe = store.subscribe(() => {
       const state = store.getState()
-      const component = getComponent(state, instance.__uuid)
-      if (!component) {
-        return
-      }
+      const component = getComponent(state, instance.__uuid) || {}
       for (const reduxKey of componentKeys) {
         if (run === false) {
           return
@@ -65,7 +61,7 @@ export const connect = <
 
         const cacheKey = `${instance.__uuid}.${reduxKey}`
         const current = cacheMap.get(cacheKey)
-        const updatedValue = component?.[reduxKey]
+        const updatedValue = component[reduxKey]
         if (updatedValue !== undefined && current !== updatedValue) {
           cacheMap.set(cacheKey, updatedValue)
           const fnName = componentListeners[reduxKey]

--- a/packages/core/src/redux/connect.ts
+++ b/packages/core/src/redux/connect.ts
@@ -103,7 +103,6 @@ export const connect = <
         }
       }
     })
-    store.dispatch(componentActions.upsert({ id: instance.__uuid }))
 
     // Run all the custom sagas
     const taskList = customSagas?.map((saga) => {

--- a/packages/core/src/redux/features/component/componentSaga.test.ts
+++ b/packages/core/src/redux/features/component/componentSaga.test.ts
@@ -1,13 +1,10 @@
 import { Store } from 'redux'
-import { configureJestStore } from '../../../testUtils'
-import {
-  componentCleanupSaga,
-  componentCleanupSagaWorker,
-} from './componentSaga'
 import { expectSaga } from 'redux-saga-test-plan'
+import { configureJestStore } from '../../../testUtils'
+import { componentCleanupSagaWorker } from './componentSaga'
 import { rootReducer } from '../../rootReducer'
 
-describe('componentSelectors', () => {
+describe('componentCleanupSaga', () => {
   let store: Store
 
   beforeEach(() => {
@@ -31,30 +28,26 @@ describe('componentSelectors', () => {
       },
     })
   })
-
-  describe('componentCleanupSaga', () => {
-    it('should cleanup unused components from the store', () => {
-      return expectSaga(componentCleanupSagaWorker)
-        .withReducer(rootReducer, store.getState())
-        // .delay(3000)
-        .hasFinalState({
-          components: {
-            byId: {
-              '268b4cf8-a3c5-4003-8666-3b7a4f0a5af9': {
-                id: '268b4cf8-a3c5-4003-8666-3b7a4f0a5af9',
-              },
+  it('should cleanup unused components from the store', () => {
+    return expectSaga(componentCleanupSagaWorker)
+      .withReducer(rootReducer, store.getState())
+      .hasFinalState({
+        components: {
+          byId: {
+            '268b4cf8-a3c5-4003-8666-3b7a4f0a5af9': {
+              id: '268b4cf8-a3c5-4003-8666-3b7a4f0a5af9',
             },
           },
-          session: {
-            protocol: '',
-            iceServers: [],
-            authStatus: 'unknown',
-            authError: undefined,
-            authCount: 0,
-          },
-          executeQueue: { queue: [] },
-        })
-        .run()
-    })
+        },
+        session: {
+          protocol: '',
+          iceServers: [],
+          authStatus: 'unknown',
+          authError: undefined,
+          authCount: 0,
+        },
+        executeQueue: { queue: [] },
+      })
+      .run()
   })
 })

--- a/packages/core/src/redux/features/component/componentSaga.test.ts
+++ b/packages/core/src/redux/features/component/componentSaga.test.ts
@@ -1,0 +1,60 @@
+import { Store } from 'redux'
+import { configureJestStore } from '../../../testUtils'
+import {
+  componentCleanupSaga,
+  componentCleanupSagaWorker,
+} from './componentSaga'
+import { expectSaga } from 'redux-saga-test-plan'
+import { rootReducer } from '../../rootReducer'
+
+describe('componentSelectors', () => {
+  let store: Store
+
+  beforeEach(() => {
+    store = configureJestStore({
+      preloadedState: {
+        components: {
+          byId: {
+            '268b4cf8-a3c5-4003-8666-3b7a4f0a5af9': {
+              id: '268b4cf8-a3c5-4003-8666-3b7a4f0a5af9',
+            },
+            'faa63915-3a64-4c39-acbb-06dac0758f8a': {
+              id: 'faa63915-3a64-4c39-acbb-06dac0758f8a',
+              responses: {},
+            },
+            'zfaa63915-3a64-4c39-acbb-06dac0758f8a': {
+              id: 'zfaa63915-3a64-4c39-acbb-06dac0758f8a',
+              errors: {},
+            },
+          },
+        },
+      },
+    })
+  })
+
+  describe('componentCleanupSaga', () => {
+    it('should cleanup unused components from the store', () => {
+      return expectSaga(componentCleanupSagaWorker)
+        .withReducer(rootReducer, store.getState())
+        // .delay(3000)
+        .hasFinalState({
+          components: {
+            byId: {
+              '268b4cf8-a3c5-4003-8666-3b7a4f0a5af9': {
+                id: '268b4cf8-a3c5-4003-8666-3b7a4f0a5af9',
+              },
+            },
+          },
+          session: {
+            protocol: '',
+            iceServers: [],
+            authStatus: 'unknown',
+            authError: undefined,
+            authCount: 0,
+          },
+          executeQueue: { queue: [] },
+        })
+        .run()
+    })
+  })
+})

--- a/packages/core/src/redux/features/component/componentSaga.ts
+++ b/packages/core/src/redux/features/component/componentSaga.ts
@@ -3,21 +3,21 @@ import { delay, fork, put, select } from '@redux-saga/core/effects'
 import { componentActions } from '..'
 import { getComponentsToCleanup } from './componentSelectors'
 
-export function* componentCleanupSaga(): SagaIterator {
-  function* worker(): SagaIterator {
-    const toCleanup = yield select(getComponentsToCleanup)
+export function* componentCleanupSagaWorker(): SagaIterator {
+  const toCleanup = yield select(getComponentsToCleanup)
 
-    if (toCleanup.length) {
-      yield put(
-        componentActions.cleanup({
-          ids: toCleanup,
-        })
-      )
-    }
+  if (toCleanup.length) {
+    yield put(
+      componentActions.cleanup({
+        ids: toCleanup,
+      })
+    )
   }
+}
 
+export function* componentCleanupSaga(): SagaIterator {
   while (true) {
     yield delay(2000)
-    yield fork(worker)
+    yield fork(componentCleanupSagaWorker)
   }
 }

--- a/packages/core/src/redux/features/component/componentSaga.ts
+++ b/packages/core/src/redux/features/component/componentSaga.ts
@@ -1,27 +1,18 @@
 import { SagaIterator } from '@redux-saga/core'
 import { delay, fork, put, select } from '@redux-saga/core/effects'
 import { componentActions } from '..'
-import { ReduxComponent } from '../../interfaces'
-import { getComponentsById } from './componentSelectors'
+import { getComponentsToCleanup } from './componentSelectors'
 
 export function* componentCleanupSaga(): SagaIterator {
   function* worker(): SagaIterator {
-    const components = yield select(getComponentsById)
-
-    let toCleanup: Array<ReduxComponent["id"]> = []
-    Object.keys(components).forEach((id) => {
-      if (
-        components[id].responses ||
-        components[id].errors
-      ) {
-        toCleanup.push(id)
-      }
-    })
+    const toCleanup = yield select(getComponentsToCleanup)
 
     if (toCleanup.length) {
-      yield put(componentActions.cleanup({
-        ids: toCleanup
-      }))
+      yield put(
+        componentActions.cleanup({
+          ids: toCleanup,
+        })
+      )
     }
   }
 

--- a/packages/core/src/redux/features/component/componentSaga.ts
+++ b/packages/core/src/redux/features/component/componentSaga.ts
@@ -1,0 +1,14 @@
+import { SagaIterator } from '@redux-saga/core'
+import { delay, fork, put } from '@redux-saga/core/effects'
+import { componentActions } from '..'
+
+export function* componentCleanupSaga(): SagaIterator {
+  function* worker(): SagaIterator {
+    yield put(componentActions.cleanup())
+  }
+
+  while (true) {
+    yield delay(2000)
+    yield fork(worker)
+  }
+}

--- a/packages/core/src/redux/features/component/componentSaga.ts
+++ b/packages/core/src/redux/features/component/componentSaga.ts
@@ -1,10 +1,28 @@
 import { SagaIterator } from '@redux-saga/core'
-import { delay, fork, put } from '@redux-saga/core/effects'
+import { delay, fork, put, select } from '@redux-saga/core/effects'
 import { componentActions } from '..'
+import { ReduxComponent } from '../../interfaces'
+import { getComponentsById } from './componentSelectors'
 
 export function* componentCleanupSaga(): SagaIterator {
   function* worker(): SagaIterator {
-    yield put(componentActions.cleanup())
+    const components = yield select(getComponentsById)
+
+    let toCleanup: Array<ReduxComponent["id"]> = []
+    Object.keys(components).forEach((id) => {
+      if (
+        components[id].responses ||
+        components[id].errors
+      ) {
+        toCleanup.push(id)
+      }
+    })
+
+    if (toCleanup.length) {
+      yield put(componentActions.cleanup({
+        ids: toCleanup
+      }))
+    }
   }
 
   while (true) {

--- a/packages/core/src/redux/features/component/componentSaga.ts
+++ b/packages/core/src/redux/features/component/componentSaga.ts
@@ -17,7 +17,7 @@ export function* componentCleanupSagaWorker(): SagaIterator {
 
 export function* componentCleanupSaga(): SagaIterator {
   while (true) {
-    yield delay(2000)
+    yield delay(3600_000) // 1 hour
     yield fork(componentCleanupSagaWorker)
   }
 }

--- a/packages/core/src/redux/features/component/componentSelectors.test.ts
+++ b/packages/core/src/redux/features/component/componentSelectors.test.ts
@@ -1,0 +1,38 @@
+import { Store } from 'redux'
+import { configureJestStore } from '../../../testUtils'
+import { getComponentsToCleanup } from './componentSelectors'
+
+describe('componentSelectors', () => {
+  let store: Store
+
+  beforeEach(() => {
+    store = configureJestStore({
+      preloadedState: {
+        components: {
+          byId: {
+            '268b4cf8-a3c5-4003-8666-3b7a4f0a5af9': {
+              id: '268b4cf8-a3c5-4003-8666-3b7a4f0a5af9',
+            },
+            'faa63915-3a64-4c39-acbb-06dac0758f8a': {
+              id: 'faa63915-3a64-4c39-acbb-06dac0758f8a',
+              responses: {},
+            },
+            'zfaa63915-3a64-4c39-acbb-06dac0758f8a': {
+              id: 'zfaa63915-3a64-4c39-acbb-06dac0758f8a',
+              errors: {},
+            },
+          },
+        },
+      },
+    })
+  })
+
+  describe('getComponentsToCleanup', () => {
+    it('should return the list of components to cleanup', () => {
+      expect(getComponentsToCleanup(store.getState())).toEqual([
+        'faa63915-3a64-4c39-acbb-06dac0758f8a',
+        'zfaa63915-3a64-4c39-acbb-06dac0758f8a',
+      ])
+    })
+  })
+})

--- a/packages/core/src/redux/features/component/componentSelectors.ts
+++ b/packages/core/src/redux/features/component/componentSelectors.ts
@@ -1,4 +1,4 @@
-import { SDKState } from '../../interfaces'
+import { ReduxComponent, SDKState } from '../../interfaces'
 
 export const getComponent = ({ components }: SDKState, id: string) => {
   return components.byId?.[id]
@@ -6,4 +6,17 @@ export const getComponent = ({ components }: SDKState, id: string) => {
 
 export const getComponentsById = ({ components }: SDKState) => {
   return components.byId
+}
+
+export const getComponentsToCleanup = (state: SDKState) => {
+  const components = getComponentsById(state)
+
+  let toCleanup: Array<ReduxComponent['id']> = []
+  Object.keys(components).forEach((id) => {
+    if (components[id].responses || components[id].errors) {
+      toCleanup.push(id)
+    }
+  })
+
+  return toCleanup
 }

--- a/packages/core/src/redux/features/component/componentSelectors.ts
+++ b/packages/core/src/redux/features/component/componentSelectors.ts
@@ -3,3 +3,7 @@ import { SDKState } from '../../interfaces'
 export const getComponent = ({ components }: SDKState, id: string) => {
   return components.byId?.[id]
 }
+
+export const getComponentsById = ({ components }: SDKState) => {
+  return components.byId
+}

--- a/packages/core/src/redux/features/component/componentSlice.test.ts
+++ b/packages/core/src/redux/features/component/componentSlice.test.ts
@@ -62,11 +62,6 @@ describe('ComponentState Tests', () => {
       response,
     })
 
-    it('should not change the state if the componentId does not exist', () => {
-      store.dispatch(executeSuccessAction)
-      expect(store.getState().components).toStrictEqual(initialComponentState)
-    })
-
     it('should update the state properly including the response', () => {
       // Create the component first
       store.dispatch(componentActions.upsert(component))
@@ -101,11 +96,6 @@ describe('ComponentState Tests', () => {
       action,
       requestId,
       error,
-    })
-
-    it('should not change the state if the componentId does not exist', () => {
-      store.dispatch(executeFailureAction)
-      expect(store.getState().components).toStrictEqual(initialComponentState)
     })
 
     it('should update the state properly including both the action request and the error response', () => {

--- a/packages/core/src/redux/features/component/componentSlice.ts
+++ b/packages/core/src/redux/features/component/componentSlice.ts
@@ -39,20 +39,21 @@ const componentSlice = createDestroyableSlice({
     },
     executeSuccess: (state, { payload }: PayloadAction<SuccessParams>) => {
       const { componentId, requestId, response } = payload
-      if (state.byId[componentId]) {
-        state.byId[componentId].responses =
-          state.byId[componentId].responses || {}
-        state.byId[componentId].responses![requestId] = response
+      state.byId[componentId] ??= {
+        id: componentId,
       }
+      state.byId[componentId].responses ??= {}
+      state.byId[componentId].responses![requestId] = response
     },
     executeFailure: (state, { payload }: PayloadAction<FailureParams>) => {
       const { componentId, requestId, error, action } = payload
-      if (state.byId[componentId]) {
-        state.byId[componentId].errors = state.byId[componentId].errors || {}
-        state.byId[componentId].errors![requestId] = {
-          action,
-          jsonrpc: error,
-        }
+      state.byId[componentId] ??= {
+        id: componentId,
+      }
+      state.byId[componentId].errors ??= {}
+      state.byId[componentId].errors![requestId] = {
+        action,
+        jsonrpc: error,
       }
     },
   },

--- a/packages/core/src/redux/features/component/componentSlice.ts
+++ b/packages/core/src/redux/features/component/componentSlice.ts
@@ -8,6 +8,9 @@ export const initialComponentState: Readonly<ComponentState> = {
 }
 
 type UpdateComponent = Partial<ReduxComponent> & Pick<ReduxComponent, 'id'>
+type CleanupComponentParams = {
+  ids: Array<ReduxComponent['id']>
+}
 
 type SuccessParams = {
   componentId: string
@@ -56,14 +59,9 @@ const componentSlice = createDestroyableSlice({
         jsonrpc: error,
       }
     },
-    cleanup: (state) => {
-      Object.keys(state.byId).forEach((componentId) => {
-        if (
-          state.byId[componentId].responses ||
-          state.byId[componentId].errors
-        ) {
-          delete state.byId[componentId]
-        }
+    cleanup: (state, { payload }: PayloadAction<CleanupComponentParams>) => {
+      payload.ids.forEach((componentId) => {
+        delete state.byId[componentId]
       })
     },
   },

--- a/packages/core/src/redux/features/component/componentSlice.ts
+++ b/packages/core/src/redux/features/component/componentSlice.ts
@@ -56,6 +56,16 @@ const componentSlice = createDestroyableSlice({
         jsonrpc: error,
       }
     },
+    cleanup: (state) => {
+      Object.keys(state.byId).forEach((componentId) => {
+        if (
+          state.byId[componentId].responses ||
+          state.byId[componentId].errors
+        ) {
+          delete state.byId[componentId]
+        }
+      })
+    },
   },
 })
 

--- a/packages/core/src/redux/index.ts
+++ b/packages/core/src/redux/index.ts
@@ -10,7 +10,7 @@ import {
   InternalChannels,
 } from '../utils/interfaces'
 
-interface ConfigureStoreOptions {
+export interface ConfigureStoreOptions {
   userOptions: InternalUserOptions
   SessionConstructor: SessionConstructor
   runSagaMiddleware?: boolean

--- a/packages/core/src/redux/rootSaga.test.ts
+++ b/packages/core/src/redux/rootSaga.test.ts
@@ -31,6 +31,7 @@ import {
 } from './actions'
 import { AuthError } from '../CustomErrors'
 import { createPubSubChannel } from '../testUtils'
+import { componentCleanupSaga } from './features/component/componentSaga'
 
 describe('socketClosedWorker', () => {
   it('should try to reconnect when session status is reconnecting', async () => {
@@ -169,6 +170,7 @@ describe('initSessionSaga', () => {
       pubSubChannel,
       userOptions,
     })
+    saga.next().fork(componentCleanupSaga)
     saga.next().take(destroyAction.type)
     saga.next().isDone()
     expect(pubSubChannel.close).toHaveBeenCalledTimes(1)

--- a/packages/core/src/redux/rootSaga.ts
+++ b/packages/core/src/redux/rootSaga.ts
@@ -37,6 +37,7 @@ import {
 import { AuthError } from '../CustomErrors'
 import { PubSubChannel } from './interfaces'
 import { createRestartableSaga } from './utils/sagaHelpers'
+import { componentCleanupSaga } from './features/component/componentSaga'
 
 interface StartSagaOptions {
   session: BaseSession
@@ -82,6 +83,8 @@ export function* initSessionSaga({
     }
   }
 
+  const compCleanupTask = yield fork(componentCleanupSaga)
+
   yield fork(sessionChannelWatcher, {
     session,
     sessionChannel,
@@ -101,6 +104,7 @@ export function* initSessionSaga({
   session.connect()
 
   yield take(destroyAction.type)
+  compCleanupTask.cancel()
   pubSubChannel.close()
   sessionChannel.close()
   customTasks.forEach((task) => task.cancel())

--- a/packages/core/src/testUtils.ts
+++ b/packages/core/src/testUtils.ts
@@ -1,5 +1,5 @@
 import { channel } from '@redux-saga/core'
-import { configureStore } from './redux'
+import { configureStore, ConfigureStoreOptions } from './redux'
 import { PubSubChannel } from './redux/interfaces'
 import { BaseSession } from './BaseSession'
 import { RPCConnectResult, InternalSDKLogger } from './utils/interfaces'
@@ -24,7 +24,7 @@ export const createMockedLogger = (): InternalSDKLogger => ({
  *
  * @returns Redux Store
  */
-export const configureJestStore = () => {
+export const configureJestStore = (options?: Partial<ConfigureStoreOptions>) => {
   return configureStore({
     userOptions: {
       project: PROJECT_ID,
@@ -34,6 +34,7 @@ export const configureJestStore = () => {
     },
     SessionConstructor: BaseSession,
     runSagaMiddleware: false,
+    ...options,
   })
 }
 


### PR DESCRIPTION
The code in this changeset includes:

* Changed the way we register components inside of `connect`: We no longer register components automatically in the redux store unless is related to the `componentListeners`, `sessionListeners` or manually calling `componentActions.upsert`. This was mostly done to simplify the cleanup process since we don't have a way to identify if a component with just an id is ready to be cleaned up.
* Added `componentSaga` to execute every hour to cleanup unused components. Check `getComponentsToCleanup` for details on how we determine if a component is ready for cleanup.
* Updated `configureJestStore` (core) to accept an optional `ConfigureStoreOptions`.