### PR TITLE
Update Chat Methods

### DIFF
--- a/.changeset/gorgeous-lies-kneel.md
+++ b/.changeset/gorgeous-lies-kneel.md
@@ -1,0 +1,6 @@
+---
+'@signalwire/core': patch
+'@signalwire/js': patch
+---
+
+[internal] Review chat payloads and interfaces

--- a/internal/playground-js/src/chat/index.js
+++ b/internal/playground-js/src/chat/index.js
@@ -35,17 +35,37 @@ window.connect = async ({ channels, host, token }) => {
 
   chat.on('message', (message) => {
     console.debug('Inbound Message', message)
+
+    // message.id
+    // message.channel
+    // message.member
+    // message.member.id
+    // message.member.channel
+    // message.member.state
+    // message.publishedAt
+    // message.content
+    // message.meta // {}
     _appendMessage(message)
   })
 
   chat.on('member.joined', (member) => {
-    console.debug('Member Joined a channel', member.id, member.channel)
+    console.debug(
+      'Member Joined a channel',
+      member.id,
+      member.channel,
+      member.state
+    )
   })
   chat.on('member.updated', (member) => {
     console.debug('Member Updated', member.id, member.channel, member.state)
   })
   chat.on('member.left', (member) => {
-    console.debug('Member Left a channel', member.id, member.channel)
+    console.debug(
+      'Member Left a channel',
+      member.id,
+      member.channel,
+      member.state
+    )
   })
 
   await chat.subscribe(channels)

--- a/packages/core/src/chat/BaseChat.ts
+++ b/packages/core/src/chat/BaseChat.ts
@@ -25,6 +25,10 @@ import type {
   ChatChannel,
 } from '../types/chat'
 
+type ChatMemberEvent =
+  | ChatMemberJoinedEvent
+  | ChatMemberLeftEvent
+  | ChatMemberUpdatedEvent
 export type BaseChatApiEventsHandlerMapping = Record<
   ChatMessageEventName,
   (message: ChatMessage) => void
@@ -133,12 +137,10 @@ export class BaseChatConsumer extends BaseConsumer<BaseChatApiEvents> {
         },
       ],
       [
-        ['member.joined', 'member.left'],
+        ['member.joined', 'member.left', 'member.updated'],
         {
           type: 'chatMessage',
-          instanceFactory: (
-            payload: ChatMemberJoinedEvent | ChatMemberLeftEvent
-          ) => {
+          instanceFactory: (payload: ChatMemberEvent) => {
             const { channel, member } = payload.params
             const params = {
               ...toExternalJSON(member),
@@ -146,36 +148,11 @@ export class BaseChatConsumer extends BaseConsumer<BaseChatApiEvents> {
             }
             return new ChatMember(params)
           },
-          payloadTransform: (
-            payload: ChatMemberJoinedEvent | ChatMemberLeftEvent
-          ) => {
+          payloadTransform: (payload: ChatMemberEvent) => {
             const { channel, member } = payload.params
             return {
               ...toExternalJSON(member),
               channel,
-            }
-          },
-        },
-      ],
-      [
-        ['member.updated'],
-        {
-          type: 'chatMessage',
-          instanceFactory: (payload: ChatMemberUpdatedEvent) => {
-            const { channel, member, state = {} } = payload.params
-            const params = {
-              ...toExternalJSON(member),
-              channel,
-              state,
-            }
-            return new ChatMember(params)
-          },
-          payloadTransform: (payload: ChatMemberUpdatedEvent) => {
-            const { channel, member, state = {} } = payload.params
-            return {
-              ...toExternalJSON(member),
-              channel,
-              state,
             }
           },
         },

--- a/packages/core/src/chat/BaseChat.ts
+++ b/packages/core/src/chat/BaseChat.ts
@@ -141,19 +141,12 @@ export class BaseChatConsumer extends BaseConsumer<BaseChatApiEvents> {
         {
           type: 'chatMessage',
           instanceFactory: (payload: ChatMemberEvent) => {
-            const { channel, member } = payload.params
-            const params = {
-              ...toExternalJSON(member),
-              channel,
-            }
-            return new ChatMember(params)
+            const { member } = payload.params
+            return new ChatMember(toExternalJSON(member))
           },
           payloadTransform: (payload: ChatMemberEvent) => {
-            const { channel, member } = payload.params
-            return {
-              ...toExternalJSON(member),
-              channel,
-            }
+            const { member } = payload.params
+            return toExternalJSON(member)
           },
         },
       ],

--- a/packages/core/src/chat/BaseChat.ts
+++ b/packages/core/src/chat/BaseChat.ts
@@ -235,8 +235,8 @@ export const BaseChatAPI = extendComponent<BaseChatConsumer, ChatMethods>(
     publish: chatMethods.publish,
     getMembers: chatMethods.getMembers,
     getMessages: chatMethods.getMessages,
-    setState: chatMethods.setState,
-    getState: chatMethods.getState,
+    setMemberState: chatMethods.setMemberState,
+    getMemberState: chatMethods.getMemberState,
   }
 )
 

--- a/packages/core/src/chat/ChatMember.ts
+++ b/packages/core/src/chat/ChatMember.ts
@@ -12,6 +12,6 @@ export class ChatMember implements ChatMemberContract {
   }
 
   get state(): any {
-    return this.payload?.state ?? {}
+    return this.payload.state ?? {}
   }
 }

--- a/packages/core/src/chat/ChatMessage.ts
+++ b/packages/core/src/chat/ChatMessage.ts
@@ -1,4 +1,4 @@
-import { ChatMessageContract } from '..'
+import { ChatMessageContract, ChatMemberContract } from '..'
 
 export class ChatMessage implements ChatMessageContract {
   constructor(private payload: ChatMessageContract) {}
@@ -7,8 +7,8 @@ export class ChatMessage implements ChatMessageContract {
     return this.payload.id
   }
 
-  get senderId(): string {
-    return this.payload.senderId
+  get member(): ChatMemberContract {
+    return this.payload.member
   }
 
   get channel(): string {

--- a/packages/core/src/chat/methods.ts
+++ b/packages/core/src/chat/methods.ts
@@ -89,15 +89,18 @@ export const getMembers = createChatMethod<{ members: any[] }>(
     }),
   }
 )
-export const setState = createChatMethod<any, void>('chat.presence.set_state', {
-  transformResolve: () => {},
-})
+export const setMemberState = createChatMethod<any, void>(
+  'chat.member.set_state',
+  {
+    transformResolve: () => {},
+  }
+)
 
 /**
  * Chat Member Methods
  */
-export const getState = createChatMemberMethod<{ channels: any }>(
-  'chat.presence.get_state',
+export const getMemberState = createChatMemberMethod<{ channels: any }>(
+  'chat.member.get_state',
   {
     transformResolve: (payload) => ({ channels: payload.channels }),
   }

--- a/packages/core/src/chat/methods.ts
+++ b/packages/core/src/chat/methods.ts
@@ -89,16 +89,16 @@ export const getMembers = createChatMethod<{ members: any[] }>(
     }),
   }
 )
-export const setMemberState = createChatMethod<any, void>(
+
+/**
+ * Chat Member Methods
+ */
+export const setMemberState = createChatMemberMethod<any, void>(
   'chat.member.set_state',
   {
     transformResolve: () => {},
   }
 )
-
-/**
- * Chat Member Methods
- */
 export const getMemberState = createChatMemberMethod<{ channels: any }>(
   'chat.member.get_state',
   {

--- a/packages/core/src/types/chat.ts
+++ b/packages/core/src/types/chat.ts
@@ -65,8 +65,8 @@ export type ChatMethods = Omit<
 
 export interface ChatMessageContract {
   id: string
-  senderId: string
   channel: string
+  member: ChatMemberContract
   content: any
   publishedAt: Date
   meta?: any
@@ -79,7 +79,7 @@ export type InternalChatMessageEntity = {
   [K in NonNullable<
     keyof ChatMessageEntity
   > as CamelToSnakeCase<K>]: ChatMessageEntity[K]
-}
+} & { member: InternalChatMemberEntity }
 
 export interface ChatMemberContract {
   id: string

--- a/packages/core/src/types/chat.ts
+++ b/packages/core/src/types/chat.ts
@@ -23,13 +23,18 @@ export type ChatEventNames = ChatMessageEventName | ChatMemberEventNames
 
 export type ChatChannel = string | string[]
 
+export interface ChatSubscribeParams {
+  message: any
+  channel: string
+  meta?: Record<any, any>
+}
 export interface ChatPublishParams {
   message: any
   channel: string
   meta?: Record<any, any>
 }
 interface ChatSetMemberStateParams {
-  memberId?: string
+  memberId: string
   channels: ChatChannel
   state: Record<any, any>
 }

--- a/packages/core/src/types/chat.ts
+++ b/packages/core/src/types/chat.ts
@@ -33,7 +33,7 @@ interface ChatSetMemberStateParams {
   state: Record<any, any>
 }
 interface ChatGetMemberStateParams {
-  channels: ChatChannel
+  channels?: ChatChannel
   memberId: string
 }
 interface ChatGetMessagesParams {

--- a/packages/core/src/types/chat.ts
+++ b/packages/core/src/types/chat.ts
@@ -29,12 +29,13 @@ export interface ChatPublishParams {
   meta?: Record<any, any>
 }
 interface ChatSetMemberStateParams {
+  memberId?: string
   channels: ChatChannel
   state: Record<any, any>
 }
 interface ChatGetMemberStateParams {
-  channels?: ChatChannel
   memberId: string
+  channels?: ChatChannel
 }
 interface ChatGetMessagesParams {
   channel: string

--- a/packages/core/src/types/chat.ts
+++ b/packages/core/src/types/chat.ts
@@ -28,22 +28,22 @@ export interface ChatPublishParams {
   channel: string
   meta?: Record<any, any>
 }
-export interface ChatSetStateParams {
+interface ChatSetMemberStateParams {
   channels: ChatChannel
   state: Record<any, any>
 }
-export interface ChatGetStateParams {
+interface ChatGetMemberStateParams {
   channels: ChatChannel
   memberId: string
 }
-export interface ChatGetMessagesParams {
+interface ChatGetMessagesParams {
   channel: string
   cursor?: {
     after?: string
     before?: string
   }
 }
-export interface ChatGetMembersParams {
+interface ChatGetMembersParams {
   channel: string
 }
 export interface ChatContract {
@@ -52,8 +52,8 @@ export interface ChatContract {
   publish(params: ChatPublishParams): Promise<any>
   getMessages(params: ChatGetMessagesParams): Promise<any>
   getMembers(params: ChatGetMembersParams): Promise<any>
-  setState(params: ChatSetStateParams): Promise<any>
-  getState(params: ChatGetStateParams): Promise<any>
+  setMemberState(params: ChatSetMemberStateParams): Promise<any>
+  getMemberState(params: ChatGetMemberStateParams): Promise<any>
 }
 
 export type ChatEntity = OnlyStateProperties<ChatContract>
@@ -176,8 +176,8 @@ export type ChatJSONRPCMethod =
   | 'chat.subscribe'
   | 'chat.publish'
   | 'chat.unsubscribe'
-  | 'chat.presence.set_state'
-  | 'chat.presence.get_state'
+  | 'chat.member.set_state'
+  | 'chat.member.get_state'
   | 'chat.members.get'
   | 'chat.messages.get'
 

--- a/packages/core/src/types/chat.ts
+++ b/packages/core/src/types/chat.ts
@@ -83,12 +83,15 @@ export type InternalChatMessageEntity = {
 export interface ChatMemberContract {
   id: string
   channel: string
-  state?: Record<any, any>
+  state: Record<any, any>
 }
 
-// Not using OnlyStateProperties because Member for now is just an id..
-export interface InternalChatMemberEntity {
-  id: string
+export type ChatMemberEntity = OnlyStateProperties<ChatMemberContract>
+
+export type InternalChatMemberEntity = {
+  [K in NonNullable<
+    keyof ChatMemberEntity
+  > as CamelToSnakeCase<K>]: ChatMemberEntity[K]
 }
 
 /**
@@ -133,7 +136,6 @@ export interface ChatMemberJoinedEvent extends SwEvent {
 export interface ChatMemberUpdatedEventParams {
   channel: string
   member: InternalChatMemberEntity
-  state: Record<any, any>
 }
 
 export interface ChatMemberUpdatedEvent extends SwEvent {

--- a/packages/js/src/chat/Client.test.ts
+++ b/packages/js/src/chat/Client.test.ts
@@ -571,29 +571,6 @@ describe('ChatClient Object', () => {
       await chat.subscribe(['test1'])
 
       const response = await chat.setMemberState({
-        channels: 'test1',
-        state: { typing: true },
-      })
-
-      const request = JSON.parse(server.messages[2].toString())
-      expect(request.method).toEqual('chat.member.set_state')
-      expect(request.params).toStrictEqual({
-        channels: [{ name: 'test1' }],
-        state: { typing: true },
-      })
-
-      expect(response).toStrictEqual(undefined)
-    })
-
-    it('should send the proper RPC with memberId and format the response', async () => {
-      const chat = new Client({
-        host,
-        token,
-      })
-      chat.on('message', () => {})
-      await chat.subscribe(['test1'])
-
-      const response = await chat.setMemberState({
         memberId: 'memberUuid1',
         channels: 'test1',
         state: { typing: true },

--- a/packages/js/src/chat/Client.test.ts
+++ b/packages/js/src/chat/Client.test.ts
@@ -69,7 +69,7 @@ describe('ChatClient Object', () => {
               },
             })
           )
-        } else if (parsedData.method === 'chat.presence.set_state') {
+        } else if (parsedData.method === 'chat.member.set_state') {
           socket.send(
             JSON.stringify({
               jsonrpc: '2.0',
@@ -80,7 +80,7 @@ describe('ChatClient Object', () => {
               },
             })
           )
-        } else if (parsedData.method === 'chat.presence.get_state') {
+        } else if (parsedData.method === 'chat.member.get_state') {
           socket.send(
             JSON.stringify({
               jsonrpc: '2.0',
@@ -555,13 +555,13 @@ describe('ChatClient Object', () => {
       chat.on('message', () => {})
       await chat.subscribe(['test1'])
 
-      const response = await chat.setState({
+      const response = await chat.setMemberState({
         channels: 'test1',
         state: { typing: true },
       })
 
       const request = JSON.parse(server.messages[2].toString())
-      expect(request.method).toEqual('chat.presence.set_state')
+      expect(request.method).toEqual('chat.member.set_state')
       expect(request.params).toStrictEqual({
         channels: [{ name: 'test1' }],
         state: { typing: true },
@@ -580,13 +580,13 @@ describe('ChatClient Object', () => {
       chat.on('message', () => {})
       await chat.subscribe(['test1'])
 
-      const response = await chat.getState({
+      const response = await chat.getMemberState({
         memberId: 'memberId',
         channels: 'test1',
       })
 
       const request = JSON.parse(server.messages[2].toString())
-      expect(request.method).toEqual('chat.presence.get_state')
+      expect(request.method).toEqual('chat.member.get_state')
       expect(request.params).toStrictEqual({
         channels: [{ name: 'test1' }],
         member_id: 'memberId',

--- a/packages/js/src/chat/Client.test.ts
+++ b/packages/js/src/chat/Client.test.ts
@@ -190,7 +190,11 @@ describe('ChatClient Object', () => {
                     channel: 'lobby',
                     message: {
                       id: 'f5511ad5-4dc2-4d28-a449-cc39909093b9',
-                      sender_id: '1507e5f9-075c-463d-94ba-a8f9ec0c7d4e',
+                      member: {
+                        id: '1507e5f9-075c-463d-94ba-a8f9ec0c7d4e',
+                        channel: 'lobby',
+                        state: { active: true },
+                      },
                       content: 'Hello World!',
                       published_at: 1641405257.795,
                     },
@@ -210,7 +214,11 @@ describe('ChatClient Object', () => {
       chat.on('message', (message) => {
         expect(message.channel).toBe('lobby')
         expect(message.id).toBe('f5511ad5-4dc2-4d28-a449-cc39909093b9')
-        expect(message.senderId).toBe('1507e5f9-075c-463d-94ba-a8f9ec0c7d4e')
+        expect(message.member).toStrictEqual({
+          id: '1507e5f9-075c-463d-94ba-a8f9ec0c7d4e',
+          channel: 'lobby',
+          state: { active: true },
+        })
         expect(message.content).toBe('Hello World!')
         expect(message.publishedAt).toStrictEqual(
           new Date(1641405257.795 * 1000)

--- a/packages/js/src/chat/Client.test.ts
+++ b/packages/js/src/chat/Client.test.ts
@@ -602,5 +602,34 @@ describe('ChatClient Object', () => {
         },
       })
     })
+
+    it('should send the proper RPC without (optional) channels', async () => {
+      const chat = new Client({
+        host,
+        token,
+      })
+      chat.on('message', () => {})
+      await chat.subscribe(['test1'])
+
+      const response = await chat.getMemberState({
+        memberId: 'memberId',
+      })
+
+      const request = JSON.parse(server.messages[2].toString())
+      expect(request.method).toEqual('chat.member.get_state')
+      expect(request.params).toStrictEqual({
+        member_id: 'memberId',
+      })
+
+      expect(response).toStrictEqual({
+        channels: {
+          lobby: {
+            state: {
+              typing: true,
+            },
+          },
+        },
+      })
+    })
   })
 })

--- a/packages/js/src/chat/Client.test.ts
+++ b/packages/js/src/chat/Client.test.ts
@@ -256,6 +256,8 @@ describe('ChatClient Object', () => {
             channel: 'lobby',
             member: {
               id: '1507e5f9-075c-463d-94ba-a8f9ec0c7d4e',
+              channel: 'lobby',
+              state: { init: 1 },
             },
           },
           timestamp: 1641468229.28,
@@ -269,6 +271,7 @@ describe('ChatClient Object', () => {
       chat.on('member.joined', (member) => {
         expect(member.channel).toBe('lobby')
         expect(member.id).toBe('1507e5f9-075c-463d-94ba-a8f9ec0c7d4e')
+        expect(member.state).toStrictEqual({ init: 1 })
 
         done()
       })
@@ -288,9 +291,10 @@ describe('ChatClient Object', () => {
             channel: 'lobby',
             member: {
               id: '1507e5f9-075c-463d-94ba-a8f9ec0c7d4e',
-            },
-            state: {
-              typing: true,
+              channel: 'lobby',
+              state: {
+                typing: true,
+              },
             },
           },
           timestamp: 1641468242.538,
@@ -326,6 +330,8 @@ describe('ChatClient Object', () => {
             channel: 'lobby',
             member: {
               id: '1507e5f9-075c-463d-94ba-a8f9ec0c7d4e',
+              channel: 'lobby',
+              state: {},
             },
           },
           timestamp: 1641468229.28,
@@ -339,6 +345,7 @@ describe('ChatClient Object', () => {
       chat.on('member.left', (member) => {
         expect(member.channel).toBe('lobby')
         expect(member.id).toBe('1507e5f9-075c-463d-94ba-a8f9ec0c7d4e')
+        expect(member.state).toStrictEqual({})
 
         done()
       })

--- a/packages/js/src/chat/Client.test.ts
+++ b/packages/js/src/chat/Client.test.ts
@@ -576,6 +576,31 @@ describe('ChatClient Object', () => {
 
       expect(response).toStrictEqual(undefined)
     })
+
+    it('should send the proper RPC with memberId and format the response', async () => {
+      const chat = new Client({
+        host,
+        token,
+      })
+      chat.on('message', () => {})
+      await chat.subscribe(['test1'])
+
+      const response = await chat.setMemberState({
+        memberId: 'memberUuid1',
+        channels: 'test1',
+        state: { typing: true },
+      })
+
+      const request = JSON.parse(server.messages[2].toString())
+      expect(request.method).toEqual('chat.member.set_state')
+      expect(request.params).toStrictEqual({
+        member_id: 'memberUuid1',
+        channels: [{ name: 'test1' }],
+        state: { typing: true },
+      })
+
+      expect(response).toStrictEqual(undefined)
+    })
   })
 
   describe('getState', () => {


### PR DESCRIPTION
Minor tweaks to the public interface and payloads over the wire. 

#### Changes:

- [x] Renamed setState/getState to setMemberState/getMemberState
- [x] Update event payloads (ChatMessage / ChatMember interfaces)