### PR TITLE
Fix iceServers in RTCPeer

### DIFF
--- a/.changeset/mean-horses-reflect.md
+++ b/.changeset/mean-horses-reflect.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/webrtc': patch
+---
+
+Read `iceServers` on RTCPeer setup to avoid races

--- a/packages/webrtc/src/BaseConnection.ts
+++ b/packages/webrtc/src/BaseConnection.ts
@@ -135,6 +135,15 @@ export class BaseConnection<EventTypes extends EventEmitter.ValidEventTypes>
     return this.options.remoteStream
   }
 
+  get iceServers() {
+    let iceServers = this.options?.iceServers ?? []
+    if (!iceServers || !iceServers.length) {
+      iceServers = this.select(selectors.getIceServers)
+    }
+
+    return iceServers
+  }
+
   /** @internal */
   get messagePayload() {
     const {

--- a/packages/webrtc/src/BaseConnection.ts
+++ b/packages/webrtc/src/BaseConnection.ts
@@ -83,13 +83,9 @@ export class BaseConnection<EventTypes extends EventEmitter.ValidEventTypes>
   ) {
     super(options)
 
-    const iceServers =
-      options?.iceServers ?? this.select(selectors.getIceServers)
-
     this.options = {
       ...DEFAULT_CALL_OPTIONS,
       ...options,
-      iceServers,
     }
 
     this.setState('new')
@@ -136,12 +132,7 @@ export class BaseConnection<EventTypes extends EventEmitter.ValidEventTypes>
   }
 
   get iceServers() {
-    let iceServers = this.options?.iceServers ?? []
-    if (!iceServers || !iceServers.length) {
-      iceServers = this.select(selectors.getIceServers)
-    }
-
-    return iceServers
+    return this.options?.iceServers ?? this.select(selectors.getIceServers)
   }
 
   /** @internal */

--- a/packages/webrtc/src/RTCPeer.ts
+++ b/packages/webrtc/src/RTCPeer.ts
@@ -90,10 +90,10 @@ export default class RTCPeer<EventTypes extends EventEmitter.ValidEventTypes> {
   }
 
   get config(): RTCConfiguration {
-    const { iceServers = [], rtcPeerConfig = {} } = this.options
+    const { rtcPeerConfig = {} } = this.options
     const config: RTCConfiguration = {
       bundlePolicy: 'max-compat',
-      iceServers,
+      iceServers: this.call.iceServers,
       // @ts-ignore
       sdpSemantics: 'unified-plan',
       ...rtcPeerConfig,

--- a/packages/webrtc/src/RTCPeer.ts
+++ b/packages/webrtc/src/RTCPeer.ts
@@ -449,7 +449,9 @@ export default class RTCPeer<EventTypes extends EventEmitter.ValidEventTypes> {
     // addTransceiver of 'kind' if not present
     const sender = this._getSenderByKind(kind)
     if (!sender && this.instance.addTransceiver) {
-      const transceiver = this.instance.addTransceiver(kind)
+      const transceiver = this.instance.addTransceiver(kind, {
+        direction: 'recvonly',
+      })
       this.logger.debug('Add transceiver', kind, transceiver)
     }
   }


### PR DESCRIPTION
This PR fixes a race within BaseConnection/RTCPeer related to the `iceServers` value.