### PR TITLE
Allow layout/positions fields for screenShare

### DIFF
--- a/.changeset/grumpy-radios-tap.md
+++ b/.changeset/grumpy-radios-tap.md
@@ -1,0 +1,8 @@
+---
+'@sw-internal/playground-js': patch
+'@signalwire/core': patch
+'@signalwire/js': patch
+'@signalwire/webrtc': patch
+---
+
+Add `layout`, `positions` and `restoreLayout` when starting a screenShare.

--- a/internal/playground-js/src/heroku/index.html
+++ b/internal/playground-js/src/heroku/index.html
@@ -188,8 +188,8 @@
                 </button>
               </div>
 
-              <div class="col-12 mt-2">
-                <label for="layout" class="form-label"> Change Layout </label>
+              <h5 class="mt-3" for="layout">Controls</h5>
+              <div class="col-12">
                 <select
                   class="form-select"
                   onchange="changeLayout(this)"
@@ -198,6 +198,24 @@
                 ></select>
               </div>
 
+              <h5 class="mt-3">ScreenShare</h5>
+              <div class="col-12">
+                <label for="ssLayout" class="form-label"
+                  >Layout to use for ScreenShare</label
+                >
+                <select class="form-select" value="" id="ssLayout"></select>
+              </div>
+              <div class="form-check p-0 mt-2">
+                <input
+                  type="checkbox"
+                  id="ssRestoreLayout"
+                  value="1"
+                  onchange="saveInLocalStorage(event)"
+                />
+                <label class="form-check-label" for="ssRestoreLayout">
+                  Restore Layout on Stop
+                </label>
+              </div>
               <div class="btn-group w-100" role="group">
                 <button
                   id="hideScreenShareBtn"
@@ -205,7 +223,7 @@
                   onClick="startScreenShare()"
                   disabled="true"
                 >
-                  Start Screenshare
+                  Start
                 </button>
                 <button
                   id="showScreenShareBtn"
@@ -213,7 +231,7 @@
                   onClick="stopScreenShare()"
                   disabled="true"
                 >
-                  Stop Screenshare
+                  Stop
                 </button>
               </div>
             </div>

--- a/internal/playground-js/src/heroku/index.js
+++ b/internal/playground-js/src/heroku/index.js
@@ -61,23 +61,29 @@ window.playbackEnded = () => {
 async function loadLayouts(currentLayoutId) {
   try {
     const { layouts } = await roomObj.getLayoutList()
-    const layoutEl = document.getElementById('layout')
-    layoutEl.innerHTML = ''
+    const fillSelectElement = (id) => {
+      const layoutEl = document.getElementById(id)
+      layoutEl.innerHTML = ''
 
-    const defOption = document.createElement('option')
-    defOption.value = ''
-    defOption.innerHTML = 'Change layout..'
-    layoutEl.appendChild(defOption)
-    for (var i = 0; i < layouts.length; i++) {
-      const layout = layouts[i]
-      var opt = document.createElement('option')
-      opt.value = layout
-      opt.innerHTML = layout
-      layoutEl.appendChild(opt)
+      const defOption = document.createElement('option')
+      defOption.value = ''
+      defOption.innerHTML =
+        id === 'layout' ? 'Change layout..' : 'Select layout for ScreenShare..'
+      layoutEl.appendChild(defOption)
+      for (var i = 0; i < layouts.length; i++) {
+        const layout = layouts[i]
+        var opt = document.createElement('option')
+        opt.value = layout
+        opt.innerHTML = layout
+        layoutEl.appendChild(opt)
+      }
+      if (currentLayoutId) {
+        layoutEl.value = currentLayoutId
+      }
     }
-    if (currentLayoutId) {
-      layoutEl.value = currentLayoutId
-    }
+
+    fillSelectElement('layout')
+    fillSelectElement('ssLayout')
   } catch (error) {
     console.warn('Error listing layout', error)
   }
@@ -307,10 +313,19 @@ window.ready = (callback) => {
 
 let screenShareObj
 window.startScreenShare = async () => {
-  screenShareObj = await roomObj.startScreenShare({
-    audio: true,
-    video: true,
-  })
+  screenShareObj = await roomObj
+    .startScreenShare({
+      audio: true,
+      video: true,
+      layout: document.getElementById('ssLayout').value,
+      restoreLayout: document.getElementById('ssRestoreLayout').checked,
+      positions: {
+        self: 'reserved-1',
+      },
+    })
+    .catch((error) => {
+      console.error('ScreenShare Error', error)
+    })
 }
 window.stopScreenShare = () => {
   screenShareObj.hangup()

--- a/packages/core/src/rooms/methods.ts
+++ b/packages/core/src/rooms/methods.ts
@@ -4,13 +4,10 @@ import type {
   VideoRecordingEntity,
   VideoPlaybackEntity,
   MemberCommandParams,
-  MemberPosition
+  VideoPosition,
 } from '../types'
 import { toLocalEvent, toExternalJSON } from '../utils'
-import {
-  ExecuteExtendedOptions,
-  RoomMethod,
-} from '../utils/interfaces'
+import { ExecuteExtendedOptions, RoomMethod } from '../utils/interfaces'
 
 interface RoomMethodPropertyDescriptor<T, ParamsType>
   extends PropertyDescriptor {
@@ -101,7 +98,7 @@ export const getMembers = createRoomMethod<{ members: VideoMemberEntity[] }>(
 )
 export interface SetLayoutParams {
   name: string
-  positions?: Record<string, MemberPosition>
+  positions?: Record<string, VideoPosition>
 }
 export const setLayout = createRoomMethod<BaseRPCResult, void>(
   'video.set_layout',
@@ -110,7 +107,7 @@ export const setLayout = createRoomMethod<BaseRPCResult, void>(
   }
 )
 export interface SetPositionsParams {
-  positions?: Record<string, MemberPosition>
+  positions: Record<string, VideoPosition>
 }
 export const setPositions = createRoomMethod<BaseRPCResult, void>(
   'video.set_position',
@@ -193,7 +190,7 @@ export const getPlaybacks = createRoomMethod<{
 export type PlayParams = {
   url: string
   volume?: number
-  positions?: Record<string, MemberPosition>
+  positions?: Record<string, VideoPosition>
 }
 export const play: RoomMethodDescriptor<any, PlayParams> = {
   value: function (params) {
@@ -313,7 +310,7 @@ export const setInputSensitivityMember = createRoomMemberMethod<
   transformResolve: baseCodeTransform,
 })
 export interface SetPositionParams extends MemberCommandParams {
-  position: MemberPosition
+  position: VideoPosition
 }
 export const setPosition = createRoomMemberMethod<BaseRPCResult, void>(
   'video.member.set_position',

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -117,13 +117,6 @@ export type PubSubChannelEvents =
   | InternalVideoEventNames
   | SessionEvents
 
-export type MemberPosition =
-  | 'reserved'
-  | `reserved-${number}`
-  | 'standard'
-  | `standard-${number}`
-  | 'off-canvas'
-
 export * from './video'
 export * from './utils'
 export * from './cantina'

--- a/packages/core/src/types/video.ts
+++ b/packages/core/src/types/video.ts
@@ -34,6 +34,16 @@ export * from './videoPlayback'
 
 export type RTCTrackEventName = 'track'
 
+export type VideoPosition =
+  | 'self'
+  | 'reserved'
+  | `reserved-${number}`
+  | 'standard'
+  | `standard-${number}`
+  | 'off-canvas'
+
+export type VideoPositions = Record<string, VideoPosition>
+
 /**
  * List of all the events a RoomObject can listen to
  */

--- a/packages/core/src/types/videoLayout.ts
+++ b/packages/core/src/types/videoLayout.ts
@@ -1,4 +1,5 @@
-import type { SwEvent, MemberPosition } from '.'
+import type { SwEvent } from '.'
+import { VideoPosition } from '..'
 import type { CamelToSnakeCase, ToInternalVideoEvent } from './utils'
 
 export type LayoutChanged = 'layout.changed'
@@ -34,7 +35,7 @@ export interface VideoLayoutLayer {
   layerIndex: number
   zIndex: number
   reservation: string
-  positions?: Record<string, MemberPosition>
+  position: VideoPosition
 }
 
 /**

--- a/packages/js/src/BaseRoomSession.ts
+++ b/packages/js/src/BaseRoomSession.ts
@@ -134,8 +134,8 @@ export class RoomSessionConnection
       audio = false,
       video = true,
       layout,
-      positions = {},
-      restoreLayout = true,
+      positions,
+      restoreLayout,
     } = opts
     const displayStream: MediaStream = await getDisplayMedia({
       audio: audio === true ? SCREENSHARE_AUDIO_CONSTRAINTS : audio,

--- a/packages/js/src/BaseRoomSession.ts
+++ b/packages/js/src/BaseRoomSession.ts
@@ -129,7 +129,14 @@ export class RoomSessionConnection
    * Allow sharing the screen within the room.
    */
   async startScreenShare(opts: StartScreenShareOptions = {}) {
-    const { autoJoin = true, audio = false, video = true } = opts
+    const {
+      autoJoin = true,
+      audio = false,
+      video = true,
+      layout,
+      positions = {},
+      restoreLayout = true,
+    } = opts
     const displayStream: MediaStream = await getDisplayMedia({
       audio: audio === true ? SCREENSHARE_AUDIO_CONSTRAINTS : audio,
       video,
@@ -145,6 +152,9 @@ export class RoomSessionConnection
         memberCallId: this.__uuid,
         memberId: this.memberId,
       },
+      layout,
+      positions,
+      restoreLayout,
     }
 
     const screenShare = connect<

--- a/packages/js/src/RoomSession.docs.ts
+++ b/packages/js/src/RoomSession.docs.ts
@@ -1,7 +1,8 @@
-import type { Rooms } from '@signalwire/core'
+import type { AssertSameType, MemberPosition, Rooms } from '@signalwire/core'
 import { BaseRoomSession } from './BaseRoomSession'
 import { RoomSessionDevice } from './RoomSessionDevice'
 import { RoomSessionScreenShare } from './RoomSessionScreenShare'
+import { StartScreenShareOptions } from './utils/interfaces'
 
 export interface RoomSessionDocs<T>
   extends RoomMemberMethodsInterfaceDocs,
@@ -119,14 +120,27 @@ export interface RoomSessionDocs<T>
    * await roomSession.startScreenShare({audio: true, video: true})
    * ```
    */
-  startScreenShare(opts: {
-    /** Whether the screen share object should automatically join the room */
-    autoJoin?: boolean
-    /** Audio constraints to use when joining the room. Default: `true`. */
-    audio?: MediaStreamConstraints['audio']
-    /** Video constraints to use when joining the room. Default: `true`. */
-    video?: MediaStreamConstraints['video']
-  }): Promise<RoomSessionScreenShare>
+  startScreenShare(
+    opts: AssertSameType<
+      StartScreenShareOptions,
+      {
+        /** Whether the screen share object should automatically join the room. Default: `true`. */
+        autoJoin?: boolean
+        /** Audio constraints to use when joining the room. Default: `true`. */
+        audio?: MediaStreamConstraints['audio']
+        /** Video constraints to use when joining the room. Default: `true`. */
+        video?: MediaStreamConstraints['video']
+        /** Layout to use to use when joining the room. */
+        layout?: string
+        /** Automatically set positions when screen share joins the room.
+         * TODO: import a Positions type from core instead Record<>
+         */
+        positions?: Record<string, MemberPosition>
+        /** Whether to restore the previous layout when the screen share leaves the room. */
+        restoreLayout?: boolean
+      }
+    >
+  ): Promise<RoomSessionScreenShare>
 
   /**
    * Adds a camera device to the room. Using this method, a user can stream
@@ -838,7 +852,7 @@ interface RoomControlMethodsInterfaceDocs {
    */
   play(params: {
     url: string
-    volume?: number,
+    volume?: number
     positions?: Record<
       string,
       | 'reserved'

--- a/packages/js/src/RoomSession.docs.ts
+++ b/packages/js/src/RoomSession.docs.ts
@@ -1,4 +1,4 @@
-import type { AssertSameType, MemberPosition, Rooms } from '@signalwire/core'
+import type { AssertSameType, VideoPositions, Rooms } from '@signalwire/core'
 import { BaseRoomSession } from './BaseRoomSession'
 import { RoomSessionDevice } from './RoomSessionDevice'
 import { RoomSessionScreenShare } from './RoomSessionScreenShare'
@@ -132,10 +132,8 @@ export interface RoomSessionDocs<T>
         video?: MediaStreamConstraints['video']
         /** Layout to use to use when joining the room. */
         layout?: string
-        /** Automatically set positions when screen share joins the room.
-         * TODO: import a Positions type from core instead Record<>
-         */
-        positions?: Record<string, MemberPosition>
+        /** Automatically set positions when screen share joins the room. */
+        positions?: VideoPositions
         /** Whether to restore the previous layout when the screen share leaves the room. */
         restoreLayout?: boolean
       }
@@ -855,6 +853,7 @@ interface RoomControlMethodsInterfaceDocs {
     volume?: number
     positions?: Record<
       string,
+      | 'self'
       | 'reserved'
       | `reserved-${number}`
       | 'standard'
@@ -913,6 +912,7 @@ interface RoomLayoutMethodsInterface {
     name: string
     positions?: Record<
       string,
+      | 'self'
       | 'reserved'
       | `reserved-${number}`
       | 'standard'
@@ -922,8 +922,9 @@ interface RoomLayoutMethodsInterface {
   }): Rooms.SetLayout
 
   setPositions(params: {
-    positions?: Record<
+    positions: Record<
       string,
+      | 'self'
       | 'reserved'
       | `reserved-${number}`
       | 'standard'
@@ -935,6 +936,7 @@ interface RoomLayoutMethodsInterface {
   setPosition(params: {
     memberId?: string
     position:
+      | 'self'
       | 'reserved'
       | `reserved-${number}`
       | 'standard'

--- a/packages/js/src/utils/interfaces.ts
+++ b/packages/js/src/utils/interfaces.ts
@@ -22,6 +22,7 @@ import type {
   VideoRoomSessionContract,
   OnlyFunctionProperties,
   AssertSameType,
+  MemberPosition,
 } from '@signalwire/core'
 import { INTERNAL_MEMBER_UPDATABLE_PROPS } from '@signalwire/core'
 import type { RoomSession } from '../RoomSession'
@@ -82,6 +83,11 @@ export type StartScreenShareOptions = {
   autoJoin?: boolean
   audio?: MediaStreamConstraints['audio']
   video?: MediaStreamConstraints['video']
+  // TODO: union types for valid layouts?
+  layout?: string
+  // TODO: export a Positions type from core
+  positions?: Record<string, MemberPosition>
+  restoreLayout?: boolean
 }
 
 /**

--- a/packages/js/src/utils/interfaces.ts
+++ b/packages/js/src/utils/interfaces.ts
@@ -22,7 +22,7 @@ import type {
   VideoRoomSessionContract,
   OnlyFunctionProperties,
   AssertSameType,
-  MemberPosition,
+  VideoPositions,
 } from '@signalwire/core'
 import { INTERNAL_MEMBER_UPDATABLE_PROPS } from '@signalwire/core'
 import type { RoomSession } from '../RoomSession'
@@ -83,10 +83,8 @@ export type StartScreenShareOptions = {
   autoJoin?: boolean
   audio?: MediaStreamConstraints['audio']
   video?: MediaStreamConstraints['video']
-  // TODO: union types for valid layouts?
   layout?: string
-  // TODO: export a Positions type from core
-  positions?: Record<string, MemberPosition>
+  positions?: VideoPositions
   restoreLayout?: boolean
 }
 

--- a/packages/realtime-api/src/video/RoomSession.ts
+++ b/packages/realtime-api/src/video/RoomSession.ts
@@ -311,6 +311,7 @@ interface RoomSessionDocs extends RoomSessionMain {
     name: string
     positions?: Record<
       string,
+      | 'self'
       | 'reserved'
       | `reserved-${number}`
       | 'standard'
@@ -320,8 +321,9 @@ interface RoomSessionDocs extends RoomSessionMain {
   }): Promise<void>
 
   setPositions(params: {
-    positions?: Record<
+    positions: Record<
       string,
+      | 'self'
       | 'reserved'
       | `reserved-${number}`
       | 'standard'
@@ -333,6 +335,7 @@ interface RoomSessionDocs extends RoomSessionMain {
   setPosition(params: {
     memberId?: string
     position:
+      | 'self'
       | 'reserved'
       | `reserved-${number}`
       | 'standard'
@@ -387,9 +390,10 @@ interface RoomSessionDocs extends RoomSessionMain {
    */
   play(params: {
     url: string
-    volume?: number,
+    volume?: number
     positions?: Record<
       string,
+      | 'self'
       | 'reserved'
       | `reserved-${number}`
       | 'standard'

--- a/packages/webrtc/src/BaseConnection.ts
+++ b/packages/webrtc/src/BaseConnection.ts
@@ -31,8 +31,6 @@ const DEFAULT_CALL_OPTIONS: ConnectionOptions = {
   requestTimeout: 10 * 1000,
   autoApplyMediaParams: true,
   iceGatheringTimeout: 2 * 1000,
-  layout: '',
-  positions: {},
   restoreLayout: true,
 }
 
@@ -478,12 +476,17 @@ export class BaseConnection<EventTypes extends EventEmitter.ValidEventTypes>
   async executeInvite(sdp: string) {
     this.setState('requesting')
     try {
+      const ssOpts = this.options.screenShare
+        ? {
+            layout: this.options.layout,
+            restore_layout: this.options.restoreLayout,
+            positions: this.options.positions,
+          }
+        : {}
       const msg = VertoInvite({
         ...this.messagePayload,
+        ...ssOpts,
         sdp,
-        layout: this.options.layout,
-        restore_layout: this.options.restoreLayout,
-        positions: this.options.positions,
       })
       const response = await this.vertoExecute(msg)
       this.logger.debug('Invite response', response)

--- a/packages/webrtc/src/BaseConnection.ts
+++ b/packages/webrtc/src/BaseConnection.ts
@@ -31,6 +31,9 @@ const DEFAULT_CALL_OPTIONS: ConnectionOptions = {
   requestTimeout: 10 * 1000,
   autoApplyMediaParams: true,
   iceGatheringTimeout: 2 * 1000,
+  layout: '',
+  positions: {},
+  restoreLayout: true,
 }
 
 type EventsHandlerMapping = Record<BaseConnectionState, () => void> &
@@ -475,7 +478,13 @@ export class BaseConnection<EventTypes extends EventEmitter.ValidEventTypes>
   async executeInvite(sdp: string) {
     this.setState('requesting')
     try {
-      const msg = VertoInvite({ ...this.messagePayload, sdp })
+      const msg = VertoInvite({
+        ...this.messagePayload,
+        sdp,
+        layout: this.options.layout,
+        restore_layout: this.options.restoreLayout,
+        positions: this.options.positions,
+      })
       const response = await this.vertoExecute(msg)
       this.logger.debug('Invite response', response)
     } catch (error) {

--- a/packages/webrtc/src/utils/interfaces.ts
+++ b/packages/webrtc/src/utils/interfaces.ts
@@ -1,3 +1,5 @@
+import type { MemberPosition } from '@signalwire/core'
+
 export interface ConnectionOptions {
   // TODO: Not used anymore but required for backend
   /** @internal */
@@ -71,4 +73,10 @@ export interface ConnectionOptions {
   rtcPeerConfig?: { [key: string]: any }
   /** @internal */
   iceGatheringTimeout?: number
+
+  // TODO: union types for valid layouts?
+  layout?: string
+  // TODO: export a Positions type from core
+  positions?: Record<string, MemberPosition>
+  restoreLayout?: boolean
 }

--- a/packages/webrtc/src/utils/interfaces.ts
+++ b/packages/webrtc/src/utils/interfaces.ts
@@ -1,4 +1,4 @@
-import type { MemberPosition } from '@signalwire/core'
+import type { VideoPositions } from '@signalwire/core'
 
 export interface ConnectionOptions {
   // TODO: Not used anymore but required for backend
@@ -74,9 +74,7 @@ export interface ConnectionOptions {
   /** @internal */
   iceGatheringTimeout?: number
 
-  // TODO: union types for valid layouts?
   layout?: string
-  // TODO: export a Positions type from core
-  positions?: Record<string, MemberPosition>
+  positions?: VideoPositions
   restoreLayout?: boolean
 }


### PR DESCRIPTION
- Allow screenShare to start with additional params like: `layout`, `positions` and `restoreLayout`
- Rename `MemberPosition` to be more generic with `VideoPosition`
- Export a `Record` to not duplicate `Record<string, VideoPosition>` (expect for typedoc)