### PR TITLE
Allow to pass transformParams in the ExecuteExtendedOptions

### DIFF
--- a/.changeset/rude-yaks-brush.md
+++ b/.changeset/rude-yaks-brush.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/core': patch
+---
+
+[internal] Add transformParams to ExecuteExtendedOptions

--- a/packages/core/src/BaseComponent.ts
+++ b/packages/core/src/BaseComponent.ts
@@ -343,7 +343,7 @@ export class BaseComponent<
         instance: cachedInstance,
         payload,
         transformedPayload,
-        transform
+        transform,
       })
 
       // @ts-expect-error
@@ -540,9 +540,11 @@ export class BaseComponent<
   execute<InputType = unknown, OutputType = unknown>(
     { method, params }: ExecuteParams,
     {
+      transformParams = identity,
       transformResolve = identity,
       transformReject = identity,
     }: ExecuteExtendedOptions<InputType, OutputType> = {
+      transformParams: identity,
       transformResolve: identity,
       transformReject: identity,
     }
@@ -561,7 +563,7 @@ export class BaseComponent<
           requestId,
           componentId: this.__uuid,
           method,
-          params,
+          params: transformParams(params),
         })
       )
     })

--- a/packages/core/src/utils/interfaces.ts
+++ b/packages/core/src/utils/interfaces.ts
@@ -269,8 +269,15 @@ export type ExecuteParams = {
 }
 
 export interface ExecuteExtendedOptions<InputType, OutputType> {
+  /** To transform the resolved response */
   transformResolve?: ExecuteTransform<InputType, OutputType>
+  /** To transform the rejected response */
   transformReject?: ExecuteTransform<InputType, OutputType>
+  /** To transform the RPC execute params */
+  transformParams?: ExecuteTransform<
+    ExecuteParams['params'],
+    ExecuteParams['params']
+  >
 }
 
 export type ExecuteTransform<InputType = unknown, OutputType = unknown> = (


### PR DESCRIPTION
Cherry pick from https://github.com/signalwire/signalwire-js/pull/412/commits/4ba8d09cc0d774b9402c838967645a660e36377e