### PR TITLE
Expose `removeAllListeners` through interface

### DIFF
--- a/.changeset/wild-goats-count.md
+++ b/.changeset/wild-goats-count.md
@@ -1,0 +1,7 @@
+---
+'@signalwire/core': minor
+'@signalwire/js': minor
+'@signalwire/realtime-api': minor
+---
+
+Expose the `removeAllListeners` method for all the components.

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -26,6 +26,10 @@ export interface EmitterContract<
     event: T,
     fn?: EventEmitter.EventListener<EventTypes, T>
   ): EmitterContract<EventTypes>
+
+  removeAllListeners<T extends EventEmitter.EventNames<EventTypes>>(
+    event?: T,
+  ): EmitterContract<EventTypes>
 }
 
 export interface BaseComponentContract {

--- a/packages/js/src/RoomSession.docs.ts
+++ b/packages/js/src/RoomSession.docs.ts
@@ -8,7 +8,7 @@ export interface RoomSessionDocs<T>
     RoomControlMethodsInterfaceDocs,
     RoomLayoutMethodsInterface,
     RoomSessionConstructorDocs<T>,
-    Pick<BaseRoomSession<T>, 'on' | 'off' | 'once'> {
+    Pick<BaseRoomSession<T>, 'on' | 'off' | 'once' | 'removeAllListeners'> {
   /** @internal */
   stopOutboundAudio(): void
   /** @internal */


### PR DESCRIPTION
The code in this changeset exposes the `removeAllListeners` through the `EmitterContract`. Code was already there (and tested), it just wasn't exposed through the interface.