### PR TITLE
Fix issue with `updateMicrophone` on Firefox

### DIFF
--- a/.changeset/sour-pillows-yell.md
+++ b/.changeset/sour-pillows-yell.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/webrtc': patch
+---
+
+Fix to properly handle switching between microphones on Firefox

--- a/packages/webrtc/src/BaseConnection.ts
+++ b/packages/webrtc/src/BaseConnection.ts
@@ -327,7 +327,7 @@ export class BaseConnection<EventTypes extends EventEmitter.ValidEventTypes>
    */
   private updateConstraints(
     constraints: MediaStreamConstraints,
-    attempt = 0
+    { attempt = 0 } = {}
   ): Promise<void> {
     if (attempt > 1) {
       return Promise.reject(new Error('Failed to update constraints'))
@@ -372,7 +372,7 @@ export class BaseConnection<EventTypes extends EventEmitter.ValidEventTypes>
            */
           if (
             error instanceof DOMException &&
-            error.name === 'NotReadableError'
+            error.message === 'Concurrent mic process limit.'
           ) {
             let oldConstraints: MediaStreamConstraints = {}
             this.options.localStream?.getTracks().forEach((track) => {
@@ -392,10 +392,18 @@ export class BaseConnection<EventTypes extends EventEmitter.ValidEventTypes>
             })
 
             try {
-              return this.updateConstraints(constraints, attempt + 1)
+              return resolve(
+                this.updateConstraints(constraints, {
+                  attempt: attempt + 1,
+                })
+              )
             } catch (error) {
               this.logger.error('Restoring previous constraints')
-              return this.updateConstraints(oldConstraints, attempt + 1)
+              return resolve(
+                this.updateConstraints(oldConstraints, {
+                  attempt: attempt + 1,
+                })
+              )
             }
           }
 

--- a/packages/webrtc/src/BaseConnection.ts
+++ b/packages/webrtc/src/BaseConnection.ts
@@ -376,11 +376,14 @@ export class BaseConnection<EventTypes extends EventEmitter.ValidEventTypes>
           ) {
             let oldConstraints: MediaStreamConstraints = {}
             this.options.localStream?.getTracks().forEach((track) => {
+              /**
+               * We'll keep a reference of the original
+               * constraints so if something fails we should
+               * be able to restore them.
+               */
               // @ts-expect-error
               oldConstraints[track.kind] = track.getConstraints()
-            })
 
-            this.options.localStream?.getTracks().forEach((track) => {
               // @ts-expect-error
               if (constraints[track.kind] !== undefined) {
                 this.logger.debug(


### PR DESCRIPTION
The code in this changeset fixes the issue that was preventing users from updating their microphone on Firefox. 

When we encounter this error, the flow will be as follows:
1. Stop the current audio track
2. Try to get another audio track with the new constraints
3. If we get an error: restore the media tracks using the previous constraints.

Related Firefox issue: https://bugzilla.mozilla.org/show_bug.cgi?id=1238038