### PR TITLE
Fix types for createMicrophoneAnalyzer

### DIFF
--- a/.changeset/gentle-eels-sin.md
+++ b/.changeset/gentle-eels-sin.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/webrtc': patch
+---
+
+Fix typings for `createMicrophoneAnalyzer` to make it return Promise<MicrophoneAnalyzer>


### PR DESCRIPTION
The code in this changeset fixes the typings for `createMicrophoneAnalyzer`. 

Before this PR, the inferred type was `Promise<any>`. We'll now have `Promise<MicrophoneAnalyzer>`