### PR TITLE
Prevent verto RPCs without node_id

### DIFF
--- a/.changeset/many-planets-hope.md
+++ b/.changeset/many-planets-hope.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/webrtc': patch
+---
+
+Prevent BaseConnection RPCs without a `node_id`.

--- a/packages/js/src/RoomSession.ts
+++ b/packages/js/src/RoomSession.ts
@@ -21,7 +21,6 @@ export const UNSAFE_PROP_ACCESS = [
   'getRecordings',
   'hideVideoMuted',
   'leave',
-  'hangup', // alias for leave (undocumented but worth to check)
   'removerMember',
   'restoreOutboundAudio',
   'restoreOutboundVideo',

--- a/packages/js/src/RoomSession.ts
+++ b/packages/js/src/RoomSession.ts
@@ -21,6 +21,7 @@ export const UNSAFE_PROP_ACCESS = [
   'getRecordings',
   'hideVideoMuted',
   'leave',
+  'hangup', // alias for leave (undocumented but worth to check)
   'removerMember',
   'restoreOutboundAudio',
   'restoreOutboundVideo',


### PR DESCRIPTION
It also includes a check for sending the `invite` only if the instance is in the `new` state. If not, throw an error since we're in a bad state.