### PR TITLE
Fix internal cleanup in core

### DIFF
--- a/.changeset/seven-zebras-press.md
+++ b/.changeset/seven-zebras-press.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/core': patch
+---
+
+[internal] Fix to avoid issues when invoking `.destroy` on cleanup.

--- a/packages/core/src/BaseComponent.ts
+++ b/packages/core/src/BaseComponent.ts
@@ -320,7 +320,6 @@ export class BaseComponent<
         instance.__uuid !== this.__uuid &&
         typeof instance.destroy === 'function'
       ) {
-        console.log('instance?', instance)
         instance.destroy()
       }
       return this._eventsTransformsCache.delete(internalEvent)

--- a/packages/core/src/BaseComponent.ts
+++ b/packages/core/src/BaseComponent.ts
@@ -312,7 +312,17 @@ export class BaseComponent<
     const eventCount = this.listenerCount(internalEvent)
 
     if (instance && (force || eventCount <= 1)) {
-      instance.destroy()
+      /**
+       * Make sure to not invoke destroy on "self"
+       * and that `instance.destroy` is defined.
+       */
+      if (
+        instance.__uuid !== this.__uuid &&
+        typeof instance.destroy === 'function'
+      ) {
+        console.log('instance?', instance)
+        instance.destroy()
+      }
       return this._eventsTransformsCache.delete(internalEvent)
     }
 


### PR DESCRIPTION
This PR checks before invoking `.destroy()` on cleanup for 2 reasons:

- the instance may be `self`: so it avoids to eat itself.
- the instance may not be a BaseComponent: so without a `destroy` method.