### PR TITLE
Fix regression in createRoomObject

### DIFF
--- a/.changeset/eighty-snakes-drop.md
+++ b/.changeset/eighty-snakes-drop.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/js': patch
+---
+
+Fix regression on `createRoomObject` method.


### PR DESCRIPTION
Quick fix for a regression in `createRoomObject` and `.join()` method.