### PR TITLE
Review parsing of nested fields in the emitter transform pipeline

### DIFF
--- a/.changeset/forty-melons-build.md
+++ b/.changeset/forty-melons-build.md
@@ -1,0 +1,9 @@
+---
+'@sw-internal/playground-js': patch
+'@sw-internal/playground-realtime-api': patch
+'@signalwire/core': patch
+'@signalwire/js': patch
+'@signalwire/realtime-api': patch
+---
+
+[internal] Review parsing of nested fields in our EE transform pipeline

--- a/.changeset/itchy-phones-fix.md
+++ b/.changeset/itchy-phones-fix.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/js': patch
+---
+
+Fix: expose all the active recordings on the `room.joined` event

--- a/internal/playground-js/src/heroku/index.js
+++ b/internal/playground-js/src/heroku/index.js
@@ -207,7 +207,12 @@ window.connect = () => {
     console.debug('>> room.started', params)
   )
   roomObj.on('room.joined', (params) => {
-    console.debug('>> room.joined', params)
+    console.debug(
+      '>> room.joined',
+      params,
+      params.room_session.recordings,
+      params.room_session.members
+    )
 
     btnConnect.classList.add('d-none')
     btnDisconnect.classList.remove('d-none')

--- a/internal/playground-realtime-api/src/with-events/index.ts
+++ b/internal/playground-realtime-api/src/with-events/index.ts
@@ -11,8 +11,18 @@ async function run() {
 
     video.on('room.started', (room) => {
       console.log('Room started --->', room.id, room.name)
+      room.on('room.subscribed', (room) => {
+        console.log(
+          'Room Subscribed --->',
+          room.id,
+          room.members[0].id,
+          room.members[0].name
+        )
+        room.members[0].audioMute()
+      })
+
       room.on('member.updated', () => {
-        console.log('Member updated --->');
+        console.log('Member updated --->')
       })
 
       room.on('member.joined', (member) => {

--- a/packages/core/src/types/videoRoomSession.ts
+++ b/packages/core/src/types/videoRoomSession.ts
@@ -56,6 +56,8 @@ export interface VideoRoomSessionContract {
   name: string
   /** Whether recording is active */
   recording: boolean
+  /** List of active recordings in the room */
+  recordings?: any[]
   /** Whether muted videos are shown in the room layout. See {@link setHideVideoMuted} */
   hideVideoMuted: boolean
   /** URL to the room preview. */

--- a/packages/core/src/utils/eventTransformUtils.ts
+++ b/packages/core/src/utils/eventTransformUtils.ts
@@ -1,23 +1,9 @@
-import { EventTransform, EventTransformType } from './interfaces'
+import { EventTransform } from './interfaces'
 import { proxyFactory } from './proxyUtils'
 
 interface InstanceProxyFactoryParams {
   transform: EventTransform
   payload: Record<any, unknown>
-}
-
-interface NestedFieldToProcess {
-  /** Nested field to transform through an EventTransform */
-  field: string
-  /**
-   * Allow us to update the nested `payload` to match the shape we already
-   * treat consuming other events from the server.
-   * For example: wrapping the `payload` within a specific key.
-   *  `payload` becomes `{ "member": payload }`
-   */
-  preProcessPayload: (payload: any) => any
-  /** Type of the EventTransform to select from `instance._emitterTransforms` */
-  eventTransformType: EventTransformType
 }
 
 /**
@@ -28,18 +14,6 @@ interface NestedFieldToProcess {
  * Exported for test purposes
  */
 export const _instanceByTransformType = new Map<string, EventTransform>()
-export const NESTED_FIELDS_TO_PROCESS: NestedFieldToProcess[] = [
-  {
-    field: 'members',
-    preProcessPayload: (payload) => ({ member: payload }),
-    eventTransformType: 'roomSessionMember',
-  },
-  {
-    field: 'recordings',
-    preProcessPayload: (payload) => ({ recording: payload }),
-    eventTransformType: 'roomSessionRecording',
-  },
-]
 
 const _getOrCreateInstance = ({
   transform,

--- a/packages/core/src/utils/interfaces.ts
+++ b/packages/core/src/utils/interfaces.ts
@@ -340,8 +340,9 @@ export type EventTransformType =
 
 export interface NestedFieldToProcess {
   /**
-   * Nested field to transform through an EventTransform
-   * It supports dot notation like `baz.foo.bar`
+   * It's responsible for digging into the `transformedPayload` and mutating it with
+   * the correct logic and using the `instanceFactory` function to create child objects
+   * for the nested fields. For example: members/recordings/playbacks.
    */
   process: (
     transformedPayload: any,

--- a/packages/core/src/utils/interfaces.ts
+++ b/packages/core/src/utils/interfaces.ts
@@ -338,6 +338,26 @@ export type EventTransformType =
   | ChatTransformType
   | MessagingTransformType
 
+export interface NestedFieldToProcess {
+  /**
+   * Nested field to transform through an EventTransform
+   * It supports dot notation like `baz.foo.bar`
+   */
+  process: (
+    transformedPayload: any,
+    instanceFactory: (payload: any) => any
+  ) => any
+  /**
+   * Allow us to update the nested `payload` to match the shape we already
+   * treat consuming other events from the server.
+   * For example: wrapping the `payload` within a specific key.
+   *  `payload` becomes `{ "member": payload }`
+   */
+  processInstancePayload: (payload: any) => any
+  /** Type of the EventTransform to select from `instance._emitterTransforms` */
+  eventTransformType: EventTransformType
+}
+
 /**
  * `EventTransform`s represent our internal pipeline for
  * creating specific instances for each event handler. This
@@ -399,6 +419,13 @@ export interface EventTransform {
    * defined by the object returned from `instanceFactory`.
    */
   payloadTransform: (payload: any) => any
+  /**
+   * For some events we need to transform not only the top-level
+   * payload but also different nested fields.
+   * This allow us to target the fields and apply transform those
+   * into stateless object following our EventTranform pattern.
+   */
+  nestedFieldsToProcess?: () => NestedFieldToProcess[]
   /**
    * Allow us to define what property to use to namespace
    * our events (_eventsNamespace).

--- a/packages/realtime-api/src/video/RoomSession.ts
+++ b/packages/realtime-api/src/video/RoomSession.ts
@@ -689,6 +689,32 @@ class RoomSessionConsumer extends BaseConsumer<RealTimeRoomApiEvents> {
           payloadTransform: (payload: VideoRoomSubscribedEventParams) => {
             return toExternalJSON(payload.room_session)
           },
+          nestedFieldsToProcess: () => {
+            return [
+              {
+                process: (transformedPayload, instanceFactory) => {
+                  if (transformedPayload?.members?.length) {
+                    transformedPayload.members =
+                      transformedPayload.members.map(instanceFactory)
+                  }
+                  return transformedPayload
+                },
+                processInstancePayload: (payload) => ({ member: payload }),
+                eventTransformType: 'roomSessionMember',
+              },
+              {
+                process: (transformedPayload, instanceFactory) => {
+                  if (transformedPayload?.recordings?.length) {
+                    transformedPayload.recordings =
+                      transformedPayload.recordings.map(instanceFactory)
+                  }
+                  return transformedPayload
+                },
+                processInstancePayload: (payload) => ({ recording: payload }),
+                eventTransformType: 'roomSessionRecording',
+              },
+            ]
+          },
           getInstanceEventNamespace: (
             payload: VideoRoomSubscribedEventParams
           ) => {


### PR DESCRIPTION
The goal was to expose the RoomSessionRecording objects for each (active) recording from a `room.joined` (= `room.subscribed`) event. 
I needed to update some internals to transform each payload (members/recordings/playbacks) and expose the proper objects.