### PR TITLE
Improve WebSocket Reconnect Logic

### DIFF
--- a/.changeset/itchy-schools-ring.md
+++ b/.changeset/itchy-schools-ring.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/core': patch
+---
+
+[internal] Improve WS reconnect logic

--- a/packages/core/src/redux/rootSaga.ts
+++ b/packages/core/src/redux/rootSaga.ts
@@ -143,6 +143,10 @@ export function* socketClosedWorker({
     sessionChannel.close()
   } else {
     getLogger().warn('Unhandled Session Status', session.status)
+
+    if ('development' === process.env.NODE_ENV) {
+      throw new Error(`Unhandled Session Status: '${session.status}'`)
+    }
   }
 }
 

--- a/packages/core/src/utils/interfaces.ts
+++ b/packages/core/src/utils/interfaces.ts
@@ -263,11 +263,15 @@ export interface WebSocketClient {
   readyState: WebSocket['readyState']
 }
 
-export interface NodeSocketClient extends WebSocketClient {
+interface NodeSocketClient extends WebSocketClient {
   addEventListener(
-    method: 'message',
+    method: 'open' | 'close' | 'error' | 'message',
     cb: (event: any) => void,
     options?: any
+  ): void
+  removeEventListener(
+    method: 'open' | 'close' | 'error' | 'message',
+    cb: (event: any) => void
   ): void
 }
 

--- a/packages/core/src/utils/interfaces.ts
+++ b/packages/core/src/utils/interfaces.ts
@@ -257,6 +257,7 @@ export type RoomMethod =
 
 export interface WebSocketClient {
   addEventListener: WebSocket['addEventListener']
+  removeEventListener: WebSocket['addEventListener']
   send: WebSocket['send']
   close: WebSocket['close']
   readyState: WebSocket['readyState']


### PR DESCRIPTION
This is a quick pass to solve some issues in Safari where the `'close'` event runs multiple times in case of network blips client-side. 
All the WebSocket events run once (expect `'message'`) so, in any case, we won't have race conditions between different handlers.