### PR TITLE
Force video elements to play when paused 

### DIFF
--- a/.changeset/slimy-socks-brake.md
+++ b/.changeset/slimy-socks-brake.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/js': patch
+---
+
+Force video elements to play when paused by UA

--- a/packages/js/src/utils/videoElement.ts
+++ b/packages/js/src/utils/videoElement.ts
@@ -14,6 +14,17 @@ const buildVideo = () => {
   video.autoplay = true
   video.playsInline = true
 
+  /**
+   * Local and Remov video elements should never be paused
+   * and Safari/Firefox pause the video (ie: enabling PiP, switch cameras etc)
+   * We try to force it to keep playing.
+   */
+  video.addEventListener('pause', () => {
+    video.play().catch((error) => {
+      getLogger().error('Video Element Paused', video, error)
+    })
+  })
+
   return video
 }
 


### PR DESCRIPTION
Both remote and local video elements should never be paused but Safari and Firefox (in some cases) pause the video so we try to `.play()` it again