### PR TITLE
Add payload to `dial` failed

### DIFF
--- a/.changeset/hip-wombats-help.md
+++ b/.changeset/hip-wombats-help.md
@@ -1,0 +1,6 @@
+---
+'@signalwire/core': patch
+'@signalwire/realtime-api': patch
+---
+
+[internal] Add ability to return the payload when the dial fails

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -69,6 +69,7 @@ export type {
   MapToPubSubShape,
   SDKActions,
 } from './redux/interfaces'
+export type { ToExternalJSONResult } from './utils'
 export * as actions from './redux/actions'
 export * as sagaHelpers from './redux/utils/sagaHelpers'
 export * as sagaEffects from '@redux-saga/core/effects'

--- a/packages/core/src/types/voiceCall.ts
+++ b/packages/core/src/types/voiceCall.ts
@@ -539,7 +539,7 @@ export interface VoiceCallContract<T = any> {
   device: any // FIXME:
   from: string
   to: string
-  direction: 'inbound' | 'outbound'
+  direction: CallingCallDirection
   headers?: SipHeader[]
 
   dial(params: VoiceDialer): Promise<T>
@@ -646,12 +646,14 @@ interface CallingCallSIPDevice {
 
 type CallingCallDevice = CallingCallPhoneDevice | CallingCallSIPDevice
 type CallingCallState = 'created' | 'ringing' | 'answered' | 'ending' | 'ended'
+type CallingCallDirection = 'inbound' | 'outbound'
+
 interface CallingCall {
   call_id: string
   call_state: CallingCallState
   context?: string
   tag?: string
-  direction: 'inbound' | 'outbound'
+  direction: CallingCallDirection
   device: CallingCallDevice
   node_id: string
   segment_id?: string
@@ -664,12 +666,28 @@ interface CallingCallDial extends CallingCall {
 /**
  * 'calling.call.dial'
  */
-export interface CallingCallDialEventParams {
+export type CallingCallDialDialingEventParams = {
   node_id: string
   tag: string
-  dial_state: 'dialing' | 'answered' | 'failed'
-  call?: CallingCallDial
+  dial_state: 'dialing'
 }
+export type CallingCallDialAnsweredEventParams = {
+  node_id: string
+  tag: string
+  dial_state: 'answered'
+  call: CallingCallDial
+}
+export type CallingCallDialFailedEventParams = {
+  node_id: string
+  tag: string
+  dial_state: 'failed'
+  reason: string
+  source: CallingCallDirection
+}
+export type CallingCallDialEventParams =
+  | CallingCallDialDialingEventParams
+  | CallingCallDialAnsweredEventParams
+  | CallingCallDialFailedEventParams
 
 export interface CallingCallDialEvent extends SwEvent {
   event_type: ToInternalVoiceEvent<CallDial>

--- a/packages/core/src/utils/toExternalJSON.ts
+++ b/packages/core/src/utils/toExternalJSON.ts
@@ -39,7 +39,7 @@ const isTimestampProperty = (prop: string) => {
   return prop.endsWith('At')
 }
 
-type ToExternalJSONResult<T> = {
+export type ToExternalJSONResult<T> = {
   [Property in NonNullable<keyof T> as SnakeToCamelCase<
     Extract<Property, string>
   >]: ConverToExternalTypes<Extract<Property, string>, T[Property]>

--- a/packages/realtime-api/src/voice/workers/voiceCallDialWorker.ts
+++ b/packages/realtime-api/src/voice/workers/voiceCallDialWorker.ts
@@ -7,6 +7,9 @@ import {
   MapToPubSubShape,
   CallingCallDialEvent,
   SDKWorkerHooks,
+  ToExternalJSONResult,
+  CallingCallDialFailedEventParams,
+  toExternalJSON,
 } from '@signalwire/core'
 import type { Call } from '../Call'
 
@@ -16,7 +19,9 @@ const TARGET_DIAL_STATES: CallingCallDialEvent['params']['dial_state'][] = [
 ]
 
 type VoiceCallDialWorkerOnDone = (args: Call) => void
-type VoiceCallDialWorkerOnFail = () => void
+type VoiceCallDialWorkerOnFail = (
+  args: ToExternalJSONResult<CallingCallDialFailedEventParams>
+) => void
 
 export type VoiceCallDialWorkerHooks = SDKWorkerHooks<
   VoiceCallDialWorkerOnDone,
@@ -43,7 +48,7 @@ export const voiceCallDialWorker: SDKWorker<Call, VoiceCallDialWorkerHooks> =
     if (action.payload.dial_state === 'answered') {
       onDone?.(instance)
     } else if (action.payload.dial_state === 'failed') {
-      onFail?.()
+      onFail?.(toExternalJSON(action.payload))
     } else {
       throw new Error('[voiceCallDialWorker] unhandled call_state')
     }


### PR DESCRIPTION
The code in this changeset includes a payload to the `onFail` handler so when the `dial` fails the user can see what happened.