### PR TITLE
Add method to wait playback ended events

### DIFF
--- a/.changeset/seven-steaks-punch.md
+++ b/.changeset/seven-steaks-punch.md
@@ -1,0 +1,7 @@
+---
+'@sw-internal/playground-realtime-api': minor
+'@signalwire/core': minor
+'@signalwire/realtime-api': minor
+---
+
+Add `waitForEnded()` method to the CallPlayback component to easily wait for playbacks to end.

--- a/internal/playground-realtime-api/src/voice/index.ts
+++ b/internal/playground-realtime-api/src/voice/index.ts
@@ -17,9 +17,9 @@ async function run() {
       token: process.env.TOKEN as string,
       contexts: [process.env.RELAY_CONTEXT as string],
       // logLevel: 'trace',
-      debug: {
-        logWsTraffic: true,
-      },
+      // debug: {
+      //   logWsTraffic: true,
+      // },
     })
 
     client.on('call.received', async (call) => {
@@ -228,6 +228,9 @@ async function run() {
           text: 'Thank you, you are now disconnected from the peer',
         })
       const playback = await call.play(playlist)
+
+      // To wait for the playback to end (without pause/resume/stop it)
+      // await playback.waitForEnded()
 
       console.log('Playback STARTED!', playback.id)
 

--- a/packages/core/src/types/voiceCall.ts
+++ b/packages/core/src/types/voiceCall.ts
@@ -381,6 +381,7 @@ export interface VoiceCallPlaybackContract {
   resume(): Promise<this>
   stop(): Promise<this>
   setVolume(volume: number): Promise<this>
+  waitForEnded(): Promise<this>
 }
 
 /**

--- a/packages/realtime-api/src/voice/Call.ts
+++ b/packages/realtime-api/src/voice/Call.ts
@@ -97,6 +97,12 @@ export interface Call extends AssertSameType<CallMain, CallDocs> {}
 export interface CallFullState extends Call {}
 
 /**
+ * Used to resolve the play() method and to update the CallPlayback object through the EmitterTransform
+ */
+export const callingPlaybackTriggerEvent =
+  toLocalEvent<EmitterTransformsEvents>('calling.playback.trigger')
+
+/**
  * Used to resolve the record() method and to update the CallRecording object through the EmitterTransform
  */
 export const callingRecordTriggerEvent = toLocalEvent<EmitterTransformsEvents>(
@@ -206,7 +212,7 @@ export class CallConsumer extends AutoApplyTransformsConsumer<RealTimeCallApiEve
     >([
       [
         [
-          toLocalEvent<EmitterTransformsEvents>('calling.playback.start'),
+          callingPlaybackTriggerEvent,
           'calling.playback.started',
           'calling.playback.updated',
           'calling.playback.ended',
@@ -436,7 +442,8 @@ export class CallConsumer extends AutoApplyTransformsConsumer<RealTimeCallApiEve
         resolve(callPlayback)
       }
 
-      this.once(toLocalEvent('calling.playback.start'), resolveHandler)
+      // @ts-expect-error
+      this.on(callingPlaybackTriggerEvent, resolveHandler)
 
       this.execute({
         method: 'calling.play',
@@ -455,11 +462,12 @@ export class CallConsumer extends AutoApplyTransformsConsumer<RealTimeCallApiEve
             node_id: this.nodeId,
             state: 'playing',
           }
-          this.emit(toLocalEvent('calling.playback.start'), startEvent)
+          // @ts-expect-error
+          this.emit(callingPlaybackTriggerEvent, startEvent)
         })
         .catch((e) => {
           // @ts-expect-error
-          this.off(toLocalEvent('calling.playback.start'), resolveHandler)
+          this.off(callingPlaybackTriggerEvent, resolveHandler)
           reject(e)
         })
     })

--- a/packages/realtime-api/src/voice/CallPlayback.ts
+++ b/packages/realtime-api/src/voice/CallPlayback.ts
@@ -27,6 +27,8 @@ export class CallPlaybackAPI
   extends BaseComponent<CallPlaybackEventsHandlerMapping>
   implements VoiceCallPlaybackContract
 {
+  protected _eventsPrefix = 'calling' as const
+
   callId: string
   nodeId: string
   controlId: string
@@ -94,6 +96,18 @@ export class CallPlaybackAPI
     })
 
     return this
+  }
+
+  waitForEnded() {
+    return new Promise<this>((resolve) => {
+      this._attachListeners(this.controlId)
+
+      const handler = () => resolve(this)
+      // @ts-expect-error
+      this.once('playback.ended', handler)
+      // // @ts-expect-error
+      // this.on('prompt.failed', handler)
+    })
   }
 }
 

--- a/packages/realtime-api/src/voice/CallPrompt.ts
+++ b/packages/realtime-api/src/voice/CallPrompt.ts
@@ -115,9 +115,9 @@ export class CallPromptAPI
 
       const handler = () => resolve(this)
       // @ts-expect-error
-      this.on('prompt.ended', handler)
+      this.once('prompt.ended', handler)
       // @ts-expect-error
-      this.on('prompt.failed', handler)
+      this.once('prompt.failed', handler)
     })
   }
 }

--- a/packages/realtime-api/src/voice/workers/voiceCallPlayWorker.ts
+++ b/packages/realtime-api/src/voice/workers/voiceCallPlayWorker.ts
@@ -71,7 +71,7 @@ export const voiceCallPlayWorker: SDKWorker<Call> = function* (
         })
 
         /**
-         * Dispatch an event to resolve `waitForResult` in CallPlayback
+         * Dispatch an event to resolve `waitForEnded` in CallPlayback
          * when ended
          */
         yield sagaEffects.put(pubSubChannel, {

--- a/packages/realtime-api/src/voice/workers/voiceCallPlayWorker.ts
+++ b/packages/realtime-api/src/voice/workers/voiceCallPlayWorker.ts
@@ -70,6 +70,19 @@ export const voiceCallPlayWorker: SDKWorker<Call> = function* (
           payload: payloadWithTag,
         })
 
+        /**
+         * Dispatch an event to resolve `waitForResult` in CallPlayback
+         * when ended
+         */
+        yield sagaEffects.put(pubSubChannel, {
+          type: 'calling.playback.ended',
+          // @ts-ignore
+          payload: {
+            tag: controlId,
+            ...action.payload,
+          },
+        })
+
         done()
         break
       }


### PR DESCRIPTION
Similar to the `CallPrompt.waitForResult()` this PR adds the method `.waitForEnded()` on the CallPlayback component.