### PR TITLE
Fix getDevicesWithPermissions

### DIFF
--- a/.changeset/few-kangaroos-accept.md
+++ b/.changeset/few-kangaroos-accept.md
@@ -1,0 +1,6 @@
+---
+'@sw-internal/playground-js': patch
+'@signalwire/webrtc': patch
+---
+
+Fix `getDevicesWithPermissions` for Firefox.

--- a/internal/playground-js/src/heroku/index.js
+++ b/internal/playground-js/src/heroku/index.js
@@ -1,6 +1,10 @@
 import { Video } from '@signalwire/js'
 import {
   enumerateDevices,
+  checkPermissions,
+  getCameraDevicesWithPermissions,
+  getMicrophoneDevicesWithPermissions,
+  getSpeakerDevicesWithPermissions,
   getMicrophoneDevices,
   getCameraDevices,
   getSpeakerDevices,
@@ -8,6 +12,14 @@ import {
   createDeviceWatcher,
   createMicrophoneAnalyzer,
 } from '@signalwire/webrtc'
+
+window.getMicrophoneDevices = getMicrophoneDevices
+window.getCameraDevices = getCameraDevices
+window.getSpeakerDevices = getSpeakerDevices
+window.checkPermissions = checkPermissions
+window.getCameraDevicesWithPermissions = getCameraDevicesWithPermissions
+window.getMicrophoneDevicesWithPermissions = getMicrophoneDevicesWithPermissions
+window.getSpeakerDevicesWithPermissions = getSpeakerDevicesWithPermissions
 
 let roomObj = null
 let micAnalyzer = null

--- a/packages/webrtc/src/utils/deviceHelpers.test.ts
+++ b/packages/webrtc/src/utils/deviceHelpers.test.ts
@@ -4,6 +4,7 @@ import {
   assureDeviceId,
   checkPermissions,
 } from './deviceHelpers'
+import * as WebRTC from './webrtcHelpers'
 
 describe('Helpers browser functions', () => {
   const group1 = 'group1'
@@ -178,20 +179,23 @@ describe('Helpers browser functions', () => {
 
     describe('without camera permissions', () => {
       it('should invoke getUserMedia to request camera permissions and return device list removing duplicates', async () => {
+        ;(WebRTC.stopStream as jest.Mock) = jest.fn()
+
+        // @ts-ignore
+        navigator.permissions.query.mockResolvedValueOnce()
         // @ts-ignore
         navigator.mediaDevices.enumerateDevices.mockResolvedValueOnce(
           DEVICES_CAMERA_NO_LABELS
         )
-        const devices = await getDevicesWithPermissions()
+        const devices = await getDevicesWithPermissions('camera')
         expect(navigator.mediaDevices.getUserMedia).toHaveBeenCalledTimes(1)
         expect(navigator.mediaDevices.getUserMedia).toHaveBeenCalledWith({
-          audio: true,
+          audio: false,
           video: true,
         })
-        expect(devices).toHaveLength(5)
-        expect(devices[0].label).toEqual(
-          'Default - External Microphone (Built-in)'
-        )
+        expect(WebRTC.stopStream).toHaveBeenCalledTimes(1)
+        expect(devices).toHaveLength(2)
+        expect(devices[0].label).toEqual('FaceTime HD Camera')
         expect(devices.every((d) => d.deviceId && d.label)).toBe(true)
       })
     })
@@ -199,16 +203,19 @@ describe('Helpers browser functions', () => {
     describe('without microphone permissions', () => {
       it('should invoke getUserMedia to request microphone permissions and return device list removing duplicates', async () => {
         // @ts-ignore
+        navigator.permissions.query.mockResolvedValueOnce()
+
+        // @ts-ignore
         navigator.mediaDevices.enumerateDevices.mockResolvedValueOnce(
           DEVICES_MICROPHONE_NO_LABELS
         )
-        const devices = await getDevicesWithPermissions()
+        const devices = await getDevicesWithPermissions('microphone')
         expect(navigator.mediaDevices.getUserMedia).toHaveBeenCalledTimes(1)
         expect(navigator.mediaDevices.getUserMedia).toHaveBeenCalledWith({
           audio: true,
-          video: true,
+          video: false,
         })
-        expect(devices).toHaveLength(5)
+        expect(devices).toHaveLength(2)
         expect(devices[0].label).toEqual(
           'Default - External Microphone (Built-in)'
         )

--- a/packages/webrtc/src/utils/deviceHelpers.ts
+++ b/packages/webrtc/src/utils/deviceHelpers.ts
@@ -155,6 +155,10 @@ export const getDevicesWithPermissions = async (
     stream = await WebRTC.getUserMedia(constraints)
   }
   const devices = await getDevices(kind, fullList)
+  /**
+   * Firefox requires an active stream at the time of `enumerateDevices`
+   * so we need to stop it after `getDevices`
+   */
   if (stream) {
     WebRTC.stopStream(stream)
   }

--- a/packages/webrtc/src/utils/deviceHelpers.ts
+++ b/packages/webrtc/src/utils/deviceHelpers.ts
@@ -149,12 +149,17 @@ export const getDevicesWithPermissions = async (
   fullList: boolean = false
 ): Promise<MediaDeviceInfo[]> => {
   const hasPerms = await checkPermissions(kind)
+  let stream: MediaStream | undefined = undefined
   if (hasPerms === false) {
     const constraints = _constraintsByKind(kind)
-    const stream = await WebRTC.getUserMedia(constraints)
+    stream = await WebRTC.getUserMedia(constraints)
+  }
+  const devices = await getDevices(kind, fullList)
+  if (stream) {
     WebRTC.stopStream(stream)
   }
-  return getDevices(kind, fullList)
+
+  return devices
 }
 
 /**


### PR DESCRIPTION
Firefox has a special `temporary permission` for the media devices and it requires an active MediaStream to proper enumerate the devices. Just stop the stream `after` the `enumerateDevices` call do the trick.