### PR TITLE
Fix issue with `Call.connect` and inbound calls + e2e voice connect/detectDigit

### DIFF
--- a/.changeset/short-apes-dance.md
+++ b/.changeset/short-apes-dance.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/realtime-api': patch
+---
+
+Fix issue with `Call.connect` and inbound calls

--- a/.drone.yml
+++ b/.drone.yml
@@ -43,6 +43,8 @@ steps:
         from_secret: VOICE_DIAL_FROM_NUMBER
       VOICE_DIAL_TO_NUMBER:
         from_secret: VOICE_DIAL_TO_NUMBER
+      VOICE_DIAL_CONNECT_TO_NUMBER:
+        from_secret: VOICE_DIAL_CONNECT_TO_NUMBER
 
 trigger:
   event: push


### PR DESCRIPTION
The code in this changeset includes:

1. Fixed issue with `Call.connect` and inbound calls where the `tag` failed to get retrieved.
2. Extended the e2e for Voice to include `Call.connect` and `detectDigit`
