### PR TITLE
Add watch mode in `realtime-playground`

### DIFF
--- a/internal/playground-realtime-api/package.json
+++ b/internal/playground-realtime-api/package.json
@@ -10,6 +10,7 @@
   "devDependencies": {
     "dotenv": "^16.0.0",
     "esbuild-register": "^3.3.2",
-    "inquirer": "^8.2.1"
+    "inquirer": "^8.2.1",
+    "node-watch": "^0.7.3"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,7 +56,8 @@
       "devDependencies": {
         "dotenv": "^16.0.0",
         "esbuild-register": "^3.3.2",
-        "inquirer": "^8.2.1"
+        "inquirer": "^8.2.1",
+        "node-watch": "^0.7.3"
       }
     },
     "internal/playground-realtime-api/node_modules/ansi-regex": {
@@ -9698,6 +9699,8 @@
     },
     "node_modules/log-symbols/node_modules/chalk": {
       "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -10416,6 +10419,15 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.4.tgz",
       "integrity": "sha512-gbMzqQtTtDz/00jQzZ21PQzdI9PyLYqUSvD0p3naOhX4odFji0ZxYdnVwPTxmSwkmxhcFImpozceidSG+AgoPQ=="
     },
+    "node_modules/node-watch": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/node-watch/-/node-watch-0.7.3.tgz",
+      "integrity": "sha512-3l4E8uMPY1HdMMryPRUAl+oIHtXtyiTlIiESNSVSNxcPfzAFzeTbXFQkZfAwBbo0B1qMSG8nUABx+Gd+YrbKrQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/normalize-package-data": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
@@ -10677,6 +10689,8 @@
     },
     "node_modules/ora/node_modules/chalk": {
       "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -13418,6 +13432,8 @@
     },
     "node_modules/tap/node_modules/ci-info": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+      "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
       "inBundle": true,
       "license": "MIT"
     },
@@ -13768,6 +13784,8 @@
     },
     "node_modules/tap/node_modules/ink/node_modules/chalk": {
       "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -13826,6 +13844,8 @@
     },
     "node_modules/tap/node_modules/is-ci": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
+      "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -14527,6 +14547,8 @@
     },
     "node_modules/tap/node_modules/widest-line": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-3.1.0.tgz",
+      "integrity": "sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -17899,7 +17921,8 @@
       "requires": {
         "dotenv": "^16.0.0",
         "esbuild-register": "^3.3.2",
-        "inquirer": "^8.2.1"
+        "inquirer": "^8.2.1",
+        "node-watch": "^0.7.3"
       },
       "dependencies": {
         "ansi-regex": {
@@ -22663,6 +22686,8 @@
         },
         "chalk": {
           "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
@@ -23145,6 +23170,12 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.4.tgz",
       "integrity": "sha512-gbMzqQtTtDz/00jQzZ21PQzdI9PyLYqUSvD0p3naOhX4odFji0ZxYdnVwPTxmSwkmxhcFImpozceidSG+AgoPQ=="
     },
+    "node-watch": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/node-watch/-/node-watch-0.7.3.tgz",
+      "integrity": "sha512-3l4E8uMPY1HdMMryPRUAl+oIHtXtyiTlIiESNSVSNxcPfzAFzeTbXFQkZfAwBbo0B1qMSG8nUABx+Gd+YrbKrQ==",
+      "dev": true
+    },
     "normalize-package-data": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
@@ -23327,6 +23358,8 @@
         },
         "chalk": {
           "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
@@ -25133,6 +25166,8 @@
         },
         "ci-info": {
           "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+          "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
           "bundled": true
         },
         "cli-boxes": {
@@ -25365,6 +25400,8 @@
             },
             "chalk": {
               "version": "4.1.2",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+              "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
               "bundled": true,
               "requires": {
                 "ansi-styles": "^4.1.0",
@@ -25405,6 +25442,8 @@
         },
         "is-ci": {
           "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
+          "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
           "bundled": true,
           "requires": {
             "ci-info": "^2.0.0"
@@ -25875,6 +25914,8 @@
         },
         "widest-line": {
           "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-3.1.0.tgz",
+          "integrity": "sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==",
           "bundled": true,
           "requires": {
             "string-width": "^4.0.0"

--- a/packages/realtime-api/package.json
+++ b/packages/realtime-api/package.json
@@ -32,7 +32,7 @@
   },
   "homepage": "https://github.com/signalwire/signalwire-js/tree/master/packages/realtime-api",
   "scripts": {
-    "start": "sw-build --dev --node",
+    "start": "sw-build --dev --node --watchFormat=cjs",
     "build": "tsc --project tsconfig.build.json && sw-build --node",
     "test": "NODE_ENV=test jest --detectOpenHandles --forceExit",
     "prepublishOnly": "npm run build",


### PR DESCRIPTION
The code in this changeset includes full watch mode for `playground-realtime-api`. Once `realtime-api` is in watch mode (`npm start` inside of `realtime-api`) the playground will get automatically re-loaded every time there's a change.