### PR TITLE
Improve compatibility-api test coverage

### DIFF
--- a/.changeset/young-carpets-raise.md
+++ b/.changeset/young-carpets-raise.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/compatibility-api': patch
+---
+
+Fix types to have `RestClient` constructable

--- a/.changeset/young-carpets-raise.md
+++ b/.changeset/young-carpets-raise.md
@@ -2,4 +2,4 @@
 '@signalwire/compatibility-api': patch
 ---
 
-Fix types to have `RestClient` constructable
+[internal] Improve test coverage for `RestClient`.

--- a/packages/compatibility-api/compatibility-api.d.ts
+++ b/packages/compatibility-api/compatibility-api.d.ts
@@ -3,13 +3,11 @@ import * as webhookTools from 'twilio/lib/webhooks/webhooks'
 import TwilioClient from 'twilio/lib/rest/Twilio'
 import type { CompatibilityAPIRestClientOptions } from './src/types'
 
-declare class RestClient extends Twilio {
-  constructor(
-    username: string,
-    token: string,
-    opts?: CompatibilityAPIRestClientOptions
-  )
-}
+declare function RestClient(
+  username: string,
+  token: string,
+  opts?: CompatibilityAPIRestClientOptions
+): Twilio
 
 declare class FaxResponse {
   constructor()

--- a/packages/compatibility-api/compatibility-api.d.ts
+++ b/packages/compatibility-api/compatibility-api.d.ts
@@ -3,38 +3,40 @@ import * as webhookTools from 'twilio/lib/webhooks/webhooks'
 import TwilioClient from 'twilio/lib/rest/Twilio'
 import type { CompatibilityAPIRestClientOptions } from './src/types'
 
-declare function RestClient(
-  username: string,
-  token: string,
-  opts?: CompatibilityAPIRestClientOptions
-): Twilio
+declare class RestClient extends Twilio {
+  constructor(
+    username: string,
+    token: string,
+    opts?: CompatibilityAPIRestClientOptions
+  )
+}
 
 declare class FaxResponse {
-  constructor();
-  receive(attributes?: FaxResponse.ReceiveAttributes): void;
-  toString(): string;
+  constructor()
+  receive(attributes?: FaxResponse.ReceiveAttributes): void
+  toString(): string
   reject(): void
 }
 
 declare namespace FaxResponse {
-  type ReceiveMediaType = 'application/pdf'|'image/tiff';
-  type ReceivePageSize = 'letter'|'legal'|'a4';
+  type ReceiveMediaType = 'application/pdf' | 'image/tiff'
+  type ReceivePageSize = 'letter' | 'legal' | 'a4'
   export interface ReceiveAttributes {
-    action?: string;
-    mediaType?: ReceiveMediaType;
-    method?: string;
-    pageSize?: ReceivePageSize;
-    storeMedia?: boolean;
+    action?: string
+    mediaType?: ReceiveMediaType
+    method?: string
+    pageSize?: ReceivePageSize
+    storeMedia?: boolean
   }
 }
 
 interface TwimlConstructor<T> {
-  new (): T;
+  new (): T
 }
 
 declare namespace RestClient {
   export interface RestClientLaMLInterface extends TwimlInterface {
-    FaxResponse: TwimlConstructor<FaxResponse>;
+    FaxResponse: TwimlConstructor<FaxResponse>
   }
 
   export import Twilio = TwilioClient

--- a/packages/compatibility-api/src/index.test.ts
+++ b/packages/compatibility-api/src/index.test.ts
@@ -36,7 +36,7 @@ describe('It is constructable', () => {
   )
 
   it('should expose all the properties', () => {
-    const client = new RestClientImpl('a', 'b', {
+    const client = RestClientImpl('a', 'b', {
       signalwireSpaceUrl: 'example.domain.com',
     })
     Object.keys(twilioProperties).forEach((prop) => {
@@ -47,7 +47,7 @@ describe('It is constructable', () => {
   it('should read the spaceUrl from SIGNALWIRE_SPACE_URL variable', () => {
     process.env.SIGNALWIRE_SPACE_URL = 'example.domain.com'
 
-    const client = new RestClientImpl('a', 'b')
+    const client = RestClientImpl('a', 'b')
     Object.keys(twilioProperties).forEach((prop) => {
       expect(client[prop as keyof Twilio]).toBeDefined()
     })
@@ -58,7 +58,7 @@ describe('It is constructable', () => {
   it('should read the spaceUrl from SIGNALWIRE_API_HOSTNAME variable', () => {
     process.env.SIGNALWIRE_API_HOSTNAME = 'example.domain.com'
 
-    const client = new RestClientImpl('a', 'b')
+    const client = RestClientImpl('a', 'b')
     Object.keys(twilioProperties).forEach((prop) => {
       expect(client[prop as keyof Twilio]).toBeDefined()
     })

--- a/packages/compatibility-api/src/index.test.ts
+++ b/packages/compatibility-api/src/index.test.ts
@@ -1,3 +1,4 @@
+import twilio, { Twilio } from 'twilio'
 import RestClientImpl from '@signalwire/compatibility-api'
 
 describe('It generate LaML', () => {
@@ -25,5 +26,43 @@ describe('It generate LaML', () => {
     expect(response.toString()).toEqual(
       '<?xml version="1.0" encoding="UTF-8"?><Response><Reject/></Response>'
     )
+  })
+})
+
+describe('It is constructable', () => {
+  const client = twilio('AC', 'token', {})
+  const twilioProperties = Object.getOwnPropertyDescriptors(
+    Object.getPrototypeOf(client)
+  )
+
+  it('should expose all the properties', () => {
+    const client = new RestClientImpl('a', 'b', {
+      signalwireSpaceUrl: 'example.domain.com',
+    })
+    Object.keys(twilioProperties).forEach((prop) => {
+      expect(client[prop as keyof Twilio]).toBeDefined()
+    })
+  })
+
+  it('should read the spaceUrl from SIGNALWIRE_SPACE_URL variable', () => {
+    process.env.SIGNALWIRE_SPACE_URL = 'example.domain.com'
+
+    const client = new RestClientImpl('a', 'b')
+    Object.keys(twilioProperties).forEach((prop) => {
+      expect(client[prop as keyof Twilio]).toBeDefined()
+    })
+
+    delete process.env.SIGNALWIRE_SPACE_URL
+  })
+
+  it('should read the spaceUrl from SIGNALWIRE_API_HOSTNAME variable', () => {
+    process.env.SIGNALWIRE_API_HOSTNAME = 'example.domain.com'
+
+    const client = new RestClientImpl('a', 'b')
+    Object.keys(twilioProperties).forEach((prop) => {
+      expect(client[prop as keyof Twilio]).toBeDefined()
+    })
+
+    delete process.env.SIGNALWIRE_API_HOSTNAME
   })
 })

--- a/packages/compatibility-api/src/index.ts
+++ b/packages/compatibility-api/src/index.ts
@@ -8,11 +8,15 @@ twilio.twiml.FaxResponse.prototype.reject = function (attributes: any) {
   return new Reject(this.response.ele('Reject', attributes))
 }
 
+/**
+ * TBD:
+ * @remarks See compatibility-api.d.ts for types
+ */
 const RestClient = function (
   username: string,
   token: string,
   opts?: CompatibilityAPIRestClientOptions
-): Twilio {
+) {
   const host = getHost(opts)
   // "AC" prefix because twilio-node requires it
   const client = twilio('AC' + username, token, opts)

--- a/packages/compatibility-api/src/index.ts
+++ b/packages/compatibility-api/src/index.ts
@@ -16,7 +16,7 @@ const RestClient = function (
   username: string,
   token: string,
   opts?: CompatibilityAPIRestClientOptions
-) {
+): Twilio {
   const host = getHost(opts)
   // "AC" prefix because twilio-node requires it
   const client = twilio('AC' + username, token, opts)


### PR DESCRIPTION
This PR adds some unit tests for the `compatibility-api` RestClient to make sure it extends all the properties.