### PR TITLE
Playback seek/rewind/forward

### DIFF
--- a/.changeset/silly-jokes-remember.md
+++ b/.changeset/silly-jokes-remember.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/core': minor
+---
+
+Expose methods to seek to a specific video position during playback.

--- a/internal/playground-js/src/heroku/index.html
+++ b/internal/playground-js/src/heroku/index.html
@@ -394,6 +394,43 @@
                   Stop Playback
                 </button>
               </div>
+              <div class="col-12 py-2 d-none" id="playbackSeekAbsoluteGroup">
+                <h6>Playback Seek</h6>
+                <div class="row g-2 align-items-center col-auto">
+                  <div class="col-auto">
+                    <input
+                      type="text"
+                      class="form-control"
+                      id="playbackSeekAbsolute"
+                    />
+                  </div>
+                  <div class="col-auto">
+                    <button
+                      id="seekPlaybackBtn"
+                      class="btn btn-danger"
+                      onClick="seekPlayback()"
+                    >
+                      Seek
+                    </button>
+                  </div>
+                  <div class="btn-group col-auto">
+                    <button
+                      id="seekRewindPlaybackBtn"
+                      class="btn btn-info"
+                      onClick="seekRewindPlayback()"
+                    >
+                      Rewind
+                    </button>
+                    <button
+                      id="seekForwardPlaybackBtn"
+                      class="btn btn-success"
+                      onClick="seekForwardPlayback()"
+                    >
+                      Forward
+                    </button>
+                  </div>
+                </div>
+              </div>
               <div id="playbackVolumeControl" class="col-12 d-none">
                 <label for="playbackVolume" class="form-label">
                   Playback Volume

--- a/internal/playground-js/src/heroku/index.js
+++ b/internal/playground-js/src/heroku/index.js
@@ -51,6 +51,7 @@ const playbackElements = [
   pausePlaybackBtn,
   resumePlaybackBtn,
   playbackVolumeControl,
+  playbackSeekAbsoluteGroup,
 ]
 
 window.playbackStarted = () => {
@@ -625,6 +626,54 @@ window.resumePlayback = () => {
     })
     .catch((error) => {
       console.error('Failed to resume playback:', error)
+    })
+}
+
+window.seekPlayback = () => {
+  const value = document.getElementById('playbackSeekAbsolute').value
+  if (!value) {
+    return console.warn('Invalid Seek Value')
+  } else if (!playbackObj) {
+    return console.warn("playbackObj doesn't exist")
+  }
+  console.debug('>> seekPlaybackBtn', value)
+  playbackObj
+    .seek(value)
+    .then(() => {
+      console.log('Playback.seek was successful')
+    })
+    .catch((error) => {
+      console.error('Failed to seek playback:', error)
+    })
+}
+
+window.seekRewindPlayback = () => {
+  if (!playbackObj) {
+    return console.warn("playbackObj doesn't exist")
+  }
+  console.debug('>> seekRewindPlayback')
+  playbackObj
+    .rewind(1000)
+    .then(() => {
+      console.log('Playback.rewind was successful')
+    })
+    .catch((error) => {
+      console.error('Failed to rewind playback:', error)
+    })
+}
+
+window.seekForwardPlayback = () => {
+  if (!playbackObj) {
+    return console.warn("playbackObj doesn't exist")
+  }
+  console.debug('>> seekForwardPlayback')
+  playbackObj
+    .forward(1000)
+    .then(() => {
+      console.log('Playback.forward was successful')
+    })
+    .catch((error) => {
+      console.error('Failed to forward playback:', error)
     })
 }
 

--- a/packages/core/src/rooms/RoomSessionPlayback.ts
+++ b/packages/core/src/rooms/RoomSessionPlayback.ts
@@ -71,12 +71,12 @@ export class RoomSessionPlaybackAPI
       params: {
         room_session_id: this.getStateProperty('roomSessionId'),
         playback_id: this.getStateProperty('id'),
-        position: timecode,
+        position: Math.abs(timecode),
       },
     })
   }
 
-  async forward(offset: number) {
+  async forward(offset: number = 5000) {
     await this.execute({
       method: 'video.playback.seek_relative',
       params: {
@@ -87,7 +87,7 @@ export class RoomSessionPlaybackAPI
     })
   }
 
-  async rewind(offset: number) {
+  async rewind(offset: number = 5000) {
     await this.execute({
       method: 'video.playback.seek_relative',
       params: {

--- a/packages/core/src/rooms/RoomSessionPlayback.ts
+++ b/packages/core/src/rooms/RoomSessionPlayback.ts
@@ -64,6 +64,39 @@ export class RoomSessionPlaybackAPI
       },
     })
   }
+
+  async seek(timecode: number) {
+    await this.execute({
+      method: 'video.playback.seek_absolute',
+      params: {
+        room_session_id: this.getStateProperty('roomSessionId'),
+        playback_id: this.getStateProperty('id'),
+        position: timecode,
+      },
+    })
+  }
+
+  async forward(offset: number) {
+    await this.execute({
+      method: 'video.playback.seek_relative',
+      params: {
+        room_session_id: this.getStateProperty('roomSessionId'),
+        playback_id: this.getStateProperty('id'),
+        position: Math.abs(offset),
+      },
+    })
+  }
+
+  async rewind(offset: number) {
+    await this.execute({
+      method: 'video.playback.seek_relative',
+      params: {
+        room_session_id: this.getStateProperty('roomSessionId'),
+        playback_id: this.getStateProperty('id'),
+        position: -Math.abs(offset),
+      },
+    })
+  }
 }
 
 export const createRoomSessionPlaybackObject = (

--- a/packages/core/src/rooms/methods.ts
+++ b/packages/core/src/rooms/methods.ts
@@ -218,6 +218,7 @@ export type PlayParams = {
   volume?: number
   positions?: Record<string, VideoPosition>
   layout?: string
+  currentTimecode?: number
 }
 export const play: RoomMethodDescriptor<any, PlayParams> = {
   value: function (params) {

--- a/packages/core/src/types/videoPlayback.ts
+++ b/packages/core/src/types/videoPlayback.ts
@@ -72,6 +72,12 @@ export interface VideoPlaybackContract {
    * default of 0.
    */
   setVolume(volume: number): Promise<void>
+
+  seek(timecode: number): Promise<void>
+
+  forward(offset: number): Promise<void>
+
+  rewind(offset: number): Promise<void>
 }
 
 /**

--- a/packages/core/src/types/videoPlayback.ts
+++ b/packages/core/src/types/videoPlayback.ts
@@ -41,6 +41,9 @@ export interface VideoPlaybackContract {
   /** Current state of the playback */
   state: 'playing' | 'paused' | 'completed'
 
+  /** Whether the seek function can be used for this playback. */
+  seekable: boolean
+
   /** Url of the file reproduced by this playback */
   url: string
 

--- a/packages/core/src/utils/interfaces.ts
+++ b/packages/core/src/utils/interfaces.ts
@@ -259,6 +259,8 @@ export type RoomMethod =
   | 'video.playback.resume'
   | 'video.playback.stop'
   | 'video.playback.set_volume'
+  | 'video.playback.seek_absolute'
+  | 'video.playback.seek_relative'
 
 export interface WebSocketClient {
   addEventListener: WebSocket['addEventListener']


### PR DESCRIPTION
The code in this changeset expose new SDK methods to seek to a specific video position during playback.

## Docs

The following need to be documented:

#### Methods
- `playback.seek(timecode)`
- `playback.forward(offset)`
- `playback.rewind(offset)`

#### Properties
- `playback.seekable`