### PR TITLE
Fix compatibility-api commonjs usage

### DIFF
--- a/.changeset/shy-peas-occur.md
+++ b/.changeset/shy-peas-occur.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/compatibility-api': patch
+---
+
+Fix `RestClient` export.

--- a/packages/compatibility-api/compatibility-api.d.ts
+++ b/packages/compatibility-api/compatibility-api.d.ts
@@ -47,4 +47,4 @@ declare namespace RestClient {
   export const LaML: RestClientLaMLInterface
 }
 
-export = RestClient
+export { RestClient }

--- a/packages/compatibility-api/src/index.test.ts
+++ b/packages/compatibility-api/src/index.test.ts
@@ -1,11 +1,11 @@
 import twilio, { Twilio } from 'twilio'
-import RestClientImpl from '@signalwire/compatibility-api'
+import { RestClient } from '@signalwire/compatibility-api'
 
 describe('It generate LaML', () => {
   const FROM = '+11111111119'
 
   it('should generate LaML', () => {
-    const response = new RestClientImpl.LaML.VoiceResponse()
+    const response = new RestClient.LaML.VoiceResponse()
     response.dial({ callerId: FROM }, '+11111111111')
     expect(response.toString()).toEqual(
       `<?xml version="1.0" encoding="UTF-8"?><Response><Dial callerId="${FROM}">+11111111111</Dial></Response>`
@@ -13,7 +13,7 @@ describe('It generate LaML', () => {
   })
 
   it('LaML to receive a fax', () => {
-    const response = new RestClientImpl.LaML.FaxResponse()
+    const response = new RestClient.LaML.FaxResponse()
     response.receive({ action: '/receive/fax' })
     expect(response.toString()).toEqual(
       '<?xml version="1.0" encoding="UTF-8"?><Response><Receive action="/receive/fax"/></Response>'
@@ -21,7 +21,7 @@ describe('It generate LaML', () => {
   })
 
   it('LaML to reject a fax', () => {
-    const response = new RestClientImpl.LaML.FaxResponse()
+    const response = new RestClient.LaML.FaxResponse()
     response.reject()
     expect(response.toString()).toEqual(
       '<?xml version="1.0" encoding="UTF-8"?><Response><Reject/></Response>'
@@ -36,7 +36,7 @@ describe('It is constructable', () => {
   )
 
   it('should expose all the properties', () => {
-    const client = RestClientImpl('a', 'b', {
+    const client = RestClient('a', 'b', {
       signalwireSpaceUrl: 'example.domain.com',
     })
     Object.keys(twilioProperties).forEach((prop) => {
@@ -47,7 +47,7 @@ describe('It is constructable', () => {
   it('should read the spaceUrl from SIGNALWIRE_SPACE_URL variable', () => {
     process.env.SIGNALWIRE_SPACE_URL = 'example.domain.com'
 
-    const client = RestClientImpl('a', 'b')
+    const client = RestClient('a', 'b')
     Object.keys(twilioProperties).forEach((prop) => {
       expect(client[prop as keyof Twilio]).toBeDefined()
     })
@@ -58,7 +58,7 @@ describe('It is constructable', () => {
   it('should read the spaceUrl from SIGNALWIRE_API_HOSTNAME variable', () => {
     process.env.SIGNALWIRE_API_HOSTNAME = 'example.domain.com'
 
-    const client = RestClientImpl('a', 'b')
+    const client = RestClient('a', 'b')
     Object.keys(twilioProperties).forEach((prop) => {
       expect(client[prop as keyof Twilio]).toBeDefined()
     })

--- a/packages/compatibility-api/src/index.ts
+++ b/packages/compatibility-api/src/index.ts
@@ -50,7 +50,8 @@ for (let i = 0; i < properties.length; i++) {
   })
 }
 
-export default RestClient
+export { RestClient }
+
 export type {
   CompatibilityAPIRestClientOptions,
   Twilio,

--- a/packages/compatibility-api/src/indexcjs.test.ts
+++ b/packages/compatibility-api/src/indexcjs.test.ts
@@ -1,0 +1,68 @@
+const twilio = require('twilio')
+const RestClient = require('@signalwire/compatibility-api')
+
+describe('It generate LaML', () => {
+  const FROM = '+11111111119'
+
+  it('should generate LaML', () => {
+    const response = new RestClient.LaML.VoiceResponse()
+    response.dial({ callerId: FROM }, '+11111111111')
+    expect(response.toString()).toEqual(
+      `<?xml version="1.0" encoding="UTF-8"?><Response><Dial callerId="${FROM}">+11111111111</Dial></Response>`
+    )
+  })
+
+  it('LaML to receive a fax', () => {
+    const response = new RestClient.LaML.FaxResponse()
+    response.receive({ action: '/receive/fax' })
+    expect(response.toString()).toEqual(
+      '<?xml version="1.0" encoding="UTF-8"?><Response><Receive action="/receive/fax"/></Response>'
+    )
+  })
+
+  it('LaML to reject a fax', () => {
+    const response = new RestClient.LaML.FaxResponse()
+    response.reject()
+    expect(response.toString()).toEqual(
+      '<?xml version="1.0" encoding="UTF-8"?><Response><Reject/></Response>'
+    )
+  })
+})
+
+describe('It is constructable', () => {
+  const client = twilio('AC', 'token', {})
+  const twilioProperties = Object.getOwnPropertyDescriptors(
+    Object.getPrototypeOf(client)
+  )
+
+  it('should expose all the properties', () => {
+    const client = RestClient('a', 'b', {
+      signalwireSpaceUrl: 'example.domain.com',
+    })
+    Object.keys(twilioProperties).forEach((prop) => {
+      expect(client[prop]).toBeDefined()
+    })
+  })
+
+  it('should read the spaceUrl from SIGNALWIRE_SPACE_URL variable', () => {
+    process.env.SIGNALWIRE_SPACE_URL = 'example.domain.com'
+
+    const client = RestClient('a', 'b')
+    Object.keys(twilioProperties).forEach((prop) => {
+      expect(client[prop]).toBeDefined()
+    })
+
+    delete process.env.SIGNALWIRE_SPACE_URL
+  })
+
+  it('should read the spaceUrl from SIGNALWIRE_API_HOSTNAME variable', () => {
+    process.env.SIGNALWIRE_API_HOSTNAME = 'example.domain.com'
+
+    const client = RestClient('a', 'b')
+    Object.keys(twilioProperties).forEach((prop) => {
+      expect(client[prop]).toBeDefined()
+    })
+
+    delete process.env.SIGNALWIRE_API_HOSTNAME
+  })
+})

--- a/packages/compatibility-api/src/indexcjs.test.ts
+++ b/packages/compatibility-api/src/indexcjs.test.ts
@@ -1,5 +1,5 @@
 const twilio = require('twilio')
-const RestClient = require('@signalwire/compatibility-api')
+const { RestClient } = require('@signalwire/compatibility-api')
 
 describe('It generate LaML', () => {
   const FROM = '+11111111119'


### PR DESCRIPTION
Moving code from `@signalwire/node` we left a `export default` that should be a named export instead. 
We avoid `default` to have room to export other objects from the Compatibility-API SDK and also to avoid common issues between ESM and CJS enviroments. 

This change should be reflected on our docs too.