### PR TITLE
Fix realtime-api esm output

### DIFF
--- a/.changeset/metal-ligers-whisper.md
+++ b/.changeset/metal-ligers-whisper.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/realtime-api': patch
+---
+
+Fix internal bundling to allow the usage of the `esm` output.

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@types/jest": "^27.5.1",
         "babel-jest": "^28.1.0",
         "concurrently": "^6.5.1",
-        "esbuild": "0.14.39",
+        "esbuild": "^0.14.43",
         "jest": "^28.1.0",
         "jest-environment-jsdom": "^28.1.0",
         "prettier": "^2.6.2",
@@ -5315,11 +5315,10 @@
       "license": "MIT"
     },
     "node_modules/esbuild": {
-      "version": "0.14.39",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.39.tgz",
-      "integrity": "sha512-2kKujuzvRWYtwvNjYDY444LQIA3TyJhJIX3Yo4+qkFlDDtGlSicWgeHVJqMUP/2sSfH10PGwfsj+O2ro1m10xQ==",
+      "version": "0.14.43",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.43.tgz",
+      "integrity": "sha512-Uf94+kQmy/5jsFwKWiQB4hfo/RkM9Dh7b79p8yqd1tshULdr25G2szLz631NoH3s2ujnKEKVD16RmOxvCNKRFA==",
       "hasInstallScript": true,
-      "license": "MIT",
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -5327,39 +5326,248 @@
         "node": ">=12"
       },
       "optionalDependencies": {
-        "esbuild-android-64": "0.14.39",
-        "esbuild-android-arm64": "0.14.39",
-        "esbuild-darwin-64": "0.14.39",
-        "esbuild-darwin-arm64": "0.14.39",
-        "esbuild-freebsd-64": "0.14.39",
-        "esbuild-freebsd-arm64": "0.14.39",
-        "esbuild-linux-32": "0.14.39",
-        "esbuild-linux-64": "0.14.39",
-        "esbuild-linux-arm": "0.14.39",
-        "esbuild-linux-arm64": "0.14.39",
-        "esbuild-linux-mips64le": "0.14.39",
-        "esbuild-linux-ppc64le": "0.14.39",
-        "esbuild-linux-riscv64": "0.14.39",
-        "esbuild-linux-s390x": "0.14.39",
-        "esbuild-netbsd-64": "0.14.39",
-        "esbuild-openbsd-64": "0.14.39",
-        "esbuild-sunos-64": "0.14.39",
-        "esbuild-windows-32": "0.14.39",
-        "esbuild-windows-64": "0.14.39",
-        "esbuild-windows-arm64": "0.14.39"
+        "esbuild-android-64": "0.14.43",
+        "esbuild-android-arm64": "0.14.43",
+        "esbuild-darwin-64": "0.14.43",
+        "esbuild-darwin-arm64": "0.14.43",
+        "esbuild-freebsd-64": "0.14.43",
+        "esbuild-freebsd-arm64": "0.14.43",
+        "esbuild-linux-32": "0.14.43",
+        "esbuild-linux-64": "0.14.43",
+        "esbuild-linux-arm": "0.14.43",
+        "esbuild-linux-arm64": "0.14.43",
+        "esbuild-linux-mips64le": "0.14.43",
+        "esbuild-linux-ppc64le": "0.14.43",
+        "esbuild-linux-riscv64": "0.14.43",
+        "esbuild-linux-s390x": "0.14.43",
+        "esbuild-netbsd-64": "0.14.43",
+        "esbuild-openbsd-64": "0.14.43",
+        "esbuild-sunos-64": "0.14.43",
+        "esbuild-windows-32": "0.14.43",
+        "esbuild-windows-64": "0.14.43",
+        "esbuild-windows-arm64": "0.14.43"
       }
     },
-    "node_modules/esbuild-darwin-64": {
-      "version": "0.14.39",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.39.tgz",
-      "integrity": "sha512-ImT6eUw3kcGcHoUxEcdBpi6LfTRWaV6+qf32iYYAfwOeV+XaQ/Xp5XQIBiijLeo+LpGci9M0FVec09nUw41a5g==",
+    "node_modules/esbuild-android-64": {
+      "version": "0.14.43",
+      "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.43.tgz",
+      "integrity": "sha512-kqFXAS72K6cNrB6RiM7YJ5lNvmWRDSlpi7ZuRZ1hu1S3w0zlwcoCxWAyM23LQUyZSs1PbjHgdbbfYAN8IGh6xg==",
       "cpu": [
         "x64"
       ],
-      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-android-arm64": {
+      "version": "0.14.43",
+      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.43.tgz",
+      "integrity": "sha512-bKS2BBFh+7XZY9rpjiHGRNA7LvWYbZWP87pLehggTG7tTaCDvj8qQGOU/OZSjCSKDYbgY7Q+oDw8RlYQ2Jt2BA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-darwin-64": {
+      "version": "0.14.43",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.43.tgz",
+      "integrity": "sha512-/3PSilx011ttoieRGkSZ0XV8zjBf2C9enV4ScMMbCT4dpx0mFhMOpFnCHkOK0pWGB8LklykFyHrWk2z6DENVUg==",
+      "cpu": [
+        "x64"
+      ],
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-darwin-arm64": {
+      "version": "0.14.43",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.43.tgz",
+      "integrity": "sha512-1HyFUKs8DMCBOvw1Qxpr5Vv/ThNcVIFb5xgXWK3pyT40WPvgYIiRTwJCvNs4l8i5qWF8/CK5bQxJVDjQvtv0Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-freebsd-64": {
+      "version": "0.14.43",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.43.tgz",
+      "integrity": "sha512-FNWc05TPHYgaXjbPZO5/rJKSBslfG6BeMSs8GhwnqAKP56eEhvmzwnIz1QcC9cRVyO+IKqWNfmHFkCa1WJTULA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-freebsd-arm64": {
+      "version": "0.14.43",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.43.tgz",
+      "integrity": "sha512-amrYopclz3VohqisOPR6hA3GOWA3LZC1WDLnp21RhNmoERmJ/vLnOpnrG2P/Zao+/erKTCUqmrCIPVtj58DRoA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-32": {
+      "version": "0.14.43",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.43.tgz",
+      "integrity": "sha512-KoxoEra+9O3AKVvgDFvDkiuddCds6q71owSQEYwjtqRV7RwbPzKxJa6+uyzUulHcyGVq0g15K0oKG5CFBcvYDw==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-64": {
+      "version": "0.14.43",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.43.tgz",
+      "integrity": "sha512-EwINwGMyiJMgBby5/SbMqKcUhS5AYAZ2CpEBzSowsJPNBJEdhkCTtEjk757TN/wxgbu3QklqDM6KghY660QCUw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-arm": {
+      "version": "0.14.43",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.43.tgz",
+      "integrity": "sha512-e6YzQUoDxxtyamuF12eVzzRC7bbEFSZohJ6igQB9tBqnNmIQY3fI6Cns3z2wxtbZ3f2o6idkD2fQnlvs2902Dg==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-arm64": {
+      "version": "0.14.43",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.43.tgz",
+      "integrity": "sha512-UlSpjMWllAc70zYbHxWuDS3FJytyuR/gHJYBr8BICcTNb/TSOYVBg6U7b3jZ3mILTrgzwJUHwhEwK18FZDouUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-mips64le": {
+      "version": "0.14.43",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.43.tgz",
+      "integrity": "sha512-f+v8cInPEL1/SDP//CfSYzcDNgE4CY3xgDV81DWm3KAPWzhvxARrKxB1Pstf5mB56yAslJDxu7ryBUPX207EZA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-ppc64le": {
+      "version": "0.14.43",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.43.tgz",
+      "integrity": "sha512-5wZYMDGAL/K2pqkdIsW+I4IR41kyfHr/QshJcNpUfK3RjB3VQcPWOaZmc+74rm4ZjVirYrtz+jWw0SgxtxRanA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-riscv64": {
+      "version": "0.14.43",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.43.tgz",
+      "integrity": "sha512-lYcAOUxp85hC7lSjycJUVSmj4/9oEfSyXjb/ua9bNl8afonaduuqtw7hvKMoKuYnVwOCDw4RSfKpcnIRDWq+Bw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-s390x": {
+      "version": "0.14.43",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.43.tgz",
+      "integrity": "sha512-27e43ZhHvhFE4nM7HqtUbMRu37I/4eNSUbb8FGZWszV+uLzMIsHDwLoBiJmw7G9N+hrehNPeQ4F5Ujad0DrUKQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-netbsd-64": {
+      "version": "0.14.43",
+      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.43.tgz",
+      "integrity": "sha512-2mH4QF6hHBn5zzAfxEI/2eBC0mspVsZ6UVo821LpAJKMvLJPBk3XJO5xwg7paDqSqpl7p6IRrAenW999AEfJhQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "netbsd"
       ],
       "engines": {
         "node": ">=12"
@@ -5445,6 +5653,21 @@
       "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
       "license": "0BSD"
     },
+    "node_modules/esbuild-openbsd-64": {
+      "version": "0.14.43",
+      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.43.tgz",
+      "integrity": "sha512-ZhQpiZjvqCqO8jKdGp9+8k9E/EHSA+zIWOg+grwZasI9RoblqJ1QiZqqi7jfd6ZrrG1UFBNGe4m0NFxCFbMVbg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/esbuild-register": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/esbuild-register/-/esbuild-register-3.3.2.tgz",
@@ -5453,6 +5676,66 @@
       "license": "MIT",
       "peerDependencies": {
         "esbuild": ">=0.12 <1"
+      }
+    },
+    "node_modules/esbuild-sunos-64": {
+      "version": "0.14.43",
+      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.43.tgz",
+      "integrity": "sha512-DgxSi9DaHReL9gYuul2rrQCAapgnCJkh3LSHPKsY26zytYppG0HgkgVF80zjIlvEsUbGBP/GHQzBtrezj/Zq1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-windows-32": {
+      "version": "0.14.43",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.43.tgz",
+      "integrity": "sha512-Ih3+2O5oExiqm0mY6YYE5dR0o8+AspccQ3vIAtRodwFvhuyGLjb0Hbmzun/F3Lw19nuhPMu3sW2fqIJ5xBxByw==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-windows-64": {
+      "version": "0.14.43",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.43.tgz",
+      "integrity": "sha512-8NsuNfI8xwFuJbrCuI+aBqNTYkrWErejFO5aYM+yHqyHuL8mmepLS9EPzAzk8rvfaJrhN0+RvKWAcymViHOKEw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-windows-arm64": {
+      "version": "0.14.43",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.43.tgz",
+      "integrity": "sha512-7ZlD7bo++kVRblJEoG+cepljkfP8bfuTPz5fIXzptwnPaFwGS6ahvfoYzY7WCf5v/1nX2X02HDraVItTgbHnKw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/escalade": {
@@ -20419,36 +20702,120 @@
       "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg=="
     },
     "esbuild": {
-      "version": "0.14.39",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.39.tgz",
-      "integrity": "sha512-2kKujuzvRWYtwvNjYDY444LQIA3TyJhJIX3Yo4+qkFlDDtGlSicWgeHVJqMUP/2sSfH10PGwfsj+O2ro1m10xQ==",
+      "version": "0.14.43",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.43.tgz",
+      "integrity": "sha512-Uf94+kQmy/5jsFwKWiQB4hfo/RkM9Dh7b79p8yqd1tshULdr25G2szLz631NoH3s2ujnKEKVD16RmOxvCNKRFA==",
       "requires": {
-        "esbuild-android-64": "0.14.39",
-        "esbuild-android-arm64": "0.14.39",
-        "esbuild-darwin-64": "0.14.39",
-        "esbuild-darwin-arm64": "0.14.39",
-        "esbuild-freebsd-64": "0.14.39",
-        "esbuild-freebsd-arm64": "0.14.39",
-        "esbuild-linux-32": "0.14.39",
-        "esbuild-linux-64": "0.14.39",
-        "esbuild-linux-arm": "0.14.39",
-        "esbuild-linux-arm64": "0.14.39",
-        "esbuild-linux-mips64le": "0.14.39",
-        "esbuild-linux-ppc64le": "0.14.39",
-        "esbuild-linux-riscv64": "0.14.39",
-        "esbuild-linux-s390x": "0.14.39",
-        "esbuild-netbsd-64": "0.14.39",
-        "esbuild-openbsd-64": "0.14.39",
-        "esbuild-sunos-64": "0.14.39",
-        "esbuild-windows-32": "0.14.39",
-        "esbuild-windows-64": "0.14.39",
-        "esbuild-windows-arm64": "0.14.39"
+        "esbuild-android-64": "0.14.43",
+        "esbuild-android-arm64": "0.14.43",
+        "esbuild-darwin-64": "0.14.43",
+        "esbuild-darwin-arm64": "0.14.43",
+        "esbuild-freebsd-64": "0.14.43",
+        "esbuild-freebsd-arm64": "0.14.43",
+        "esbuild-linux-32": "0.14.43",
+        "esbuild-linux-64": "0.14.43",
+        "esbuild-linux-arm": "0.14.43",
+        "esbuild-linux-arm64": "0.14.43",
+        "esbuild-linux-mips64le": "0.14.43",
+        "esbuild-linux-ppc64le": "0.14.43",
+        "esbuild-linux-riscv64": "0.14.43",
+        "esbuild-linux-s390x": "0.14.43",
+        "esbuild-netbsd-64": "0.14.43",
+        "esbuild-openbsd-64": "0.14.43",
+        "esbuild-sunos-64": "0.14.43",
+        "esbuild-windows-32": "0.14.43",
+        "esbuild-windows-64": "0.14.43",
+        "esbuild-windows-arm64": "0.14.43"
       }
     },
+    "esbuild-android-64": {
+      "version": "0.14.43",
+      "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.43.tgz",
+      "integrity": "sha512-kqFXAS72K6cNrB6RiM7YJ5lNvmWRDSlpi7ZuRZ1hu1S3w0zlwcoCxWAyM23LQUyZSs1PbjHgdbbfYAN8IGh6xg==",
+      "optional": true
+    },
+    "esbuild-android-arm64": {
+      "version": "0.14.43",
+      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.43.tgz",
+      "integrity": "sha512-bKS2BBFh+7XZY9rpjiHGRNA7LvWYbZWP87pLehggTG7tTaCDvj8qQGOU/OZSjCSKDYbgY7Q+oDw8RlYQ2Jt2BA==",
+      "optional": true
+    },
     "esbuild-darwin-64": {
-      "version": "0.14.39",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.39.tgz",
-      "integrity": "sha512-ImT6eUw3kcGcHoUxEcdBpi6LfTRWaV6+qf32iYYAfwOeV+XaQ/Xp5XQIBiijLeo+LpGci9M0FVec09nUw41a5g==",
+      "version": "0.14.43",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.43.tgz",
+      "integrity": "sha512-/3PSilx011ttoieRGkSZ0XV8zjBf2C9enV4ScMMbCT4dpx0mFhMOpFnCHkOK0pWGB8LklykFyHrWk2z6DENVUg==",
+      "optional": true
+    },
+    "esbuild-darwin-arm64": {
+      "version": "0.14.43",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.43.tgz",
+      "integrity": "sha512-1HyFUKs8DMCBOvw1Qxpr5Vv/ThNcVIFb5xgXWK3pyT40WPvgYIiRTwJCvNs4l8i5qWF8/CK5bQxJVDjQvtv0Yw==",
+      "optional": true
+    },
+    "esbuild-freebsd-64": {
+      "version": "0.14.43",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.43.tgz",
+      "integrity": "sha512-FNWc05TPHYgaXjbPZO5/rJKSBslfG6BeMSs8GhwnqAKP56eEhvmzwnIz1QcC9cRVyO+IKqWNfmHFkCa1WJTULA==",
+      "optional": true
+    },
+    "esbuild-freebsd-arm64": {
+      "version": "0.14.43",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.43.tgz",
+      "integrity": "sha512-amrYopclz3VohqisOPR6hA3GOWA3LZC1WDLnp21RhNmoERmJ/vLnOpnrG2P/Zao+/erKTCUqmrCIPVtj58DRoA==",
+      "optional": true
+    },
+    "esbuild-linux-32": {
+      "version": "0.14.43",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.43.tgz",
+      "integrity": "sha512-KoxoEra+9O3AKVvgDFvDkiuddCds6q71owSQEYwjtqRV7RwbPzKxJa6+uyzUulHcyGVq0g15K0oKG5CFBcvYDw==",
+      "optional": true
+    },
+    "esbuild-linux-64": {
+      "version": "0.14.43",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.43.tgz",
+      "integrity": "sha512-EwINwGMyiJMgBby5/SbMqKcUhS5AYAZ2CpEBzSowsJPNBJEdhkCTtEjk757TN/wxgbu3QklqDM6KghY660QCUw==",
+      "optional": true
+    },
+    "esbuild-linux-arm": {
+      "version": "0.14.43",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.43.tgz",
+      "integrity": "sha512-e6YzQUoDxxtyamuF12eVzzRC7bbEFSZohJ6igQB9tBqnNmIQY3fI6Cns3z2wxtbZ3f2o6idkD2fQnlvs2902Dg==",
+      "optional": true
+    },
+    "esbuild-linux-arm64": {
+      "version": "0.14.43",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.43.tgz",
+      "integrity": "sha512-UlSpjMWllAc70zYbHxWuDS3FJytyuR/gHJYBr8BICcTNb/TSOYVBg6U7b3jZ3mILTrgzwJUHwhEwK18FZDouUQ==",
+      "optional": true
+    },
+    "esbuild-linux-mips64le": {
+      "version": "0.14.43",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.43.tgz",
+      "integrity": "sha512-f+v8cInPEL1/SDP//CfSYzcDNgE4CY3xgDV81DWm3KAPWzhvxARrKxB1Pstf5mB56yAslJDxu7ryBUPX207EZA==",
+      "optional": true
+    },
+    "esbuild-linux-ppc64le": {
+      "version": "0.14.43",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.43.tgz",
+      "integrity": "sha512-5wZYMDGAL/K2pqkdIsW+I4IR41kyfHr/QshJcNpUfK3RjB3VQcPWOaZmc+74rm4ZjVirYrtz+jWw0SgxtxRanA==",
+      "optional": true
+    },
+    "esbuild-linux-riscv64": {
+      "version": "0.14.43",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.43.tgz",
+      "integrity": "sha512-lYcAOUxp85hC7lSjycJUVSmj4/9oEfSyXjb/ua9bNl8afonaduuqtw7hvKMoKuYnVwOCDw4RSfKpcnIRDWq+Bw==",
+      "optional": true
+    },
+    "esbuild-linux-s390x": {
+      "version": "0.14.43",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.43.tgz",
+      "integrity": "sha512-27e43ZhHvhFE4nM7HqtUbMRu37I/4eNSUbb8FGZWszV+uLzMIsHDwLoBiJmw7G9N+hrehNPeQ4F5Ujad0DrUKQ==",
+      "optional": true
+    },
+    "esbuild-netbsd-64": {
+      "version": "0.14.43",
+      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.43.tgz",
+      "integrity": "sha512-2mH4QF6hHBn5zzAfxEI/2eBC0mspVsZ6UVo821LpAJKMvLJPBk3XJO5xwg7paDqSqpl7p6IRrAenW999AEfJhQ==",
       "optional": true
     },
     "esbuild-node-externals": {
@@ -20500,12 +20867,42 @@
         }
       }
     },
+    "esbuild-openbsd-64": {
+      "version": "0.14.43",
+      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.43.tgz",
+      "integrity": "sha512-ZhQpiZjvqCqO8jKdGp9+8k9E/EHSA+zIWOg+grwZasI9RoblqJ1QiZqqi7jfd6ZrrG1UFBNGe4m0NFxCFbMVbg==",
+      "optional": true
+    },
     "esbuild-register": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/esbuild-register/-/esbuild-register-3.3.2.tgz",
       "integrity": "sha512-jceAtTO6zxPmCfSD5cBb3rgIK1vmuqCKYwgylHiS1BF4pq0jJiJb4K2QMuqF4BEw7XDBRatYzip0upyTzfkgsQ==",
       "dev": true,
       "requires": {}
+    },
+    "esbuild-sunos-64": {
+      "version": "0.14.43",
+      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.43.tgz",
+      "integrity": "sha512-DgxSi9DaHReL9gYuul2rrQCAapgnCJkh3LSHPKsY26zytYppG0HgkgVF80zjIlvEsUbGBP/GHQzBtrezj/Zq1Q==",
+      "optional": true
+    },
+    "esbuild-windows-32": {
+      "version": "0.14.43",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.43.tgz",
+      "integrity": "sha512-Ih3+2O5oExiqm0mY6YYE5dR0o8+AspccQ3vIAtRodwFvhuyGLjb0Hbmzun/F3Lw19nuhPMu3sW2fqIJ5xBxByw==",
+      "optional": true
+    },
+    "esbuild-windows-64": {
+      "version": "0.14.43",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.43.tgz",
+      "integrity": "sha512-8NsuNfI8xwFuJbrCuI+aBqNTYkrWErejFO5aYM+yHqyHuL8mmepLS9EPzAzk8rvfaJrhN0+RvKWAcymViHOKEw==",
+      "optional": true
+    },
+    "esbuild-windows-arm64": {
+      "version": "0.14.43",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.43.tgz",
+      "integrity": "sha512-7ZlD7bo++kVRblJEoG+cepljkfP8bfuTPz5fIXzptwnPaFwGS6ahvfoYzY7WCf5v/1nX2X02HDraVItTgbHnKw==",
+      "optional": true
     },
     "escalade": {
       "version": "3.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@types/jest": "^27.5.1",
         "babel-jest": "^28.1.0",
         "concurrently": "^6.5.1",
-        "esbuild": "^0.14.43",
+        "esbuild": "0.14.43",
         "jest": "^28.1.0",
         "jest-environment-jsdom": "^28.1.0",
         "prettier": "^2.6.2",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@types/jest": "^27.5.1",
     "babel-jest": "^28.1.0",
     "concurrently": "^6.5.1",
-    "esbuild": "^0.14.43",
+    "esbuild": "0.14.43",
     "jest": "^28.1.0",
     "jest-environment-jsdom": "^28.1.0",
     "prettier": "^2.6.2",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@types/jest": "^27.5.1",
     "babel-jest": "^28.1.0",
     "concurrently": "^6.5.1",
-    "esbuild": "0.14.39",
+    "esbuild": "^0.14.43",
     "jest": "^28.1.0",
     "jest-environment-jsdom": "^28.1.0",
     "prettier": "^2.6.2",

--- a/packages/realtime-api/src/messaging/Messaging.ts
+++ b/packages/realtime-api/src/messaging/Messaging.ts
@@ -140,4 +140,4 @@ export const createMessagingObject = (
 
 export * from './MessagingClient'
 export * from './Message'
-export { MessagingMessageState } from '@signalwire/core'
+export type { MessagingMessageState } from '@signalwire/core'

--- a/packages/realtime-api/src/voice/Voice.ts
+++ b/packages/realtime-api/src/voice/Voice.ts
@@ -1,4 +1,9 @@
-import { connect, BaseComponentOptions, toExternalJSON, ClientContextContract } from '@signalwire/core'
+import {
+  connect,
+  BaseComponentOptions,
+  toExternalJSON,
+  ClientContextContract,
+} from '@signalwire/core'
 import type {
   DisconnectableClientContract,
   EventTransform,
@@ -18,7 +23,7 @@ export * from './VoiceClient'
 export { Call } from './Call'
 export { DeviceBuilder }
 export { Playlist } from './Playlist'
-export {
+export type {
   VoiceCallPlayParams,
   VoiceCallPlayAudioMethodParams,
   VoiceCallPlayTTSMethodParams,
@@ -35,7 +40,8 @@ type EmitterTransformsEvents = 'calling.call.received'
 
 /** @ignore */
 export interface Voice
-  extends DisconnectableClientContract<Voice, VoiceClientApiEvents>, ClientContextContract {
+  extends DisconnectableClientContract<Voice, VoiceClientApiEvents>,
+    ClientContextContract {
   /** @internal */
   _session: RealtimeClient
   dial(dialer: VoiceDeviceBuilder): Promise<Call>


### PR DESCRIPTION
This is the hotfix to solve a fatal error when using the `@signalwire/realtime-api` in a `esm` Node app. It seems like esbuild wasn't able to detect some type exports generating invalid javascript.

We'll followup with another PR to include tests to make sure we support all the different enviroments.