### PR TITLE
Missing constructors

### DIFF
--- a/.changeset/chilled-seahorses-mix.md
+++ b/.changeset/chilled-seahorses-mix.md
@@ -1,0 +1,6 @@
+---
+'@signalwire/js': patch
+'@signalwire/webrtc': patch
+---
+
+Fix issue with missing constructors on react-native

--- a/packages/js/src/features/mediaElements/mediaElementsSagas.ts
+++ b/packages/js/src/features/mediaElements/mediaElementsSagas.ts
@@ -162,6 +162,7 @@ export const makeAudioElementSaga = ({ speakerId }: { speakerId?: string }) => {
     runSaga,
   }: CustomSagaParams<RoomSessionConnection>): SagaIterator {
     if (typeof Audio === 'undefined') {
+      getLogger().warn('`Audio` is not supported on this environment.')
       return
     }
 

--- a/packages/js/src/features/mediaElements/mediaElementsSagas.ts
+++ b/packages/js/src/features/mediaElements/mediaElementsSagas.ts
@@ -161,6 +161,10 @@ export const makeAudioElementSaga = ({ speakerId }: { speakerId?: string }) => {
     instance: room,
     runSaga,
   }: CustomSagaParams<RoomSessionConnection>): SagaIterator {
+    if (typeof Audio === 'undefined') {
+      return
+    }
+
     try {
       const audioEl = new Audio()
       let audioTask: Task | undefined

--- a/packages/webrtc/src/utils/webrtcHelpers.native.ts
+++ b/packages/webrtc/src/utils/webrtcHelpers.native.ts
@@ -60,9 +60,28 @@ export const stopStream = (stream: RNMediaStream) => {
   stream = null
 }
 
+/**
+ * This class in implemented by `react-native-webrtc` but
+ * it's not exported directly. To avoid dealing with manual
+ * file imports and having (potential) issues of mixing
+ * commonjs/esm we ported it here since it's just a few
+ * lines of code.
+ */
+class MediaStreamTrackEvent {
+  type: string
+  track: any
+  constructor(type: string, eventInitDict: { track: any }) {
+    this.type = type.toString()
+    this.track = eventInitDict.track
+  }
+}
+
 export const stopTrack = (track: MediaStreamTrack) => {
   if (track && track.readyState === 'live') {
     track.stop()
-    track.dispatchEvent(new Event('ended'))
+    track.dispatchEvent(
+      // @ts-expect-error
+      new MediaStreamTrackEvent('ended', { track })
+    )
   }
 }


### PR DESCRIPTION
The code in this changeset includes:

- [x] Add replacement for `Event` on `react-native` when dealing with MediaTrackEvents
- [x] Add warning when a `Audio` is not available on the platform