### PR TITLE
Stack tests for `realtime-api` and `compatibility-api`

### DIFF
--- a/.changeset/clever-melons-look.md
+++ b/.changeset/clever-melons-look.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/compatibility-api': patch
+---
+
+Include JwtInterface in compatibility-api declaration file.

--- a/.changeset/silent-balloons-lay.md
+++ b/.changeset/silent-balloons-lay.md
@@ -1,0 +1,5 @@
+---
+'@sw-internal/stack-tests': patch
+---
+
+[internal] add tests for messaging, task, pubSub, task and voice namespaces (realtime-api). add tests for compatibility-api

--- a/internal/stack-tests/index.js
+++ b/internal/stack-tests/index.js
@@ -34,7 +34,9 @@ async function executeExamples(pkg) {
 
   for (const scriptName of allScripts) {
     const scriptType = getScriptType(scriptName)
-    const { stdout } = await execa('node', [`dist/${scriptType}/app.js`], {
+    const command = ['node', [`dist/${scriptType}/app.js`]]
+    console.log(`🏃‍♂️ Command ⇢ "${command.join(' ')}"`)
+    const { stdout } = await execa(...command, {
       cwd: pkg.pathname,
       env: process.env,
     })
@@ -46,12 +48,15 @@ async function main() {
   const packages = getPackages({ pathname: 'src' })
 
   // --------------- Build examples ---------------
-  console.log('🛠  Building the examples', packages.map(pkg => pkg.name))
-  await Promise.all(packages.map(pkg => buildExamples(pkg)))
+  console.log(
+    '🛠  Building the examples',
+    packages.map((pkg) => pkg.name)
+  )
+  await Promise.all(packages.map((pkg) => buildExamples(pkg)))
 
   // --------------- Run examples ---------------
   for (const pkg of packages) {
-    console.log('🏃‍♂️ Running example ->', pkg.name)
+    console.log(`💻 Example ⇢ "${pkg.name}"`)
     await executeExamples(pkg)
   }
 }

--- a/internal/stack-tests/src/chat/package.json
+++ b/internal/stack-tests/src/chat/package.json
@@ -2,7 +2,6 @@
   "name": "stack-tests-chat",
   "version": "1.0.0",
   "description": "",
-  "main": "index.js",
   "scripts": {
     "build:cjs": "tsc app.ts --rootDir ./ --skipLibCheck --esModuleInterop --lib DOM --lib ES2015 --target ESNext --moduleResolution node --module CommonJS --outDir dist/cjs",
     "build:esm": "tsc app.ts --rootDir ./ --skipLibCheck --esModuleInterop --lib DOM --lib ES2015 --target ESNext --moduleResolution node --module ESNext --outDir dist/esm"

--- a/internal/stack-tests/src/compatibility-api/app.ts
+++ b/internal/stack-tests/src/compatibility-api/app.ts
@@ -1,0 +1,53 @@
+import twilio, { Twilio } from 'twilio'
+import { RestClient } from '@signalwire/compatibility-api'
+import tap from 'tap'
+
+async function run() {
+  try {
+    tap.ok(RestClient.jwt.AccessToken, 'RestClient.jwt.AccessToken is defined')
+    tap.ok(
+      RestClient.jwt.ClientCapability,
+      'RestClient.jwt.ClientCapability is defined'
+    )
+    tap.ok(RestClient.jwt.taskrouter, 'RestClient.jwt.taskrouter is defined')
+    tap.ok(
+      RestClient.LaML.VoiceResponse,
+      'RestClient.LaML.VoiceResponse is defined'
+    )
+    tap.ok(
+      RestClient.LaML.FaxResponse,
+      'RestClient.LaML.FaxResponse is defined'
+    )
+    tap.ok(
+      RestClient.LaML.MessagingResponse,
+      'RestClient.LaML.MessagingResponse is defined'
+    )
+    tap.ok(RestClient.RequestClient, 'RestClient.RequestClient is defined')
+    tap.ok(RestClient.Twilio, 'RestClient.Twilio is defined')
+    tap.ok(
+      RestClient.validateExpressRequest,
+      'RestClient.validateExpressRequest is defined'
+    )
+    tap.ok(RestClient.validateRequest, 'RestClient.validateRequest is defined')
+    tap.ok(
+      RestClient.validateRequestWithBody,
+      'RestClient.validateRequestWithBody is defined'
+    )
+    tap.ok(RestClient.webhook, 'RestClient.webhook is defined')
+    const twilioProperties = Object.getOwnPropertyDescriptors(
+      Object.getPrototypeOf(twilio('AC', 'token', {}))
+    )
+    const client = RestClient('a', 'b', {
+      signalwireSpaceUrl: 'example.domain.com',
+    })
+    Object.keys(twilioProperties).forEach((prop) => {
+      tap.ok(client[prop as keyof Twilio], `${prop} is defined`)
+    })
+    process.exit(0)
+  } catch (error) {
+    console.log('<Error>', error)
+    process.exit(1)
+  }
+}
+
+run()

--- a/internal/stack-tests/src/compatibility-api/package.json
+++ b/internal/stack-tests/src/compatibility-api/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "stack-tests-compatibility-api",
+  "version": "1.0.0",
+  "description": "",
+  "scripts": {
+    "build:cjs": "tsc app.ts --rootDir ./ --skipLibCheck --esModuleInterop --lib DOM --lib ES2015 --target ESNext --moduleResolution node --module CommonJS --outDir dist/cjs",
+    "build:esm": "tsc app.ts --rootDir ./ --skipLibCheck --esModuleInterop --lib DOM --lib ES2015 --target ESNext --moduleResolution node --module ESNext --outDir dist/esm"
+  },
+  "dependencies": {
+    "@signalwire/compatibility-api": "^3.0.1"
+  }
+}

--- a/internal/stack-tests/src/messaging/app.ts
+++ b/internal/stack-tests/src/messaging/app.ts
@@ -1,0 +1,28 @@
+import { Messaging } from '@signalwire/realtime-api'
+import tap from 'tap'
+
+async function run() {
+  try {
+    const message = new Messaging.Client({
+      host: process.env.RELAY_HOST || 'relay.swire.io',
+      project: process.env.RELAY_PROJECT as string,
+      token: process.env.RELAY_TOKEN as string,
+      contexts: [process.env.RELAY_CONTEXT as string],
+    })
+
+    tap.ok(message.on, 'message.on is defined')
+    tap.ok(message.once, 'message.once is defined')
+    tap.ok(message.off, 'message.off is defined')
+    tap.ok(message.removeAllListeners, 'message.removeAllListeners is defined')
+    tap.ok(message.addContexts, 'message.addContexts is defined')
+    tap.ok(message.send, 'message.send is defined')
+    tap.ok(message.disconnect, 'message.disconnect is defined')
+
+    process.exit(0)
+  } catch (error) {
+    console.log('<Error>', error)
+    process.exit(1)
+  }
+}
+
+run()

--- a/internal/stack-tests/src/messaging/package.json
+++ b/internal/stack-tests/src/messaging/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "stack-tests-messaging",
+  "version": "1.0.0",
+  "description": "",
+  "scripts": {
+    "build:cjs": "tsc app.ts --rootDir ./ --skipLibCheck --esModuleInterop --lib DOM --lib ES2015 --target ESNext --moduleResolution node --module CommonJS --outDir dist/cjs",
+    "build:esm": "tsc app.ts --rootDir ./ --skipLibCheck --esModuleInterop --lib DOM --lib ES2015 --target ESNext --moduleResolution node --module ESNext --outDir dist/esm"
+  },
+  "dependencies": {
+    "@signalwire/realtime-api": "^3.1.1"
+  }
+}

--- a/internal/stack-tests/src/pubSub/app.ts
+++ b/internal/stack-tests/src/pubSub/app.ts
@@ -1,0 +1,30 @@
+import { PubSub } from '@signalwire/realtime-api'
+import tap from 'tap'
+
+async function run() {
+  try {
+    const pubSub = new PubSub.Client({
+      // @ts-expect-error
+      host: process.env.RELAY_HOST || 'relay.swire.io',
+      project: process.env.RELAY_PROJECT as string,
+      token: process.env.RELAY_TOKEN as string,
+      contexts: [process.env.RELAY_CONTEXT as string],
+    })
+
+    tap.ok(pubSub.on, 'pubSub.on is defined')
+    tap.ok(pubSub.once, 'pubSub.once is defined')
+    tap.ok(pubSub.off, 'pubSub.off is defined')
+    tap.ok(pubSub.removeAllListeners, 'pubSub.removeAllListeners is defined')
+    tap.ok(pubSub.publish, 'pubSub.publish is defined')
+    tap.ok(pubSub.subscribe, 'pubSub.subscribe is defined')
+    tap.ok(pubSub.unsubscribe, 'pubSub.unsubscribe is defined')
+    tap.ok(pubSub.updateToken, 'pubSub.updateToken is defined')
+
+    process.exit(0)
+  } catch (error) {
+    console.log('<Error>', error)
+    process.exit(1)
+  }
+}
+
+run()

--- a/internal/stack-tests/src/pubSub/package.json
+++ b/internal/stack-tests/src/pubSub/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "stack-tests-pubsub",
+  "version": "1.0.0",
+  "description": "",
+  "scripts": {
+    "build:cjs": "tsc app.ts --rootDir ./ --skipLibCheck --esModuleInterop --lib DOM --lib ES2015 --target ESNext --moduleResolution node --module CommonJS --outDir dist/cjs",
+    "build:esm": "tsc app.ts --rootDir ./ --skipLibCheck --esModuleInterop --lib DOM --lib ES2015 --target ESNext --moduleResolution node --module ESNext --outDir dist/esm"
+  },
+  "dependencies": {
+    "@signalwire/realtime-api": "^3.1.1"
+  }
+}

--- a/internal/stack-tests/src/task/app.ts
+++ b/internal/stack-tests/src/task/app.ts
@@ -1,0 +1,28 @@
+import { Task } from '@signalwire/realtime-api'
+import tap from 'tap'
+
+async function run() {
+  try {
+    const task = new Task.Client({
+      host: process.env.RELAY_HOST || 'relay.swire.io',
+      project: process.env.RELAY_PROJECT as string,
+      token: process.env.RELAY_TOKEN as string,
+      contexts: [process.env.RELAY_CONTEXT as string],
+    })
+
+    tap.ok(task.on, 'task.on is defined')
+    tap.ok(task.once, 'task.once is defined')
+    tap.ok(task.off, 'task.off is defined')
+    tap.ok(task.removeAllListeners, 'task.removeAllListeners is defined')
+    tap.ok(task.addContexts, 'task.addContexts is defined')
+    tap.ok(task.disconnect, 'task.disconnect is defined')
+    tap.ok(task.removeContexts, 'task.removeContexts is defined')
+
+    process.exit(0)
+  } catch (error) {
+    console.log('<Error>', error)
+    process.exit(1)
+  }
+}
+
+run()

--- a/internal/stack-tests/src/task/package.json
+++ b/internal/stack-tests/src/task/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "stack-tests-task",
+  "version": "1.0.0",
+  "description": "",
+  "scripts": {
+    "build:cjs": "tsc app.ts --rootDir ./ --skipLibCheck --esModuleInterop --lib DOM --lib ES2015 --target ESNext --moduleResolution node --module CommonJS --outDir dist/cjs",
+    "build:esm": "tsc app.ts --rootDir ./ --skipLibCheck --esModuleInterop --lib DOM --lib ES2015 --target ESNext --moduleResolution node --module ESNext --outDir dist/esm"
+  },
+  "dependencies": {
+    "@signalwire/realtime-api": "^3.1.1"
+  }
+}

--- a/internal/stack-tests/src/video/package.json
+++ b/internal/stack-tests/src/video/package.json
@@ -2,7 +2,6 @@
   "name": "stack-tests-video",
   "version": "1.0.0",
   "description": "",
-  "main": "index.js",
   "scripts": {
     "build:cjs": "tsc app.ts --rootDir ./ --skipLibCheck --esModuleInterop --lib DOM --lib ES2015 --target ESNext --moduleResolution node --module CommonJS --outDir dist/cjs",
     "build:esm": "tsc app.ts --rootDir ./ --skipLibCheck --esModuleInterop --lib DOM --lib ES2015 --target ESNext --moduleResolution node --module ESNext --outDir dist/esm"

--- a/internal/stack-tests/src/voice/app.ts
+++ b/internal/stack-tests/src/voice/app.ts
@@ -1,0 +1,29 @@
+import { Voice } from '@signalwire/realtime-api'
+import tap from 'tap'
+
+async function run() {
+  try {
+    const voice = new Voice.Client({
+      host: process.env.RELAY_HOST || 'relay.swire.io',
+      project: process.env.RELAY_PROJECT as string,
+      token: process.env.RELAY_TOKEN as string,
+      contexts: [process.env.RELAY_CONTEXT as string],
+    })
+
+    tap.ok(voice.on, 'voice.on is defined')
+    tap.ok(voice.once, 'voice.once is defined')
+    tap.ok(voice.off, 'voice.off is defined')
+    tap.ok(voice.removeAllListeners, 'voice.removeAllListeners is defined')
+    tap.ok(voice.dial, 'voice.dial is defined')
+    tap.ok(voice.dialPhone, 'voice.dialPhone is defined')
+    tap.ok(voice.dialSip, 'voice.dialSip is defined')
+    tap.ok(voice.disconnect, 'voice.disconnect is defined')
+
+    process.exit(0)
+  } catch (error) {
+    console.log('<Error>', error)
+    process.exit(1)
+  }
+}
+
+run()

--- a/internal/stack-tests/src/voice/package.json
+++ b/internal/stack-tests/src/voice/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "stack-tests-voice",
+  "version": "1.0.0",
+  "description": "",
+  "scripts": {
+    "build:cjs": "tsc app.ts --rootDir ./ --skipLibCheck --esModuleInterop --lib DOM --lib ES2015 --target ESNext --moduleResolution node --module CommonJS --outDir dist/cjs",
+    "build:esm": "tsc app.ts --rootDir ./ --skipLibCheck --esModuleInterop --lib DOM --lib ES2015 --target ESNext --moduleResolution node --module ESNext --outDir dist/esm"
+  },
+  "dependencies": {
+    "@signalwire/realtime-api": "^3.1.1"
+  }
+}

--- a/packages/compatibility-api/compatibility-api.d.ts
+++ b/packages/compatibility-api/compatibility-api.d.ts
@@ -1,4 +1,4 @@
-import type { Twilio, TwimlInterface } from 'twilio'
+import type { Twilio, TwimlInterface, JwtInterface } from 'twilio'
 import * as webhookTools from 'twilio/lib/webhooks/webhooks'
 import TwilioClient from 'twilio/lib/rest/Twilio'
 import type { CompatibilityAPIRestClientOptions } from './src/types'


### PR DESCRIPTION
The code in this changeset includes:

- [x] Added stack tests for all the namespaces exported by `realtime-api`
- [x] Added stack tests for `compatibility-api`
- [x] Fixed issue on `compatibility-api` with missing `JwtInterface` type. Since it wasn't part of the declaration file it was inferred as `any`