### PR TITLE
Update default video constraints

### DIFF
--- a/.changeset/tricky-turkeys-crash.md
+++ b/.changeset/tricky-turkeys-crash.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/js': patch
+---
+
+Add default width/height for video constraints.

--- a/packages/js/src/RoomSession.ts
+++ b/packages/js/src/RoomSession.ts
@@ -15,6 +15,8 @@ import type { RoomSessionDocs } from './RoomSession.docs'
 import type { RoomSessionJoinAudienceParams } from './utils/interfaces'
 
 const VIDEO_CONSTRAINTS: MediaTrackConstraints = {
+  width: { ideal: 1280, min: 320 },
+  height: { ideal: 720, min: 180 },
   aspectRatio: { ideal: 16 / 9 },
 }
 
@@ -159,9 +161,7 @@ export const RoomSession = function (roomOptions: RoomSessionOptions) {
     })
   }
 
-  const joinAudience = (
-    params?: RoomSessionJoinAudienceParams
-  ) => {
+  const joinAudience = (params?: RoomSessionJoinAudienceParams) => {
     return new Promise(async (resolve, reject) => {
       try {
         // @ts-expect-error


### PR DESCRIPTION
Small change to have Firefox pick the correct A/R by default.