### PR TITLE
Fix local video overlay shows up between video mute/unmute

### DIFF
--- a/.changeset/quiet-ligers-explain.md
+++ b/.changeset/quiet-ligers-explain.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/js': patch
+---
+
+Fix a possible condition where the localVideo overlay shows up after a video mute and video unmute in sequence without any layout changes in between.

--- a/packages/js/src/features/mediaElements/mediaElementsSagas.ts
+++ b/packages/js/src/features/mediaElements/mediaElementsSagas.ts
@@ -42,6 +42,8 @@ export const makeVideoElementSaga = ({
        * Instead of querying the `document`, let's use our `layerMap`.
        */
       const localOverlay: LocalOverlay = {
+        // Each `layout.changed` event will update `status`
+        status: 'hidden',
         get id() {
           return addSDKPrefix(room.memberId)
         },
@@ -66,6 +68,9 @@ export const makeVideoElementSaga = ({
         show() {
           if (!this.domElement) {
             return getLogger().warn('Missing localOverlay to show')
+          }
+          if (this.status === 'hidden') {
+            return getLogger().info('localOverlay not visible')
           }
           this.domElement.style.opacity = '1'
         },

--- a/packages/js/src/utils/videoElement.ts
+++ b/packages/js/src/utils/videoElement.ts
@@ -70,6 +70,7 @@ const _buildLayer = ({ location }: { location: InternalVideoLayoutLayer }) => {
 
 export interface LocalOverlay {
   readonly id: string
+  status: 'hidden' | 'visible'
   domElement: HTMLDivElement | undefined
   hide(): void
   show(): void
@@ -95,6 +96,8 @@ const makeLayoutChangedHandler =
       const location = layers.find(({ member_id }) => member_id === myMemberId)
 
       let myLayer = localOverlay.domElement
+      // Update localOverlay.status if a location has been found
+      localOverlay.status = location ? 'visible' : 'hidden'
       if (!location) {
         getLogger().debug('Location not found')
         if (myLayer) {


### PR DESCRIPTION
This PR fixes an issue where - during a screenShare session - the user muted and unmuted the video. With more than 2 persons in the room, if the user wasn't the active speaker (in the top-right corner) his video was showing up _on top_ of the screenShare.