### PR TITLE
`realtime-api`: Fix issue with missing `member.updated` event

### DIFF
--- a/.changeset/cold-bags-repeat.md
+++ b/.changeset/cold-bags-repeat.md
@@ -1,0 +1,6 @@
+---
+'@signalwire/core': patch
+'@signalwire/js': patch
+---
+
+Fix issue with missing member.update events

--- a/packages/core/src/memberPosition/workers.ts
+++ b/packages/core/src/memberPosition/workers.ts
@@ -28,7 +28,10 @@ function* memberPositionLayoutChangedWorker(options: any) {
 
     const memberEventParams = memberList.get(memberId)
 
-    if (layer.position !== memberEventParams.member?.current_position) {
+    if (
+      memberEventParams &&
+      layer.position !== memberEventParams.member?.current_position
+    ) {
       mutateMemberCurrentPosition({
         memberList,
         memberId,

--- a/packages/realtime-api/src/video/memberPosition/workers.ts
+++ b/packages/realtime-api/src/video/memberPosition/workers.ts
@@ -21,6 +21,6 @@ export const memberPositionWorker: SDKWorker<any> =
 
     yield sagaEffects.fork(MemberPosition.memberPositionWorker, {
       ...options,
-      payload: action.payload,
+      initialState: action.payload,
     })
   }


### PR DESCRIPTION
The code in this changeset includes a fix for the issue where `member.updated` wasn't getting dispatched in `realtime-api`