### PR TITLE
Update Playlist methods types

### DIFF
--- a/.changeset/quick-suns-return.md
+++ b/.changeset/quick-suns-return.md
@@ -1,0 +1,6 @@
+---
+'@signalwire/core': patch
+'@signalwire/realtime-api': patch
+---
+
+Remove option to pass 'volume' from methods of Voice.Playlist typings

--- a/packages/core/src/types/voiceCall.ts
+++ b/packages/core/src/types/voiceCall.ts
@@ -199,16 +199,29 @@ export interface VoiceCallPlayAudioMethodParams
   volume?: number
 }
 
+export interface VoicePlaylistAudioParams
+  extends OmitType<VoiceCallPlayAudioParams> {}
+
 export interface VoiceCallPlaySilenceMethodParams
+  extends OmitType<VoiceCallPlaySilenceParams> {}
+
+export interface VoicePlaylistSilenceParams
   extends OmitType<VoiceCallPlaySilenceParams> {}
 
 export interface VoiceCallPlayRingtoneMethodParams
   extends OmitType<VoiceCallPlayRingtoneParams> {
   volume?: number
 }
+export interface VoicePlaylistRingtoneParams
+  extends OmitType<VoiceCallPlayRingtoneParams> {
+}
+
 export interface VoiceCallPlayTTSMethodParams
   extends OmitType<VoiceCallPlayTTSParams> {
   volume?: number
+}
+export interface VoicePlaylistTTSParams
+  extends OmitType<VoiceCallPlayTTSParams> {
 }
 
 export interface VoiceCallRecordMethodParams {

--- a/packages/realtime-api/src/voice/Playlist.ts
+++ b/packages/realtime-api/src/voice/Playlist.ts
@@ -3,13 +3,13 @@ import type {
   VoicePlaylist,
   VoiceCallPlayParams,
   VoiceCallPlayAudioParams,
-  VoiceCallPlayAudioMethodParams,
   VoiceCallPlayTTSParams,
-  VoiceCallPlayTTSMethodParams,
   VoiceCallPlaySilenceParams,
-  VoiceCallPlaySilenceMethodParams,
   VoiceCallPlayRingtoneParams,
-  VoiceCallPlayRingtoneMethodParams,
+  VoicePlaylistAudioParams,
+  VoicePlaylistTTSParams,
+  VoicePlaylistSilenceParams,
+  VoicePlaylistRingtoneParams,
 } from '@signalwire/core'
 
 /**
@@ -56,26 +56,26 @@ export class Playlist implements VoicePlaylist {
 
   /** An audio media. */
   static Audio(
-    params: VoiceCallPlayAudioMethodParams
+    params: VoicePlaylistAudioParams
   ): VoiceCallPlayAudioParams {
     return { type: 'audio', ...params }
   }
 
   /** A TTS media. */
-  static TTS(params: VoiceCallPlayTTSMethodParams): VoiceCallPlayTTSParams {
+  static TTS(params: VoicePlaylistTTSParams): VoiceCallPlayTTSParams {
     return { type: 'tts', ...params }
   }
 
   /** A silence interval. */
   static Silence(
-    params: VoiceCallPlaySilenceMethodParams
+    params: VoicePlaylistSilenceParams
   ): VoiceCallPlaySilenceParams {
     return { type: 'silence', ...params }
   }
 
   /** A ringtone media. */
   static Ringtone(
-    params: VoiceCallPlayRingtoneMethodParams
+    params: VoicePlaylistRingtoneParams
   ): VoiceCallPlayRingtoneParams {
     return { type: 'ringtone', ...params }
   }

--- a/packages/realtime-api/src/voice/Playlist.ts
+++ b/packages/realtime-api/src/voice/Playlist.ts
@@ -54,26 +54,40 @@ export class Playlist implements VoicePlaylist {
     return this
   }
 
-  /** An audio media. */
-  static Audio(
-    params: VoicePlaylistAudioParams
-  ): VoiceCallPlayAudioParams {
+  /**
+   * An audio media.
+   * @params params - {@link VoicePlaylistAudioParams}
+   * @returns - {@link VoiceCallPlayAudioParams}
+   **/
+  static Audio(params: VoicePlaylistAudioParams): VoiceCallPlayAudioParams {
     return { type: 'audio', ...params }
   }
 
-  /** A TTS media. */
+  /**
+   * A TTS media.
+   * @params params - {@link VoicePlaylistTTSParams}
+   * @returns - {@link VoiceCallPlayTTSParams}
+   **/
   static TTS(params: VoicePlaylistTTSParams): VoiceCallPlayTTSParams {
     return { type: 'tts', ...params }
   }
 
-  /** A silence interval. */
+  /**
+   * A silence interval.
+   * @params params - {@link VoicePlaylistSilenceParams}
+   * @returns - {@link VoiceCallPlaySilenceParams}
+   **/
   static Silence(
     params: VoicePlaylistSilenceParams
   ): VoiceCallPlaySilenceParams {
     return { type: 'silence', ...params }
   }
 
-  /** A ringtone media. */
+  /**
+   * A ringtone media.
+   * @params param - {@link VoicePlaylistRingtoneParams}
+   * @returns - {@link VoiceCallPlayRingtoneParams}
+   **/
   static Ringtone(
     params: VoicePlaylistRingtoneParams
   ): VoiceCallPlayRingtoneParams {


### PR DESCRIPTION
The code in this changeset improves the typings for the `Voice.Playlist` methods to remove the option to pass `volume` as a param. This param was already ignored since it's not a supported feature.