### PR TITLE
Add `room.left` event

### DIFF
--- a/.changeset/hip-emus-do.md
+++ b/.changeset/hip-emus-do.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/js': minor
+---
+
+Add ability to listen to `room.left` on room instances.

--- a/packages/js/src/RoomSession.ts
+++ b/packages/js/src/RoomSession.ts
@@ -133,6 +133,8 @@ export const RoomSession = function (roomOptions: RoomSessionOptions) {
 
   // WebRTC connection left the room.
   room.once('destroy', () => {
+    // @ts-expect-error
+    room.emit('room.left')
     client.disconnect()
   })
 

--- a/packages/js/src/createRoomObject.ts
+++ b/packages/js/src/createRoomObject.ts
@@ -139,6 +139,8 @@ export const createRoomObject = (
 
     // WebRTC connection left the room.
     roomObject.once('destroy', () => {
+      // @ts-expect-error
+      roomObject.emit('room.left')
       client.disconnect()
     })
 


### PR DESCRIPTION
The code in this changeset includes the ability to listen to `room.left` from RoomSession instances.