### PR TITLE
Enable pingSupported by default for all sessions

### DIFF
--- a/.changeset/long-teachers-carry.md
+++ b/.changeset/long-teachers-carry.md
@@ -1,0 +1,5 @@
+---
+'@sw-internal/playground-js': patch
+---
+
+Restore the UI when the server removes the user from the room

--- a/.changeset/poor-oranges-live.md
+++ b/.changeset/poor-oranges-live.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/webrtc': patch
+---
+
+Enable `pingSupported` by default for all WebRTC Connections.

--- a/internal/playground-js/src/heroku/index.js
+++ b/internal/playground-js/src/heroku/index.js
@@ -202,6 +202,17 @@ const initializeMicAnalyzer = async (stream) => {
   })
 }
 
+function restoreUI() {
+  btnConnect.classList.remove('d-none')
+  btnDisconnect.classList.add('d-none')
+  connectStatus.innerHTML = 'Not Connected'
+
+  inCallElements.forEach((button) => {
+    button.classList.add('d-none')
+    button.disabled = true
+  })
+}
+
 /**
  * Connect with Relay creating a client and attaching all the event handler.
  */
@@ -252,6 +263,10 @@ window.connect = () => {
       button.disabled = false
     })
     loadLayouts()
+  })
+  roomObj.on('destroy', () => {
+    console.debug('>> destroy')
+    restoreUI()
   })
   roomObj.on('room.updated', (params) =>
     console.debug('>> room.updated', params)
@@ -364,14 +379,7 @@ window.hangup = () => {
     roomObj.hangup()
   }
 
-  btnConnect.classList.remove('d-none')
-  btnDisconnect.classList.add('d-none')
-  connectStatus.innerHTML = 'Not Connected'
-
-  inCallElements.forEach((button) => {
-    button.classList.add('d-none')
-    button.disabled = true
-  })
+  restoreUI()
 }
 
 window.saveInLocalStorage = (e) => {

--- a/packages/webrtc/src/BaseConnection.ts
+++ b/packages/webrtc/src/BaseConnection.ts
@@ -147,7 +147,7 @@ export class BaseConnection<EventTypes extends EventEmitter.ValidEventTypes>
       userVariables,
       screenShare,
       additionalDevice,
-      pingSupported,
+      pingSupported = true,
     } = this.options
     return {
       sessid: this.options.sessionid,


### PR DESCRIPTION
Small change to set `pingSupported: true` by default so to enable ping/pong messages through the wire for the session.