### PR TITLE
Update media allowed values from Authorization

### DIFF
--- a/.changeset/gorgeous-timers-agree.md
+++ b/.changeset/gorgeous-timers-agree.md
@@ -1,0 +1,6 @@
+---
+'@signalwire/core': patch
+'@signalwire/js': patch
+---
+
+[internal] Update media_allowed, video_allowed and audio_allowed values for joinAudience method.

--- a/packages/core/src/redux/features/session/sessionSlice.test.ts
+++ b/packages/core/src/redux/features/session/sessionSlice.test.ts
@@ -18,7 +18,7 @@ describe('SessionState Tests', () => {
       iceServers: rpcConnectResultVRT.ice_servers,
       authStatus: 'authorized',
       authState: {
-        audio_allowed: true,
+        audio_allowed: 'both',
         project: '8f0a119a-cda7-4497-a47d-c81493b824d4',
         resource: '9c80f1e8-9430-4070-a043-937eb3a96b38',
         room: {
@@ -31,7 +31,7 @@ describe('SessionState Tests', () => {
           'SGZtkRD9fvuBAOUp1UF56zESxdEvGT6qSGZtkRD9fvuBAOUp1UF56zESxdEvGT6q',
         type: 'video',
         user_name: 'Joe',
-        video_allowed: true,
+        video_allowed: 'both',
       },
       authError: undefined,
       authCount: 1,

--- a/packages/core/src/redux/features/session/sessionSlice.test.ts
+++ b/packages/core/src/redux/features/session/sessionSlice.test.ts
@@ -18,6 +18,7 @@ describe('SessionState Tests', () => {
       iceServers: rpcConnectResultVRT.ice_servers,
       authStatus: 'authorized',
       authState: {
+        media_allowed: 'all',
         audio_allowed: 'both',
         project: '8f0a119a-cda7-4497-a47d-c81493b824d4',
         resource: '9c80f1e8-9430-4070-a043-937eb3a96b38',

--- a/packages/core/src/testUtils.ts
+++ b/packages/core/src/testUtils.ts
@@ -24,7 +24,9 @@ export const createMockedLogger = (): InternalSDKLogger => ({
  *
  * @returns Redux Store
  */
-export const configureJestStore = (options?: Partial<ConfigureStoreOptions>) => {
+export const configureJestStore = (
+  options?: Partial<ConfigureStoreOptions>
+) => {
   return configureStore({
     userOptions: {
       project: PROJECT_ID,
@@ -60,8 +62,9 @@ export const rpcConnectResultVRT: RPCConnectResult = {
     },
     signature:
       'SGZtkRD9fvuBAOUp1UF56zESxdEvGT6qSGZtkRD9fvuBAOUp1UF56zESxdEvGT6q',
-    audio_allowed: true,
-    video_allowed: true,
+    media_allowed: 'all',
+    audio_allowed: 'both',
+    video_allowed: 'both',
   },
   protocol:
     'signalwire_SGZtkRD9fvuBAOUp1UF56zESxdEvGT6qSGZtkRD9fvuBAOUp1UF56zESxdEvGT6q_03e8c927-8ea3-4661-86d5-778c3e03296a_8f0a119a-cda7-4497-a47d-c81493b824d4',

--- a/packages/core/src/utils/interfaces.ts
+++ b/packages/core/src/utils/interfaces.ts
@@ -158,6 +158,11 @@ export interface SessionRequestObject {
   reject: (value: unknown) => void
 }
 
+export type MediaAllowed = 'all' | 'audio-only' | 'video-only'
+export type MediaDirectionAllowed = 'none' | 'receive' | 'both'
+export type AudioAllowed = MediaDirectionAllowed
+export type VideoAllowed = MediaDirectionAllowed
+
 export interface Authorization {
   type: 'video'
   project: string
@@ -171,8 +176,9 @@ export interface Authorization {
   }
   signature: string
   expires_at?: number
-  audio_allowed?: boolean
-  video_allowed?: boolean
+  media_allowed: MediaAllowed
+  audio_allowed: AudioAllowed
+  video_allowed: VideoAllowed
 }
 
 export interface RPCConnectResult {

--- a/packages/js/src/BaseRoomSession.ts
+++ b/packages/js/src/BaseRoomSession.ts
@@ -28,6 +28,7 @@ import type {
   RoomMethods,
   StartScreenShareOptions,
   RoomSessionConnectionContract,
+  RoomSessionJoinAudienceParams,
 } from './utils/interfaces'
 import {
   ROOM_COMPONENT_LISTENERS,
@@ -56,7 +57,7 @@ export interface BaseRoomSession<T>
    */
   join(): Promise<T>
   /** @internal */
-  joinAudience(options?: { audio?: boolean; video?: boolean }): Promise<T>
+  joinAudience(options?: RoomSessionJoinAudienceParams): Promise<T>
   /**
    * Leaves the room. This detaches all the locally originating streams from the
    * room.

--- a/packages/js/src/utils/interfaces.ts
+++ b/packages/js/src/utils/interfaces.ts
@@ -382,8 +382,8 @@ export interface RoomScreenShareMethods
   extends RoomMemberSelfMethodsInterface {}
 
 export interface RoomSessionJoinAudienceParams {
-  audio?: boolean
-  video?: boolean
+  receiveAudio?: boolean
+  receiveVideo?: boolean
 }
 
 export type PagingCursor =

--- a/packages/js/src/utils/roomSession.ts
+++ b/packages/js/src/utils/roomSession.ts
@@ -1,5 +1,5 @@
 import { getLogger } from '@signalwire/core'
-import type { Authorization } from '@signalwire/core'
+import type { Authorization, MediaDirectionAllowed } from '@signalwire/core'
 import type { RoomSessionJoinAudienceParams } from './interfaces'
 
 // `joinAudience` utils
@@ -15,17 +15,18 @@ const getJoinAudienceMediaParams = ({
     local,
     kind,
   }: {
-    remote?: boolean
-    local?: boolean
+    remote: MediaDirectionAllowed
+    local: boolean
     kind: 'audio' | 'video'
   }) => {
-    if (!remote && local) {
+    const remoteAllowed = remote !== 'none'
+    if (!remoteAllowed && local) {
       getLogger().warn(
         `[joinAudience] ${kind} is currently not allowed on this room.`
       )
     }
 
-    return !!(remote && local)
+    return !!(remoteAllowed && local)
   }
 
   return {

--- a/packages/js/src/utils/roomSession.ts
+++ b/packages/js/src/utils/roomSession.ts
@@ -5,8 +5,8 @@ import type { RoomSessionJoinAudienceParams } from './interfaces'
 // `joinAudience` utils
 const getJoinAudienceMediaParams = ({
   authState,
-  audio = true,
-  video = true,
+  receiveAudio = true,
+  receiveVideo = true,
 }: RoomSessionJoinAudienceParams & {
   authState: Authorization
 }) => {
@@ -33,12 +33,12 @@ const getJoinAudienceMediaParams = ({
     video: false,
     negotiateAudio: getMediaValue({
       remote: authState.audio_allowed,
-      local: audio,
+      local: receiveAudio,
       kind: 'audio',
     }),
     negotiateVideo: getMediaValue({
       remote: authState.video_allowed,
-      local: video,
+      local: receiveVideo,
       kind: 'video',
     }),
   }


### PR DESCRIPTION
We updated the values from the backend for `video_allowed` and `audio_allowed` so i reflect the changes in here. I also updated the boolean checks because now we'll receive strings: `both` | `none` | `receive`.