### PR TITLE
Fix RealtimeAPI SDK DeviceBuilder export

### DIFF
--- a/.changeset/cold-nails-cheer.md
+++ b/.changeset/cold-nails-cheer.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/realtime-api': patch
+---
+
+Fix missing export for `DeviceBuilder`

--- a/packages/realtime-api/src/voice/Voice.ts
+++ b/packages/realtime-api/src/voice/Voice.ts
@@ -21,7 +21,8 @@ import { AutoApplyTransformsConsumer } from '../AutoApplyTransformsConsumer'
 
 export * from './VoiceClient'
 export { Call } from './Call'
-export type { DeviceBuilder, RealTimeCallApiEvents }
+export type { RealTimeCallApiEvents }
+export { DeviceBuilder }
 export { Playlist } from './Playlist'
 export type { CallPlayback } from './CallPlayback'
 export type { CallPrompt } from './CallPrompt'


### PR DESCRIPTION
Instead of export only the types, we need to export the object too.