### PR TITLE
Generate Releases

### DIFF
--- a/.changeset/cold-nails-cheer.md
+++ b/.changeset/cold-nails-cheer.md
@@ -1,5 +1,0 @@
----
-'@signalwire/realtime-api': patch
----
-
-Fix missing export for `DeviceBuilder`

--- a/.changeset/forty-badgers-press.md
+++ b/.changeset/forty-badgers-press.md
@@ -1,7 +1,0 @@
----
-'@sw-internal/e2e-js': patch
-'@sw-internal/e2e-realtime-api': patch
-'@sw-internal/test': patch
----
-
-[internal] added sw-test to e2e-js and e2e-realtime-api

--- a/.changeset/little-goats-peel.md
+++ b/.changeset/little-goats-peel.md
@@ -1,5 +1,0 @@
----
-'@signalwire/webrtc': patch
----
-
-Review webrtc folder structure and import order to fix a circular dependency between modules.

--- a/.changeset/lovely-crabs-impress.md
+++ b/.changeset/lovely-crabs-impress.md
@@ -1,6 +1,0 @@
----
-'@signalwire/core': patch
-'@signalwire/realtime-api': patch
----
-
-Improve auto-subscribe logic in Video client and PubSub

--- a/.changeset/popular-readers-mix.md
+++ b/.changeset/popular-readers-mix.md
@@ -1,6 +1,0 @@
----
-'@sw-internal/e2e-js': patch
-'@sw-internal/playground-js': patch
----
-
-Add PubSub examples and e2e tests

--- a/.changeset/strange-queens-jump.md
+++ b/.changeset/strange-queens-jump.md
@@ -1,5 +1,0 @@
----
-'@signalwire/webrtc': patch
----
-
-Set a timeout for getUserMedia only if the permissions have already been granted

--- a/internal/e2e-js/CHANGELOG.md
+++ b/internal/e2e-js/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @sw-internal/e2e-js
 
+## 0.0.3
+
+### Patch Changes
+
+- [#598](https://github.com/signalwire/signalwire-js/pull/598) [`06d16780`](https://github.com/signalwire/signalwire-js/commit/06d1678074b72cbfcd26d098d90c8a3b7f406469) - [internal] added sw-test to e2e-js and e2e-realtime-api
+
+* [#596](https://github.com/signalwire/signalwire-js/pull/596) [`6bc89d81`](https://github.com/signalwire/signalwire-js/commit/6bc89d81fe6ffa7530f60ed90482db1e7a39d6ac) - [internal] Add `PubSub` playground and e2e-tests.
+
+* Updated dependencies [[`6bc89d81`](https://github.com/signalwire/signalwire-js/commit/6bc89d81fe6ffa7530f60ed90482db1e7a39d6ac)]:
+  - @sw-internal/playground-js@0.0.6
+
 ## 0.0.2
 
 ### Patch Changes

--- a/internal/e2e-js/package.json
+++ b/internal/e2e-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sw-internal/e2e-js",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "private": true,
   "main": "index.js",
   "scripts": {
@@ -8,7 +8,7 @@
     "test": ""
   },
   "dependencies": {
-    "@sw-internal/playground-js": "0.0.5",
+    "@sw-internal/playground-js": "0.0.6",
     "node-fetch": "^2.6.1",
     "vite": "^2.9.9"
   },

--- a/internal/e2e-realtime-api/CHANGELOG.md
+++ b/internal/e2e-realtime-api/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @sw-internal/e2e-realtime-api
 
+## 0.1.2
+
+### Patch Changes
+
+- [#598](https://github.com/signalwire/signalwire-js/pull/598) [`06d16780`](https://github.com/signalwire/signalwire-js/commit/06d1678074b72cbfcd26d098d90c8a3b7f406469) - [internal] added sw-test to e2e-js and e2e-realtime-api
+
 ## 0.1.1
 
 ### Patch Changes

--- a/internal/e2e-realtime-api/package.json
+++ b/internal/e2e-realtime-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sw-internal/e2e-realtime-api",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "main": "index.js",
   "scripts": {

--- a/internal/playground-js/CHANGELOG.md
+++ b/internal/playground-js/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @sw-internal/playground-js
 
+## 0.0.6
+
+### Patch Changes
+
+- [#596](https://github.com/signalwire/signalwire-js/pull/596) [`6bc89d81`](https://github.com/signalwire/signalwire-js/commit/6bc89d81fe6ffa7530f60ed90482db1e7a39d6ac) - [internal] Add `PubSub` playground and e2e-tests.
+
 ## 0.0.5
 
 ### Patch Changes

--- a/internal/playground-js/package.json
+++ b/internal/playground-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sw-internal/playground-js",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "private": true,
   "scripts": {
     "dev": "vite",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.10.1]- 2022-07-27
+
+### Patch Changes
+
+- [#596](https://github.com/signalwire/signalwire-js/pull/596) [`6bc89d81`](https://github.com/signalwire/signalwire-js/commit/6bc89d81fe6ffa7530f60ed90482db1e7a39d6ac) - Improve auto-subscribe logic in `Video` and `PubSub` namespaces.
+
 ## [3.10.0]- 2022-07-14
 
 ### Added

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,7 +3,7 @@
   "description": "Shared code for the SignalWire JS SDK",
   "author": "SignalWire Team <open.source@signalwire.com>",
   "license": "MIT",
-  "version": "3.10.0",
+  "version": "3.10.1",
   "main": "dist/index.node.js",
   "module": "dist/index.esm.js",
   "files": [

--- a/packages/js/CHANGELOG.md
+++ b/packages/js/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.13.1]- 2022-07-27
+
+### Dependencies
+
+- Updated dependencies [[`6b4ad46d`](https://github.com/signalwire/signalwire-js/commit/6b4ad46db6eb01e3e13496d65206a87cf09819aa), [`6bc89d81`](https://github.com/signalwire/signalwire-js/commit/6bc89d81fe6ffa7530f60ed90482db1e7a39d6ac), [`6d1c26ea`](https://github.com/signalwire/signalwire-js/commit/6d1c26eaaaa6799bde38099218e55e88dbe634ca)]:
+  - @signalwire/webrtc@3.5.5
+  - @signalwire/core@3.10.1
+
 ## [3.13.0]- 2022-07-14
 
 ### Added

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -3,7 +3,7 @@
   "description": "SignalWire JS SDK",
   "author": "SignalWire Team <open.source@signalwire.com>",
   "license": "MIT",
-  "version": "3.13.0",
+  "version": "3.13.1",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",
   "unpkg": "dist/index.umd.js",
@@ -43,8 +43,8 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@signalwire/core": "3.10.0",
-    "@signalwire/webrtc": "3.5.4",
+    "@signalwire/core": "3.10.1",
+    "@signalwire/webrtc": "3.5.5",
     "jwt-decode": "^3.1.2"
   },
   "types": "dist/js/src/index.d.ts"

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -21,7 +21,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@signalwire/core": "3.10.0",
-    "@signalwire/webrtc": "3.5.4"
+    "@signalwire/core": "3.10.1",
+    "@signalwire/webrtc": "3.5.5"
   }
 }

--- a/packages/realtime-api/CHANGELOG.md
+++ b/packages/realtime-api/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.1]- 2022-07-27
+
+### Changed
+
+- [#596](https://github.com/signalwire/signalwire-js/pull/596) [`6bc89d81`](https://github.com/signalwire/signalwire-js/commit/6bc89d81fe6ffa7530f60ed90482db1e7a39d6ac) - Improve auto-subscribe logic in `Video` and `PubSub` namespaces.
+
+### Fixed
+
+- [#597](https://github.com/signalwire/signalwire-js/pull/597) [`b2abd7ac`](https://github.com/signalwire/signalwire-js/commit/b2abd7ac3a21b058beba0689ddbe8af3b83a6b40) - Fix missing export for `DeviceBuilder`
+
+### Dependencies
+
+- Updated dependencies [[`6bc89d81`](https://github.com/signalwire/signalwire-js/commit/6bc89d81fe6ffa7530f60ed90482db1e7a39d6ac)]:
+  - @signalwire/core@3.10.1
+
 ## [3.3.0]- 2022-07-14
 
 ### Added

--- a/packages/realtime-api/package.json
+++ b/packages/realtime-api/package.json
@@ -3,7 +3,7 @@
   "description": "SignalWire RealTime SDK for Node.js",
   "author": "SignalWire Team <open.source@signalwire.com>",
   "license": "MIT",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "main": "dist/index.node.js",
   "exports": {
     "require": "./dist/index.node.js",
@@ -41,7 +41,7 @@
     "docs:watch": "npm run docs -- --watch"
   },
   "dependencies": {
-    "@signalwire/core": "3.10.0",
+    "@signalwire/core": "3.10.1",
     "ws": "^8.5.0"
   },
   "devDependencies": {

--- a/packages/web-api/package.json
+++ b/packages/web-api/package.json
@@ -40,7 +40,7 @@
     "docs:watch": "npm run docs -- --watch"
   },
   "dependencies": {
-    "@signalwire/core": "3.10.0",
+    "@signalwire/core": "3.10.1",
     "node-abort-controller": "^2.0.0",
     "node-fetch": "^2.6.1"
   },

--- a/packages/webrtc/CHANGELOG.md
+++ b/packages/webrtc/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.5.5]- 2022-07-27
+
+### Changed
+
+- [#593](https://github.com/signalwire/signalwire-js/pull/593) [`6b4ad46d`](https://github.com/signalwire/signalwire-js/commit/6b4ad46db6eb01e3e13496d65206a87cf09819aa) - Review `webrtc` folder structure and import order to fix a circular dependency between modules.
+
+### Fixed
+
+- [#592](https://github.com/signalwire/signalwire-js/pull/592) [`6d1c26ea`](https://github.com/signalwire/signalwire-js/commit/6d1c26eaaaa6799bde38099218e55e88dbe634ca) - Set a timeout for `getUserMedia` only if the permissions have already been granted.
+
+### Dependencies
+
+- Updated dependencies [[`6bc89d81`](https://github.com/signalwire/signalwire-js/commit/6bc89d81fe6ffa7530f60ed90482db1e7a39d6ac)]:
+  - @signalwire/core@3.10.1
+
 ## [3.5.4]- 2022-07-14
 
 ### Changed

--- a/packages/webrtc/package.json
+++ b/packages/webrtc/package.json
@@ -3,7 +3,7 @@
   "description": "SignalWire WebRTC library",
   "author": "SignalWire Team <open.source@signalwire.com>",
   "license": "MIT",
-  "version": "3.5.4",
+  "version": "3.5.5",
   "main": "dist/cjs/webrtc/src/index.js",
   "module": "dist/mjs/webrtc/src/index.js",
   "files": [
@@ -39,7 +39,7 @@
     "docs:watch": "npm run docs -- --watch"
   },
   "dependencies": {
-    "@signalwire/core": "3.10.0"
+    "@signalwire/core": "3.10.1"
   },
   "types": "dist/cjs/webrtc/src/index.d.ts"
 }

--- a/scripts/sw-test/CHANGELOG.md
+++ b/scripts/sw-test/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @sw-internal/test
+
+## 0.0.1
+
+### Patch Changes
+
+- [#598](https://github.com/signalwire/signalwire-js/pull/598) [`06d16780`](https://github.com/signalwire/signalwire-js/commit/06d1678074b72cbfcd26d098d90c8a3b7f406469) - [internal] added sw-test to e2e-js and e2e-realtime-api

--- a/scripts/sw-test/package.json
+++ b/scripts/sw-test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sw-internal/test",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "description": "A CLI for running tests using Jest",
   "main": "index.js",
   "private": true,


### PR DESCRIPTION
We'll have only `patch` version mostly for `webrtc` and `realtime-api` changes.