### PR TITLE
Custom SDK Agents + global `sw.config.js`

### DIFF
--- a/.changeset/serious-bananas-hug.md
+++ b/.changeset/serious-bananas-hug.md
@@ -1,0 +1,13 @@
+---
+'@sw-internal/build': patch
+'@signalwire/compatibility-api': patch
+'@signalwire/core': patch
+'@signalwire/js': patch
+'@signalwire/node': patch
+'@signalwire/react-native': patch
+'@signalwire/realtime-api': patch
+'@signalwire/web-api': patch
+'@signalwire/webrtc': patch
+---
+
+[internal] change how the SDK agent is defined

--- a/sw.config.js
+++ b/sw.config.js
@@ -3,10 +3,10 @@ module.exports = {
     // Maps packages to agent-name. Take into account that
     // these names are just a part within the fully
     // qualified agent sent to the server:
-    // @signalwire/<platform>/<agent-name>/<x.y.x>
+    // @signalwire/<platform>/<sdk-name>/<x.y.x>
     byName: {
       '@signalwire/realtime-api': 'nodejs/realtime-api',
-      '@signalwire/js': 'browser/js',
+      '@signalwire/js': 'js/browser',
       '@signalwire/compatibility-api': 'nodejs/compatibility-api',
     },
   },

--- a/sw.config.js
+++ b/sw.config.js
@@ -1,0 +1,14 @@
+module.exports = {
+  agents: {
+    // Maps packages to agent-name. Take into account that
+    // these names are just a part within the fully
+    // qualified agent sent to the server:
+    // @signalwire/<platform>/<agent-name>/<x.y.x>
+    byName: {
+      '@signalwire/realtime-api': 'nodejs/realtime-api',
+      '@signalwire/js': 'browser/js',
+      '@signalwire/compatibility-api': 'nodejs/compatibility-api',
+    },
+  },
+  utilityPackages: ['@signalwire/core', '@signalwire/webrtc'],
+}


### PR DESCRIPTION
The code in this changeset includes:

- [x] Ability to define custom agent names by package. This uses the new `sw.config.js` file. 
- [x] Global config file: `sw.config.js`: For now we're only using it for handling agents.
- [x] Standardise agent names

**Pattern**
```@signalwire/<platform>/<package-name>/<x.y.z>```

**Example**
```@signalwire/<nodejs | browser | reactnative>/<realtime-api | js | compatibility-api>/<x.y.z>```

### SDK Agents

* `@signalwire/compatibility-api` -> `@signalwire/nodejs/compatibility-api/3.0.2`
* `@signalwire/core` -> none (because it's marked as an utility package in `sw.config.js`)
* `@signalwire/js` -> `@signalwire/browser/js/3.13.1`
* `@signalwire/node` -> none (because it's a `private` package)
* `@signalwire/react-native` -> none (because it's a `private` package)
* `@signalwire/realtime-api` -> `@signalwire/nodejs/realtime-api/3.3.1`
* `@signalwire/web-api` -> none (because it's a `private` package)
* `@signalwire/webrtc` -> none (because it's marked as an utility package in `sw.config.js`)
 