### PR TITLE
Fix typing issue with Authorization state

### DIFF
--- a/.changeset/wicked-seahorses-drive.md
+++ b/.changeset/wicked-seahorses-drive.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/webrtc': patch
+---
+
+Fix typing issue with Authorization state

--- a/packages/webrtc/src/workers/promoteDemoteWorker.ts
+++ b/packages/webrtc/src/workers/promoteDemoteWorker.ts
@@ -10,6 +10,7 @@ import {
   VideoMemberDemotedEvent,
   sessionActions,
   selectors,
+  VideoAuthorization,
 } from '@signalwire/core'
 
 import { BaseConnection } from '../BaseConnection'
@@ -52,14 +53,10 @@ export const promoteDemoteWorker: SDKWorker<
   yield sagaEffects.put(
     sessionActions.updateAuthState(action.payload.authorization)
   )
-  const authState: ReturnType<typeof selectors.getAuthState> =
+  const authState: VideoAuthorization =
     yield sagaEffects.select(selectors.getAuthState)
   if (!authState) {
     throw new Error(`Invalid authState for '${action.type}'`)
-  }
-
-  if (authState?.type !== 'video') {
-    return
   }
 
   instance.updateMediaOptions({

--- a/packages/webrtc/src/workers/promoteDemoteWorker.ts
+++ b/packages/webrtc/src/workers/promoteDemoteWorker.ts
@@ -58,6 +58,10 @@ export const promoteDemoteWorker: SDKWorker<
     throw new Error(`Invalid authState for '${action.type}'`)
   }
 
+  if (authState?.type !== 'video') {
+    return
+  }
+
   instance.updateMediaOptions({
     audio: isPromoted && authState.audio_allowed !== 'none',
     video: isPromoted && authState.video_allowed !== 'none',


### PR DESCRIPTION
Build was failing because now the `Authorization` state handle other namespaces other than video and `audio_allowed`/`video_allowed` are not always present.