### PR TITLE
Change auto managed `rootElement` logic for cleaning up styles

### DIFF
--- a/.changeset/mean-panthers-exercise.md
+++ b/.changeset/mean-panthers-exercise.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/js': patch
+---
+
+Change logic for handling the auto managed rootElement so we don't mutate its styles

--- a/packages/js/src/features/mediaElements/mediaElementsSagas.ts
+++ b/packages/js/src/features/mediaElements/mediaElementsSagas.ts
@@ -344,10 +344,13 @@ function* videoElementSetupWorker({
     relativeWrapper.style.margin = '0 auto'
     relativeWrapper.appendChild(paddingWrapper)
 
-    rootElement.style.display = 'flex'
-    rootElement.style.alignItems = 'center'
-    rootElement.style.justifyContent = 'center'
-    rootElement.appendChild(relativeWrapper)
+    const contentWrapper = document.createElement('div')
+    contentWrapper.style.display = 'flex'
+    contentWrapper.style.alignItems = 'center'
+    contentWrapper.style.justifyContent = 'center'
+    contentWrapper.appendChild(relativeWrapper)
+
+    rootElement.appendChild(contentWrapper)
 
     if (element.readyState === HTMLMediaElement.HAVE_NOTHING) {
       getLogger().debug('Wait for the MCU to be ready')


### PR DESCRIPTION
The code in this changeset changes the way we handle the auto managed `rootElement` to avoid mutating its styles. Instead of applying the styles directly to it, we do it in an intermediate `div` element. This also simplifies the cleaning since we now have to remove a single element.