### PR TITLE
Update types for RoomSession/Member/Layout/Playback

### DIFF
--- a/.changeset/sharp-cameras-draw.md
+++ b/.changeset/sharp-cameras-draw.md
@@ -1,0 +1,7 @@
+---
+'@signalwire/core': minor
+'@signalwire/js': minor
+'@signalwire/realtime-api': minor
+---
+
+Updated interfaces to match the spec, update `RoomSession.getRecordings` and `RoomSession.getPlaybacks` to return stateful objects, deprecated `RoomSession.members` and `RoomSession.recordings` in favour of their corresponding getters

--- a/internal/e2e-js/tests/roomSession.spec.ts
+++ b/internal/e2e-js/tests/roomSession.spec.ts
@@ -329,7 +329,7 @@ test.describe('RoomSession', () => {
     // --------------- Leaving the room ---------------
     await page.evaluate(() => {
       // @ts-expect-error
-      return window._roomObj.hangup()
+      return window._roomObj.leave()
     })
 
     // Checks that all the elements added by the SDK are gone.
@@ -563,11 +563,11 @@ test.describe('RoomSession', () => {
     await Promise.all([
       pageOne.evaluate(() => {
         // @ts-expect-error
-        return window._roomObj.hangup()
+        return window._roomObj.leave()
       }),
       pageTwo.evaluate(() => {
         // @ts-expect-error
-        return window._roomObj.hangup()
+        return window._roomObj.leave()
       }),
     ])
   })

--- a/packages/core/src/types/videoLayout.ts
+++ b/packages/core/src/types/videoLayout.ts
@@ -36,6 +36,8 @@ export interface VideoLayoutLayer {
   zIndex: number
   reservation: string
   position: VideoPosition
+  playingFile: boolean
+  visible: boolean
 }
 
 /**

--- a/packages/core/src/types/videoMember.ts
+++ b/packages/core/src/types/videoMember.ts
@@ -21,7 +21,6 @@ export const INTERNAL_MEMBER_UPDATABLE_PROPS = {
   audio_muted: true,
   video_muted: true,
   deaf: true,
-  on_hold: true,
   visible: true,
   input_volume: 1,
   output_volume: 1,
@@ -147,6 +146,8 @@ export interface VideoMemberContract extends VideoMemberUpdatableProps {
   requestedPosition: VideoPosition
   /** Current position of this member in the layout. */
   currentPosition?: VideoPosition
+  /** Metadata associated to this member. */
+  meta?: Record<string, unknown>
 
   /**
    * Mutes the outbound audio for this member (e.g., the one coming from a

--- a/packages/core/src/types/videoPlayback.ts
+++ b/packages/core/src/types/videoPlayback.ts
@@ -41,6 +41,9 @@ export interface VideoPlaybackContract {
   /** Current state of the playback */
   state: 'playing' | 'paused' | 'completed'
 
+  /** The current playback position, in milliseconds. */
+  position: number;
+
   /** Whether the seek function can be used for this playback. */
   seekable: boolean
 

--- a/packages/core/src/types/videoRoomSession.ts
+++ b/packages/core/src/types/videoRoomSession.ts
@@ -64,7 +64,10 @@ export interface VideoRoomSessionContract {
   name: string
   /** Whether recording is active */
   recording: boolean
-  /** List of active recordings in the room */
+  /**
+   * List of active recordings in the room
+   * @deprecated Use {@link getRecordings}
+   **/
   recordings?: any[]
   /** Whether muted videos are shown in the room layout. See {@link setHideVideoMuted} */
   hideVideoMuted: boolean

--- a/packages/core/src/types/videoRoomSession.ts
+++ b/packages/core/src/types/videoRoomSession.ts
@@ -76,6 +76,8 @@ export interface VideoRoomSessionContract {
   meta?: Record<string, unknown>
   /** List of members that are part of this room session */
   members?: InternalVideoMemberEntity[]
+  /** Fields that have changed in this room session */
+  updated?: Array<Exclude<keyof VideoRoomSessionContract, 'updated'>>
 
   /**
    * Puts the microphone on mute. The other participants will not hear audio

--- a/packages/core/src/types/videoRoomSession.ts
+++ b/packages/core/src/types/videoRoomSession.ts
@@ -77,10 +77,11 @@ export interface VideoRoomSessionContract {
   layoutName: string
   /** Metadata associated to this room session. */
   meta?: Record<string, unknown>
-  /** List of members that are part of this room session */
+  /**
+   * List of members that are part of this room session
+   * @deprecated Use {@link getMembers}
+   **/
   members?: InternalVideoMemberEntity[]
-  /** Fields that have changed in this room session */
-  updated?: Array<Exclude<keyof VideoRoomSessionContract, 'updated'>>
 
   /**
    * Puts the microphone on mute. The other participants will not hear audio

--- a/packages/core/src/utils/interfaces.ts
+++ b/packages/core/src/utils/interfaces.ts
@@ -379,6 +379,7 @@ export type EventTransformType =
   | 'roomSessionLayout'
   | 'roomSessionRecording'
   | 'roomSessionRecordingList'
+  | 'roomSessionPlaybackList'
   | 'roomSessionPlayback'
   | 'roomSessionAudienceCount'
   | ChatTransformType

--- a/packages/core/src/utils/interfaces.ts
+++ b/packages/core/src/utils/interfaces.ts
@@ -378,6 +378,7 @@ export type EventTransformType =
   | 'roomSessionMember'
   | 'roomSessionLayout'
   | 'roomSessionRecording'
+  | 'roomSessionRecordingList'
   | 'roomSessionPlayback'
   | 'roomSessionAudienceCount'
   | ChatTransformType

--- a/packages/js/src/BaseRoomSession.test.ts
+++ b/packages/js/src/BaseRoomSession.test.ts
@@ -84,20 +84,13 @@ describe('Room Object', () => {
 
   describe('getRecordings', () => {
     it('should return an array of recordings', async () => {
-      const { store, session, emitter, destroy } = configureFullStack()
       const recordingList = [{ id: 'recordingOne' }, { id: 'recordingTwo' }]
 
-      session.execute = jest.fn().mockResolvedValue({
-        code: '200',
-        message: 'OK',
+      // @ts-expect-error
+      ;(room.execute as jest.Mock).mockResolvedValueOnce({
         recordings: recordingList,
       })
 
-      room = createBaseRoomSessionObject({
-        store,
-        // @ts-expect-error
-        emitter,
-      })
       store.dispatch(
         componentActions.upsert({
           id: callId,
@@ -107,21 +100,14 @@ describe('Room Object', () => {
           memberId: 'member-id',
         })
       )
-      // mock a room.subscribed event
-      dispatchMockedRoomSubscribed({
-        session,
-        callId,
-        roomId: '6e83849b-5cc2-4fc6-80ed-448113c8a426',
-        roomSessionId: '8e03ac25-8622-411a-95fc-f897b34ac9e7',
-        memberId: 'member-id',
-      })
 
       const result = await room.getRecordings()
-      expect(result).toStrictEqual({
-        recordings: recordingList,
+      result.recordings.forEach((recording, index) => {
+        expect(recording.id).toEqual(recordingList[index].id)
+        expect(typeof recording.pause).toBe('function')
+        expect(typeof recording.resume).toBe('function')
+        expect(typeof recording.stop).toBe('function')
       })
-
-      destroy()
     })
   })
 
@@ -233,20 +219,13 @@ describe('Room Object', () => {
 
   describe('playback methods', () => {
     it('getPlaybacks should return an array of playbacks', async () => {
-      const { store, session, emitter, destroy } = configureFullStack()
       const playbacks = [{ id: 'playbackOne' }, { id: 'playbackTwo' }]
 
-      session.execute = jest.fn().mockResolvedValue({
-        code: '200',
-        message: 'OK',
+      // @ts-expect-error
+      ;(room.execute as jest.Mock).mockResolvedValueOnce({
         playbacks,
       })
 
-      room = createBaseRoomSessionObject({
-        store,
-        // @ts-expect-error
-        emitter,
-      })
       store.dispatch(
         componentActions.upsert({
           id: callId,
@@ -256,21 +235,18 @@ describe('Room Object', () => {
           memberId: 'member-id',
         })
       )
-      // mock a room.subscribed event
-      dispatchMockedRoomSubscribed({
-        session,
-        callId,
-        roomId: '6e83849b-5cc2-4fc6-80ed-448113c8a426',
-        roomSessionId: '8e03ac25-8622-411a-95fc-f897b34ac9e7',
-        memberId: 'member-id',
-      })
 
       const result = await room.getPlaybacks()
-      expect(result).toStrictEqual({
-        playbacks,
+      result.playbacks.forEach((playback, index) => {
+        expect(playback.id).toEqual(playbacks[index].id)
+        expect(typeof playback.forward).toBe('function')
+        expect(typeof playback.pause).toBe('function')
+        expect(typeof playback.resume).toBe('function')
+        expect(typeof playback.rewind).toBe('function')
+        expect(typeof playback.seek).toBe('function')
+        expect(typeof playback.setVolume).toBe('function')
+        expect(typeof playback.stop).toBe('function')
       })
-
-      destroy()
     })
 
     it('play should return an interactive object', async () => {

--- a/packages/js/src/BaseRoomSession.ts
+++ b/packages/js/src/BaseRoomSession.ts
@@ -124,6 +124,24 @@ export class RoomSessionConnection
         },
       ],
       [
+        [toLocalEvent('video.playback.list')],
+        {
+          type: 'roomSessionPlaybackList',
+          instanceFactory: (_payload: any) => {
+            return {}
+          },
+          payloadTransform: (payload: any) => {
+            return payload
+          },
+          nestedFieldsToProcess: {
+            playbacks: {
+              eventTransformType: 'roomSessionPlayback',
+              processInstancePayload: (payload) => ({ playback: payload }),
+            },
+          },
+        },
+      ],
+      [
         [
           toLocalEvent('video.recording.start'),
           'video.recording.started',

--- a/packages/js/src/BaseRoomSession.ts
+++ b/packages/js/src/BaseRoomSession.ts
@@ -100,7 +100,7 @@ export class RoomSessionConnection
             },
             playbacks: {
               eventTransformType: 'roomSessionPlayback',
-              processInstancePayload: (payload) => ({ member: payload }),
+              processInstancePayload: (payload) => ({ playback: payload }),
             },
           },
         },

--- a/packages/js/src/BaseRoomSession.ts
+++ b/packages/js/src/BaseRoomSession.ts
@@ -106,6 +106,24 @@ export class RoomSessionConnection
         },
       ],
       [
+        [toLocalEvent('video.recording.list')],
+        {
+          type: 'roomSessionRecordingList',
+          instanceFactory: (_payload: any) => {
+            return {}
+          },
+          payloadTransform: (payload: any) => {
+            return payload
+          },
+          nestedFieldsToProcess: {
+            recordings: {
+              eventTransformType: 'roomSessionRecording',
+              processInstancePayload: (payload) => ({ recording: payload }),
+            },
+          },
+        },
+      ],
+      [
         [
           toLocalEvent('video.recording.start'),
           'video.recording.started',

--- a/packages/realtime-api/src/video/RoomSession.ts
+++ b/packages/realtime-api/src/video/RoomSession.ts
@@ -193,6 +193,24 @@ export class RoomSessionConsumer extends BaseConsumer<RealTimeRoomApiEvents> {
         },
       ],
       [
+        [toLocalEvent<EmitterTransformsEvents>('video.playback.list')],
+        {
+          type: 'roomSessionPlaybackList',
+          instanceFactory: (_payload: any) => {
+            return {}
+          },
+          payloadTransform: (payload: any) => {
+            return payload
+          },
+          nestedFieldsToProcess: {
+            playbacks: {
+              eventTransformType: 'roomSessionPlayback',
+              processInstancePayload: (payload) => ({ playback: payload }),
+            },
+          },
+        },
+      ],
+      [
         'video.room.updated',
         {
           type: 'roomSession',

--- a/packages/realtime-api/src/video/RoomSession.ts
+++ b/packages/realtime-api/src/video/RoomSession.ts
@@ -175,6 +175,24 @@ export class RoomSessionConsumer extends BaseConsumer<RealTimeRoomApiEvents> {
         },
       ],
       [
+        [toLocalEvent<EmitterTransformsEvents>('video.recording.list')],
+        {
+          type: 'roomSessionRecordingList',
+          instanceFactory: (_payload: any) => {
+            return {}
+          },
+          payloadTransform: (payload: any) => {
+            return payload
+          },
+          nestedFieldsToProcess: {
+            recordings: {
+              eventTransformType: 'roomSessionRecording',
+              processInstancePayload: (payload) => ({ recording: payload }),
+            },
+          },
+        },
+      ],
+      [
         'video.room.updated',
         {
           type: 'roomSession',


### PR DESCRIPTION
`VideoRoomSessionContract`
- [x] Deprecate `RoomSession.members` in favour of `RoomSession.getMembers`
- [x] Deprecate `RoomSession.recordings` in favour of `RoomSession.getRecordings`
- [x] Update `RoomSession.getRecordings` to return instances of `RoomSessionRecording`
- [x] Update `RoomSession.getPlaybacks` to return instances of `RoomSessionPlayback`

`VideoMemberContract`
- [x] Remove `on_hold`: we had it on the SDK but it doesn’t seem to come over the wire nor is in the spec.

`VideoPlaybackContract`
- [x] Add missing `position` property

`VideoLayoutLayer`
- [x] Add missing `playing_file` and `visible` properties
