### PR TITLE
Logger Tweaks

### DIFF
--- a/.changeset/rotten-donuts-search.md
+++ b/.changeset/rotten-donuts-search.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/core': patch
+---
+
+[internal] Do not print timestamp in logs on browsers.

--- a/packages/core/src/utils/logger.ts
+++ b/packages/core/src/utils/logger.ts
@@ -13,12 +13,11 @@ const originalFactory = defaultLogger.methodFactory
 defaultLogger.methodFactory = (methodName, logLevel, loggerName) => {
   const rawMethod = originalFactory(methodName, logLevel, loggerName)
 
-  return function () {
-    const messages = [datetime(), '-']
-    for (let i = 0; i < arguments.length; i++) {
-      messages.push(arguments[i])
+  return function (...args: any[]) {
+    if (typeof window === 'undefined') {
+      args.unshift(datetime(), '-')
     }
-    rawMethod.apply(undefined, messages)
+    rawMethod.apply(undefined, args)
   }
 }
 

--- a/packages/core/src/utils/logger.ts
+++ b/packages/core/src/utils/logger.ts
@@ -6,8 +6,7 @@ import type {
   UserOptions,
 } from '..'
 
-const datetime = () =>
-  new Date().toISOString().replace('T', ' ').replace('Z', '')
+const datetime = () => new Date().toISOString()
 const defaultLogger = log.getLogger('signalwire')
 
 const originalFactory = defaultLogger.methodFactory

--- a/packages/core/src/utils/logger.ts
+++ b/packages/core/src/utils/logger.ts
@@ -8,13 +8,14 @@ import type {
 
 const datetime = () => new Date().toISOString()
 const defaultLogger = log.getLogger('signalwire')
+const isWindowUndefined = typeof window === 'undefined'
 
 const originalFactory = defaultLogger.methodFactory
 defaultLogger.methodFactory = (methodName, logLevel, loggerName) => {
   const rawMethod = originalFactory(methodName, logLevel, loggerName)
 
   return function (...args: any[]) {
-    if (typeof window === 'undefined') {
+    if (isWindowUndefined) {
       args.unshift(datetime(), '-')
     }
     rawMethod.apply(undefined, args)


### PR DESCRIPTION
Minor changes in the internal logger to skip the timestamp on browser environments (where the TS is already provided by dev-tools etc).