### PR TITLE
fix: Link was going to the browser SDK page

### DIFF
--- a/packages/realtime-api/README.md
+++ b/packages/realtime-api/README.md
@@ -8,7 +8,7 @@ The RealTime SDK enables Node.js developers to connect and use SignalWire's Real
 
 ## Getting Started
 
-Read the implementation documentation, guides and API Reference at the official [RELAY RealTime SDK Documentation]([https://developer.signalwire.com/client-sdk/docs/getting-started](https://developer.signalwire.com/sdks/reference/realtime-sdk)) site.
+Read the implementation documentation, guides and API Reference at the official [RELAY RealTime SDK Documentation](https://developer.signalwire.com/sdks/reference/realtime-sdk) site.
 
 ---
 

--- a/packages/realtime-api/README.md
+++ b/packages/realtime-api/README.md
@@ -8,7 +8,7 @@ The RealTime SDK enables Node.js developers to connect and use SignalWire's Real
 
 ## Getting Started
 
-Read the implementation documentation, guides and API Reference at the official [RELAY RealTime SDK Documentation](https://developer.signalwire.com/client-sdk/docs/getting-started) site.
+Read the implementation documentation, guides and API Reference at the official [RELAY RealTime SDK Documentation]([https://developer.signalwire.com/client-sdk/docs/getting-started](https://developer.signalwire.com/sdks/reference/realtime-sdk)) site.
 
 ---
 


### PR DESCRIPTION
This PR updates to link to go the Realtime SDK reference docs rather than the browser SDK docs.