### PR TITLE
`Call` with `ended` methods 

### DIFF
--- a/.changeset/empty-jeans-doubt.md
+++ b/.changeset/empty-jeans-doubt.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/realtime-api': minor
+---
+
+Review the Voice namespace interface: deprecate `waitForEnded` and added `ended`.

--- a/.changeset/fresh-ants-punch.md
+++ b/.changeset/fresh-ants-punch.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/core': patch
+---
+
+[internal] Stop using \_proxyFactoryCache.

--- a/.changeset/smooth-fans-allow.md
+++ b/.changeset/smooth-fans-allow.md
@@ -1,0 +1,6 @@
+---
+'@sw-internal/e2e-realtime-api': patch
+'@sw-internal/playground-realtime-api': patch
+---
+
+Update playground and e2e tests to use the new `ended` notation.

--- a/internal/e2e-realtime-api/src/voice.test.ts
+++ b/internal/e2e-realtime-api/src/voice.test.ts
@@ -60,8 +60,7 @@ const handler = () => {
         tap.ok(playback.id, 'Playback')
 
         console.log('Waiting for Playback to end')
-        // TODO: waitForEnded should probably accept a timeout
-        await playback.waitForEnded()
+        await playback.ended()
         tap.pass('Playback ended')
 
         call.on('prompt.started', (p) => {

--- a/internal/e2e-realtime-api/src/voice.test.ts
+++ b/internal/e2e-realtime-api/src/voice.test.ts
@@ -121,6 +121,11 @@ const handler = () => {
           'Detect digit is finished'
         )
 
+        // TODO: not currently working
+        // console.log('Stopping the recording.')
+        // recording.stop()
+        // await recording.ended()
+
         console.log('Finishing the calls.')
         await peer.hangup()
         await call.hangup()

--- a/internal/e2e-realtime-api/src/voice.test.ts
+++ b/internal/e2e-realtime-api/src/voice.test.ts
@@ -62,7 +62,7 @@ const handler = () => {
         console.log('Waiting for Playback to end')
         const endedResult = await playback.ended()
         tap.equal(playback.id, endedResult.id, 'Instances are the same')
-        tap.ok(endedResult.state, 'finished')
+        tap.equal(endedResult.state, 'finished', 'Playback state is "finished"')
         tap.pass('Playback ended')
 
         call.on('prompt.started', (p) => {

--- a/internal/e2e-realtime-api/src/voice.test.ts
+++ b/internal/e2e-realtime-api/src/voice.test.ts
@@ -16,9 +16,9 @@ const handler = () => {
       token: process.env.RELAY_TOKEN as string,
       contexts: [process.env.VOICE_CONTEXT as string],
       // logLevel: "trace",
-      // debug: {
-      //   logWsTraffic: true,
-      // },
+      debug: {
+        logWsTraffic: true,
+      },
     })
 
     let callsReceived = new Set()

--- a/internal/e2e-realtime-api/src/voice.test.ts
+++ b/internal/e2e-realtime-api/src/voice.test.ts
@@ -60,7 +60,9 @@ const handler = () => {
         tap.ok(playback.id, 'Playback')
 
         console.log('Waiting for Playback to end')
-        await playback.ended()
+        const endedResult = await playback.ended()
+        tap.equal(playback.id, endedResult.id, 'Instances are the same')
+        tap.ok(endedResult.state, 'finished')
         tap.pass('Playback ended')
 
         call.on('prompt.started', (p) => {
@@ -83,10 +85,9 @@ const handler = () => {
           },
         })
 
-        const result = await prompt.ended()
-
-        tap.equal(prompt.id, result.id, 'Instances are the same')
-        tap.equal(result.digits, '123', 'Correct Digits were entered')
+        const promptResult = await prompt.ended()
+        tap.equal(prompt.id, promptResult.id, 'Instances are the same')
+        tap.equal(promptResult.digits, '123', 'Correct Digits were entered')
 
         console.log(
           `Connecting ${process.env.VOICE_DIAL_FROM_NUMBER} to ${process.env.VOICE_CONNECT_TO_NUMBER}`

--- a/internal/e2e-realtime-api/src/voice.test.ts
+++ b/internal/e2e-realtime-api/src/voice.test.ts
@@ -16,9 +16,9 @@ const handler = () => {
       token: process.env.RELAY_TOKEN as string,
       contexts: [process.env.VOICE_CONTEXT as string],
       // logLevel: "trace",
-      debug: {
-        logWsTraffic: true,
-      },
+      // debug: {
+      //   logWsTraffic: true,
+      // },
     })
 
     let callsReceived = new Set()
@@ -51,6 +51,15 @@ const handler = () => {
         const recording = await call.recordAudio()
         tap.ok(recording.id, 'Recording started')
 
+        console.log('Stopping the recording.')
+        recording.stop()
+        const recordingEndedResult = await recording.ended()
+        tap.equal(
+          recordingEndedResult.state,
+          'finished',
+          'Recording state is "finished"'
+        )
+
         const playlist = new Voice.Playlist({ volume: 2 }).add(
           Voice.Playlist.TTS({
             text: 'Message is getting recorded',
@@ -60,9 +69,13 @@ const handler = () => {
         tap.ok(playback.id, 'Playback')
 
         console.log('Waiting for Playback to end')
-        const endedResult = await playback.ended()
-        tap.equal(playback.id, endedResult.id, 'Instances are the same')
-        tap.equal(endedResult.state, 'finished', 'Playback state is "finished"')
+        const playbackEndedResult = await playback.ended()
+        tap.equal(playback.id, playbackEndedResult.id, 'Instances are the same')
+        tap.equal(
+          playbackEndedResult.state,
+          'finished',
+          'Playback state is "finished"'
+        )
         tap.pass('Playback ended')
 
         call.on('prompt.started', (p) => {
@@ -85,9 +98,13 @@ const handler = () => {
           },
         })
 
-        const promptResult = await prompt.ended()
-        tap.equal(prompt.id, promptResult.id, 'Instances are the same')
-        tap.equal(promptResult.digits, '123', 'Correct Digits were entered')
+        const promptEndedResult = await prompt.ended()
+        tap.equal(prompt.id, promptEndedResult.id, 'Instances are the same')
+        tap.equal(
+          promptEndedResult.digits,
+          '123',
+          'Correct Digits were entered'
+        )
 
         console.log(
           `Connecting ${process.env.VOICE_DIAL_FROM_NUMBER} to ${process.env.VOICE_CONNECT_TO_NUMBER}`
@@ -121,11 +138,6 @@ const handler = () => {
           'finished',
           'Detect digit is finished'
         )
-
-        // TODO: currently not working
-        // console.log('Stopping the recording.')
-        // recording.stop()
-        // await recording.ended()
 
         console.log('Finishing the calls.')
         await peer.hangup()

--- a/internal/e2e-realtime-api/src/voice.test.ts
+++ b/internal/e2e-realtime-api/src/voice.test.ts
@@ -110,7 +110,7 @@ const handler = () => {
           digits: '1',
         })
 
-        const resultDetector = await detector.waitForResult()
+        const resultDetector = await detector.ended()
 
         // TODO: update this once the backend can send us
         // the actual result

--- a/internal/e2e-realtime-api/src/voice.test.ts
+++ b/internal/e2e-realtime-api/src/voice.test.ts
@@ -121,7 +121,7 @@ const handler = () => {
           'Detect digit is finished'
         )
 
-        // TODO: not currently working
+        // TODO: currently not working
         // console.log('Stopping the recording.')
         // recording.stop()
         // await recording.ended()

--- a/internal/e2e-realtime-api/src/voice.test.ts
+++ b/internal/e2e-realtime-api/src/voice.test.ts
@@ -83,7 +83,7 @@ const handler = () => {
           },
         })
 
-        const result = await prompt.waitForResult()
+        const result = await prompt.ended()
 
         tap.equal(prompt.id, result.id, 'Instances are the same')
         tap.equal(result.digits, '123', 'Correct Digits were entered')

--- a/internal/playground-realtime-api/src/voice-inbound/index.ts
+++ b/internal/playground-realtime-api/src/voice-inbound/index.ts
@@ -24,7 +24,7 @@ async function run() {
           text: "Hello! Welcome to Knee Rub's Weather Helpline. What place would you like to know the weather of?",
           gender: 'male',
         })
-        await pb.waitForEnded()
+        await pb.ended()
         console.log('Welcome text ok')
 
         const prompt = await call.promptTTS({

--- a/internal/playground-realtime-api/src/voice-inbound/index.ts
+++ b/internal/playground-realtime-api/src/voice-inbound/index.ts
@@ -34,7 +34,7 @@ async function run() {
             digitTimeout: 15,
           },
         })
-        const { type, digits, terminator } = await prompt.waitForResult()
+        const { type, digits, terminator } = await prompt.ended()
         console.log('Received digits', type, digits, terminator)
       } catch (error) {
         console.error('Error answering inbound call', error)

--- a/internal/playground-realtime-api/src/voice/index.ts
+++ b/internal/playground-realtime-api/src/voice/index.ts
@@ -112,7 +112,7 @@ async function run() {
         console.log('Main:', call.id, call.type, call.from, call.to)
 
         // Wait until Main and Peer are connected
-        await call.waitForDisconnected()
+        await call.disconnected()
 
         const playlist = new Voice.Playlist({ volume: 2 }).add(
           Voice.Playlist.TTS({

--- a/internal/playground-realtime-api/src/voice/index.ts
+++ b/internal/playground-realtime-api/src/voice/index.ts
@@ -181,7 +181,7 @@ async function run() {
       })
 
       /** Wait for the result - sync way */
-      // const { type, digits, terminator } = await prompt.waitForResult()
+      // const { type, digits, terminator } = await prompt.ended()
       // console.log('Prompt Output:', type, digits, terminator)
 
       console.log('Prompt STARTED!', prompt.id)

--- a/internal/playground-realtime-api/src/voice/index.ts
+++ b/internal/playground-realtime-api/src/voice/index.ts
@@ -121,7 +121,7 @@ async function run() {
         )
         const pb = await call.play(playlist)
 
-        await pb.waitForEnded()
+        await pb.ended()
       } catch (error) {
         console.error('Connect Error', error)
       }
@@ -239,7 +239,7 @@ async function run() {
       const playback = await call.play(playlist)
 
       // To wait for the playback to end (without pause/resume/stop it)
-      // await playback.waitForEnded()
+      // await playback.ended()
 
       console.log('Playback STARTED!', playback.id)
 

--- a/internal/playground-realtime-api/src/voice/index.ts
+++ b/internal/playground-realtime-api/src/voice/index.ts
@@ -85,7 +85,7 @@ async function run() {
       if (RUN_DETECTOR) {
         // See the `call.received` handler
         const detect = await call.detectDigit()
-        const result = await detect.waitForResult()
+        const result = await detect.ended()
         console.log('Detect Result', result.type)
 
         await sleep()

--- a/packages/core/src/BaseComponent.ts
+++ b/packages/core/src/BaseComponent.ts
@@ -74,7 +74,7 @@ export class BaseComponent<
   private readonly uuid = uuid()
 
   /** @internal */
-  private _proxyFactoryCache = new WeakMap<any, any>()
+  // private _proxyFactoryCache = new WeakMap<any, any>()
 
   /** @internal */
   get __uuid() {
@@ -417,20 +417,20 @@ export class BaseComponent<
       // transforms and creating a brand new Proxy for each
       // handler we'll cache the computed value and pass
       // that computed value instead to each handler.
-      if (this._proxyFactoryCache.has(payload)) {
-        proxiedObj = this._proxyFactoryCache.get(payload)
-      } else {
-        const transformedPayload = this._parseNestedFields(payload, transform)
+      // if (this._proxyFactoryCache.has(payload)) {
+      //   proxiedObj = this._proxyFactoryCache.get(payload)
+      // } else {
+      const transformedPayload = this._parseNestedFields(payload, transform)
 
-        proxiedObj = proxyFactory({
-          instance: cachedInstance,
-          payload,
-          transformedPayload,
-          transform,
-        })
+      proxiedObj = proxyFactory({
+        instance: cachedInstance,
+        payload,
+        transformedPayload,
+        transform,
+      })
 
-        this._proxyFactoryCache.set(payload, proxiedObj)
-      }
+      // this._proxyFactoryCache.set(payload, proxiedObj)
+      // }
 
       // @ts-expect-error
       return fn(proxiedObj)

--- a/packages/core/src/types/voiceCall.ts
+++ b/packages/core/src/types/voiceCall.ts
@@ -528,7 +528,11 @@ export interface VoiceCallPromptContract {
 
   stop(): Promise<this>
   setVolume(volume: number): Promise<this>
+  /**
+   * @deprecated use {@link ended} instead.
+   */
   waitForResult(): Promise<VoiceCallPromptContract>
+  ended(): Promise<this>
 }
 
 /**

--- a/packages/core/src/types/voiceCall.ts
+++ b/packages/core/src/types/voiceCall.ts
@@ -649,10 +649,10 @@ export interface VoiceCallContract<T = any> {
     params: VoiceCallConnectSipMethodParams
   ): Promise<VoiceCallContract>
   /**
-   * @deprectated use {@link disconnected} instead.
+   * @deprecated use {@link disconnected} instead.
    */
   waitForDisconnected(): Promise<this>
-   /**
+  /**
    * Returns a promise that is resolved only after the current call has been
    * disconnected. Also see {@link connect}.
    *

--- a/packages/core/src/types/voiceCall.ts
+++ b/packages/core/src/types/voiceCall.ts
@@ -464,6 +464,7 @@ export interface VoiceCallRecordingContract {
   readonly duration?: number
 
   stop(): Promise<this>
+  ended(): Promise<this>
 }
 
 /**

--- a/packages/core/src/types/voiceCall.ts
+++ b/packages/core/src/types/voiceCall.ts
@@ -564,6 +564,7 @@ export interface VoiceCallTapContract {
   readonly state: CallingCallTapState
 
   stop(): Promise<this>
+  ended(): Promise<this>
 }
 
 /**

--- a/packages/core/src/types/voiceCall.ts
+++ b/packages/core/src/types/voiceCall.ts
@@ -425,7 +425,11 @@ export interface VoiceCallPlaybackContract {
   resume(): Promise<this>
   stop(): Promise<this>
   setVolume(volume: number): Promise<this>
+  /**
+   * @deprecated use {@link ended} instead.
+   */
   waitForEnded(): Promise<this>
+  ended(): Promise<this>
 }
 
 /**

--- a/packages/core/src/types/voiceCall.ts
+++ b/packages/core/src/types/voiceCall.ts
@@ -648,7 +648,30 @@ export interface VoiceCallContract<T = any> {
   connectSip(
     params: VoiceCallConnectSipMethodParams
   ): Promise<VoiceCallContract>
+  /**
+   * @deprectated use {@link disconnected} instead.
+   */
   waitForDisconnected(): Promise<this>
+   /**
+   * Returns a promise that is resolved only after the current call has been
+   * disconnected. Also see {@link connect}.
+   *
+   * @example
+   *
+   * ```js
+   * const plan = new Voice.DeviceBuilder().add(
+   *   Voice.DeviceBuilder.Sip({
+   *     from: 'sip:user1@domain.com',
+   *     to: 'sip:user2@domain.com',
+   *     timeout: 30,
+   *   })
+   * )
+   *
+   * const peer = await call.connect(plan)
+   * await call.disconnected()
+   * ```
+   */
+  disconnected(): Promise<this>
   waitFor(
     params: CallingCallWaitForState | CallingCallWaitForState[]
   ): Promise<boolean>

--- a/packages/core/src/types/voiceCall.ts
+++ b/packages/core/src/types/voiceCall.ts
@@ -493,7 +493,11 @@ export interface VoiceCallDetectContract {
   readonly type?: CallingCallDetectType
 
   stop(): Promise<this>
+  /**
+   * @deprecated use {@link ended} instead.
+   */
   waitForResult(): Promise<this>
+  ended(): Promise<this>
 }
 
 /**

--- a/packages/realtime-api/src/voice/Call.ts
+++ b/packages/realtime-api/src/voice/Call.ts
@@ -521,11 +521,12 @@ export class CallConsumer extends AutoApplyTransformsConsumer<RealTimeCallApiEve
         },
       })
         .then(() => {
-          const startEvent: CallingCallPlayEventParams = {
+          // We intentionally omit `state` since that
+          // property is handled internally by the instance.
+          const startEvent: Omit<CallingCallPlayEventParams, 'state'>= {
             control_id: controlId,
             call_id: this.id,
             node_id: this.nodeId,
-            state: 'playing',
           }
           // @ts-expect-error
           this.emit(callingPlaybackTriggerEvent, startEvent)

--- a/packages/realtime-api/src/voice/Call.ts
+++ b/packages/realtime-api/src/voice/Call.ts
@@ -1188,6 +1188,10 @@ export class CallConsumer extends AutoApplyTransformsConsumer<RealTimeCallApiEve
       this.once('connect.disconnected', resolveHandler)
       // @ts-expect-error
       this.once('connect.failed', resolveHandler)
+
+      if (this.state === 'ended' || this.state === 'ending') {
+        return resolveHandler()
+      }
     })
   }
 

--- a/packages/realtime-api/src/voice/Call.ts
+++ b/packages/realtime-api/src/voice/Call.ts
@@ -757,7 +757,7 @@ export class CallConsumer extends AutoApplyTransformsConsumer<RealTimeCallApiEve
    *     terminators: '#*'
    *   }
    * })
-   * const { type, digits, terminator } = await prompt.waitForResult()
+   * const { type, digits, terminator } = await prompt.ended()
    * ```
    */
   promptAudio(params: VoiceCallPromptAudioMethodParams) {
@@ -787,7 +787,7 @@ export class CallConsumer extends AutoApplyTransformsConsumer<RealTimeCallApiEve
    *     terminators: '#*'
    *   }
    * })
-   * const { type, digits, terminator } = await prompt.waitForResult()
+   * const { type, digits, terminator } = await prompt.ended()
    * ```
    */
   promptRingtone(params: VoiceCallPromptRingtoneMethodParams) {
@@ -818,7 +818,7 @@ export class CallConsumer extends AutoApplyTransformsConsumer<RealTimeCallApiEve
    *     terminators: '#*'
    *   }
    * })
-   * const { type, digits, terminator } = await prompt.waitForResult()
+   * const { type, digits, terminator } = await prompt.ended()
    * ```
    */
   promptTTS(params: VoiceCallPromptTTSMethodParams) {

--- a/packages/realtime-api/src/voice/Call.ts
+++ b/packages/realtime-api/src/voice/Call.ts
@@ -1261,7 +1261,7 @@ export class CallConsumer extends AutoApplyTransformsConsumer<RealTimeCallApiEve
    *
    * ```js
    * const detect = await call.amd()
-   * const result = await detect.waitForResult()
+   * const result = await detect.ended()
    *
    * console.log('Detect result:', result.type)
    * ```
@@ -1280,7 +1280,7 @@ export class CallConsumer extends AutoApplyTransformsConsumer<RealTimeCallApiEve
    *
    * ```js
    * const detect = await call.detectFax()
-   * const result = await detect.waitForResult()
+   * const result = await detect.ended()
    *
    * console.log('Detect result:', result.type)
    * ```
@@ -1299,7 +1299,7 @@ export class CallConsumer extends AutoApplyTransformsConsumer<RealTimeCallApiEve
    *
    * ```js
    * const detect = await call.detectDigit()
-   * const result = await detect.waitForResult()
+   * const result = await detect.ended()
    *
    * console.log('Detect result:', result.type)
    * ```

--- a/packages/realtime-api/src/voice/Call.ts
+++ b/packages/realtime-api/src/voice/Call.ts
@@ -135,6 +135,7 @@ export class CallConsumer extends AutoApplyTransformsConsumer<RealTimeCallApiEve
   public callId: string
   public nodeId: string
   public peer: string
+  public callState: string
 
   constructor(options: BaseComponentOptions<RealTimeCallApiEvents>) {
     super(options)
@@ -164,6 +165,10 @@ export class CallConsumer extends AutoApplyTransformsConsumer<RealTimeCallApiEve
   /** Unique id for this voice call */
   get id() {
     return this.callId
+  }
+
+  get state() {
+    return this.callState
   }
 
   get tag() {

--- a/packages/realtime-api/src/voice/Call.ts
+++ b/packages/realtime-api/src/voice/Call.ts
@@ -1173,7 +1173,7 @@ export class CallConsumer extends AutoApplyTransformsConsumer<RealTimeCallApiEve
   }
 
   /**
-   * @deprectated use {@link disconnected} instead.
+   * @deprecated use {@link disconnected} instead.
    */
   waitForDisconnected() {
     return this.disconnect

--- a/packages/realtime-api/src/voice/Call.ts
+++ b/packages/realtime-api/src/voice/Call.ts
@@ -39,6 +39,7 @@ import {
   VoiceCallDetectDigitParams,
   CallingCallDetectEventParams,
   VoiceDialerParams,
+  CallingCallWaitForState,
 } from '@signalwire/core'
 import { RealTimeCallApiEvents } from '../types'
 import { AutoApplyTransformsConsumer } from '../AutoApplyTransformsConsumer'
@@ -1325,7 +1326,7 @@ export class CallConsumer extends AutoApplyTransformsConsumer<RealTimeCallApiEve
    * await call.waitFor('ended')
    * ```
    */
-  waitFor(params: CallingCallState | CallingCallState[]) {
+  waitFor(params: CallingCallWaitForState | CallingCallWaitForState[]) {
     return new Promise((resolve) => {
       if (!params) {
         resolve(true)

--- a/packages/realtime-api/src/voice/Call.ts
+++ b/packages/realtime-api/src/voice/Call.ts
@@ -523,7 +523,7 @@ export class CallConsumer extends AutoApplyTransformsConsumer<RealTimeCallApiEve
         .then(() => {
           // We intentionally omit `state` since that
           // property is handled internally by the instance.
-          const startEvent: Omit<CallingCallPlayEventParams, 'state'>= {
+          const startEvent: Omit<CallingCallPlayEventParams, 'state'> = {
             control_id: controlId,
             call_id: this.id,
             node_id: this.nodeId,
@@ -1008,7 +1008,7 @@ export class CallConsumer extends AutoApplyTransformsConsumer<RealTimeCallApiEve
     return this.tap({ audio: { direction }, device })
   }
 
-   /**
+  /**
    * Attempt to connect an existing call to a new outbound call. You can wait
    * until the call is disconnected by calling {@link waitForDisconnected}.
    *

--- a/packages/realtime-api/src/voice/Call.ts
+++ b/packages/realtime-api/src/voice/Call.ts
@@ -1168,25 +1168,13 @@ export class CallConsumer extends AutoApplyTransformsConsumer<RealTimeCallApiEve
   }
 
   /**
-   * Returns a promise that is resolved only after the current call has been
-   * disconnected. Also see {@link connect}.
-   *
-   * @example
-   *
-   * ```js
-   * const plan = new Voice.DeviceBuilder().add(
-   *   Voice.DeviceBuilder.Sip({
-   *     from: 'sip:user1@domain.com',
-   *     to: 'sip:user2@domain.com',
-   *     timeout: 30,
-   *   })
-   * )
-   *
-   * const peer = await call.connect(plan)
-   * await call.waitForDisconnected()
-   * ```
+   * @deprectated use {@link disconnected} instead.
    */
   waitForDisconnected() {
+    return this.disconnect
+  }
+
+  disconnected() {
     return new Promise<this>((resolve) => {
       const resolveHandler = () => {
         resolve(this)

--- a/packages/realtime-api/src/voice/Call.ts
+++ b/packages/realtime-api/src/voice/Call.ts
@@ -545,7 +545,7 @@ export class CallConsumer extends AutoApplyTransformsConsumer<RealTimeCallApiEve
    *
    * ```js
    * const playback = await call.playAudio({ url: 'https://cdn.signalwire.com/default-music/welcome.mp3' });
-   * await playback.waitForEnded();
+   * await playback.ended();
    * ```
    */
   playAudio(params: VoiceCallPlayAudioMethodParams) {
@@ -561,7 +561,7 @@ export class CallConsumer extends AutoApplyTransformsConsumer<RealTimeCallApiEve
    *
    * ```js
    * const playback = await call.playSilence({ duration: 3 });
-   * await playback.waitForEnded();
+   * await playback.ended();
    * ```
    */
   playSilence(params: VoiceCallPlaySilenceMethodParams) {
@@ -576,7 +576,7 @@ export class CallConsumer extends AutoApplyTransformsConsumer<RealTimeCallApiEve
    *
    * ```js
    * const playback = await call.playRingtone({ name: 'it' });
-   * await playback.waitForEnded();
+   * await playback.ended();
    * ```
    */
   playRingtone(params: VoiceCallPlayRingtoneMethodParams) {
@@ -592,7 +592,7 @@ export class CallConsumer extends AutoApplyTransformsConsumer<RealTimeCallApiEve
    *
    * ```js
    * const playback = await call.playTTS({ text: 'Welcome to SignalWire!' });
-   * await playback.waitForEnded();
+   * await playback.ended();
    * ```
    */
   playTTS(params: VoiceCallPlayTTSMethodParams) {

--- a/packages/realtime-api/src/voice/CallDetect.ts
+++ b/packages/realtime-api/src/voice/CallDetect.ts
@@ -64,6 +64,14 @@ export class CallDetectAPI
 
       // @ts-expect-error
       this.once('detect.ended', () => {
+        // It's important to notice that we're returning
+        // `this` instead of creating a brand new instance
+        // using the payload + EventEmitter Transform
+        // pipeline. `this` is the instance created by the
+        // `Call` Emitter Transform pipeline (singleton per
+        // `Call.detect()`) that gets auto updated (using
+        // the latest payload per event) by the
+        // `voiceCallDetectWorker`
         resolve(this)
       })
     })

--- a/packages/realtime-api/src/voice/CallDetect.ts
+++ b/packages/realtime-api/src/voice/CallDetect.ts
@@ -53,7 +53,12 @@ export class CallDetectAPI
     return this
   }
 
+  /** @deprecated */
   waitForResult() {
+    return this.ended()
+  }
+
+  ended() {
     return new Promise<this>((resolve) => {
       this._attachListeners(this.controlId)
 

--- a/packages/realtime-api/src/voice/CallPlayback.ts
+++ b/packages/realtime-api/src/voice/CallPlayback.ts
@@ -4,7 +4,6 @@ import {
   BaseComponentOptions,
   VoiceCallPlaybackContract,
   CallingCallPlayState,
-  CallPlaybackEndedEvent,
 } from '@signalwire/core'
 
 /**

--- a/packages/realtime-api/src/voice/CallPlayback.ts
+++ b/packages/realtime-api/src/voice/CallPlayback.ts
@@ -98,7 +98,12 @@ export class CallPlaybackAPI
     return this
   }
 
+  /** @deprecated */
   waitForEnded() {
+    return this.ended()
+  }
+
+  ended() {
     return new Promise<this>((resolve) => {
       this._attachListeners(this.controlId)
 

--- a/packages/realtime-api/src/voice/CallPlayback.ts
+++ b/packages/realtime-api/src/voice/CallPlayback.ts
@@ -108,15 +108,17 @@ export class CallPlaybackAPI
     return new Promise<this>((resolve) => {
       this._attachListeners(this.controlId)
 
-      const handler = (payload: CallPlaybackEndedEvent['params']) => {
-        // This object gets created every time we call
-        // `Call.play()`, instead of creating a brand new
-        // object through the Emitter Transform we're
-        // reusing that same instance created from `Call`
-        // (and its Emitter Transform). Only thing we're
-        // doing is to update the state of this object with
-        // the lastes payload received from the server.
-        this.state = payload.state
+      const handler = () => {
+        // @ts-expect-error
+        this.off('playback.ended', handler)
+        // It's important to notice that we're returning
+        // `this` instead of creating a brand new instance
+        // using the payload + EventEmitter Transform
+        // pipeline. `this` is the instance created by the
+        // `Call` Emitter Transform pipeline (singleton per
+        // `Call.play()`) that gets auto updated (using
+        // the latest payload per event) by the
+        // `voiceCallPlayWorker`
         resolve(this)
       }
       // @ts-expect-error

--- a/packages/realtime-api/src/voice/CallPlayback.ts
+++ b/packages/realtime-api/src/voice/CallPlayback.ts
@@ -109,8 +109,6 @@ export class CallPlaybackAPI
       this._attachListeners(this.controlId)
 
       const handler = () => {
-        // @ts-expect-error
-        this.off('playback.ended', handler)
         // It's important to notice that we're returning
         // `this` instead of creating a brand new instance
         // using the payload + EventEmitter Transform

--- a/packages/realtime-api/src/voice/CallPlayback.ts
+++ b/packages/realtime-api/src/voice/CallPlayback.ts
@@ -4,6 +4,7 @@ import {
   BaseComponentOptions,
   VoiceCallPlaybackContract,
   CallingCallPlayState,
+  CallPlaybackEndedEvent,
 } from '@signalwire/core'
 
 /**
@@ -107,7 +108,17 @@ export class CallPlaybackAPI
     return new Promise<this>((resolve) => {
       this._attachListeners(this.controlId)
 
-      const handler = () => resolve(this)
+      const handler = (payload: CallPlaybackEndedEvent['params']) => {
+        // This object gets created every time we call
+        // `Call.play()`, instead of creating a brand new
+        // object through the Emitter Transform we're
+        // reusing that same instance created from `Call`
+        // (and its Emitter Transform). Only thing we're
+        // doing is to update the state of this object with
+        // the lastes payload received from the server.
+        this.state = payload.state
+        resolve(this)
+      }
       // @ts-expect-error
       this.once('playback.ended', handler)
       // // @ts-expect-error

--- a/packages/realtime-api/src/voice/CallPrompt.ts
+++ b/packages/realtime-api/src/voice/CallPrompt.ts
@@ -141,11 +141,16 @@ export class CallPromptAPI
     return this
   }
 
+  /** @deprecated */
   waitForResult() {
-    return new Promise<CallPrompt>((resolve) => {
+    return this.ended()
+  }
+
+  ended() {
+    return new Promise<this>((resolve) => {
       this._attachListeners(this.controlId)
 
-      const handler = (callPrompt: CallPrompt) => {
+      const handler = (callPrompt: this) => {
         // @ts-expect-error
         this.off('prompt.ended', handler)
         // @ts-expect-error

--- a/packages/realtime-api/src/voice/CallPrompt.ts
+++ b/packages/realtime-api/src/voice/CallPrompt.ts
@@ -118,16 +118,19 @@ export class CallPromptAPI
   ended() {
     return new Promise<this>((resolve) => {
       this._attachListeners(this.controlId)
-
-      const handler = (callPrompt: CallPromptEndedEvent['params']) => {
-        // This object gets created every time we call
-        // `Call.prompt()`, instead of creating a brand new
-        // object through the Emitter Transform we're
-        // reusing that same instance created from `Call`
-        // (and its Emitter Transform). Only thing we're
-        // doing is to update the state of this object with
-        // the lastes payload received from the server.
-        this.result = callPrompt.result
+      const handler = (_callPrompt: CallPromptEndedEvent['params']) => {
+        // @ts-expect-error
+        this.off('prompt.ended', handler)
+        // @ts-expect-error
+        this.off('prompt.failed', handler)
+        // It's important to notice that we're returning
+        // `this` instead of creating a brand new instance
+        // using the payload + EventEmitter Transform
+        // pipeline. `this` is the instance created by the
+        // `Call` Emitter Transform pipeline (singleton per
+        // `Call.prompt()`) that gets auto updated (using
+        // the latest payload per event) by the
+        // `voiceCallPromptWorker`
         resolve(this)
       }
       // @ts-expect-error

--- a/packages/realtime-api/src/voice/CallPrompt.ts
+++ b/packages/realtime-api/src/voice/CallPrompt.ts
@@ -120,6 +120,13 @@ export class CallPromptAPI
       this._attachListeners(this.controlId)
 
       const handler = (callPrompt: CallPromptEndedEvent['params']) => {
+        // This object gets created every time we call
+        // `Call.prompt()`, instead of creating a brand new
+        // object through the Emitter Transform we're
+        // reusing that same instance created from `Call`
+        // (and its Emitter Transform). Only thing we're
+        // doing is to update the state of this object with
+        // the lastes payload received from the server.
         this.result = callPrompt.result
         resolve(this)
       }

--- a/packages/realtime-api/src/voice/CallPrompt.ts
+++ b/packages/realtime-api/src/voice/CallPrompt.ts
@@ -3,16 +3,9 @@ import {
   BaseComponentOptions,
   VoiceCallPromptContract,
   CallingCallCollectResult,
-  EventTransform,
-  toExternalJSON,
+  BaseComponent,
+  CallPromptEndedEvent,
 } from '@signalwire/core'
-import { AutoApplyTransformsConsumer } from '../AutoApplyTransformsConsumer'
-
-type EmitterTransformsEvents =
-  | 'calling.prompt.started'
-  | 'calling.prompt.updated'
-  | 'calling.prompt.ended'
-  | 'calling.prompt.failed'
 
 /**
  * Instances of this class allow you to control (e.g., resume) the
@@ -28,7 +21,7 @@ export interface CallPromptOptions
   extends BaseComponentOptions<CallPromptEventsHandlerMapping> {}
 
 export class CallPromptAPI
-  extends AutoApplyTransformsConsumer<CallPromptEventsHandlerMapping>
+  extends BaseComponent<CallPromptEventsHandlerMapping>
   implements VoiceCallPromptContract
 {
   protected _eventsPrefix = 'calling' as const
@@ -37,30 +30,6 @@ export class CallPromptAPI
   nodeId: string
   controlId: string
   result?: CallingCallCollectResult
-
-  /** @internal */
-  protected getEmitterTransforms() {
-    return new Map<
-      EmitterTransformsEvents | EmitterTransformsEvents[],
-      EventTransform
-    >([
-      [
-        ['calling.prompt.ended', 'calling.prompt.failed'],
-        {
-          type: 'voiceCallPrompt',
-          instanceFactory: (_payload: any) => {
-            return createCallPromptObject({
-              store: this.store,
-              emitter: this.emitter,
-            })
-          },
-          payloadTransform: (payload: any) => {
-            return toExternalJSON(payload)
-          },
-        },
-      ],
-    ])
-  }
 
   get id() {
     return this.controlId
@@ -150,15 +119,10 @@ export class CallPromptAPI
     return new Promise<this>((resolve) => {
       this._attachListeners(this.controlId)
 
-      const handler = (callPrompt: this) => {
-        // @ts-expect-error
-        this.off('prompt.ended', handler)
-        // @ts-expect-error
-        this.off('prompt.failed', handler)
-
-        resolve(callPrompt)
+      const handler = (callPrompt: CallPromptEndedEvent['params']) => {
+        this.result = callPrompt.result
+        resolve(this)
       }
-
       // @ts-expect-error
       this.once('prompt.ended', handler)
       // @ts-expect-error

--- a/packages/realtime-api/src/voice/CallRecording.ts
+++ b/packages/realtime-api/src/voice/CallRecording.ts
@@ -49,6 +49,25 @@ export class CallRecordingAPI
 
     return this
   }
+
+  ended() {
+    return new Promise<this>((resolve) => {
+      this._attachListeners(this.controlId)
+      const handler = (instance: this) => {
+        // @ts-expect-error
+        this.off('recording.ended', handler)
+        // @ts-expect-error
+        this.off('recording.failed', handler)
+
+        resolve(instance)
+      }
+      // @ts-expect-error
+      this.once('recording.ended', handler)
+      // TODO: review what else to return when `recording.failed` happens.
+      // @ts-expect-error
+      this.once('recording.failed', handler)
+    })
+  }
 }
 
 export const createCallRecordingObject = (

--- a/packages/realtime-api/src/voice/CallTap.ts
+++ b/packages/realtime-api/src/voice/CallTap.ts
@@ -46,6 +46,26 @@ export class CallTapAPI
 
     return this
   }
+
+  ended() {
+    return new Promise<this>((resolve) => {
+      this._attachListeners(this.controlId)
+
+      const handler = () => {
+        // It's important to notice that we're returning
+        // `this` instead of creating a brand new instance
+        // using the payload + EventEmitter Transform
+        // pipeline. `this` is the instance created by the
+        // `Call` Emitter Transform pipeline (singleton per
+        // `Call.tap()`) that gets auto updated (using
+        // the latest payload per event) by the
+        // `voiceCallTapWorker`
+        resolve(this)
+      }
+      // @ts-expect-error
+      this.once('tap.ended', handler)
+    })
+  }
 }
 
 export const createCallTapObject = (params: CallTapOptions): CallTap => {

--- a/packages/realtime-api/src/voice/workers/voiceCallDetectWorker.ts
+++ b/packages/realtime-api/src/voice/workers/voiceCallDetectWorker.ts
@@ -102,7 +102,7 @@ export const voiceCallDetectWorker: SDKWorker<Call> = function* (
 
   if (lastAction) {
     /**
-     * On endef, dispatch an event to resolve `waitForResult` in CallDetect
+     * On endef, dispatch an event to resolve `ended` in CallDetect
      * overriding the `tag` to be the controlId
      */
     yield sagaEffects.put(pubSubChannel, {

--- a/packages/realtime-api/src/voice/workers/voiceCallPlayWorker.ts
+++ b/packages/realtime-api/src/voice/workers/voiceCallPlayWorker.ts
@@ -71,7 +71,7 @@ export const voiceCallPlayWorker: SDKWorker<Call> = function* (
         })
 
         /**
-         * Dispatch an event to resolve `waitForEnded` in CallPlayback
+         * Dispatch an event to resolve `ended()` in CallPlayback
          * when ended
          */
         yield sagaEffects.put(pubSubChannel, {

--- a/packages/realtime-api/src/voice/workers/voiceCallPlayWorker.ts
+++ b/packages/realtime-api/src/voice/workers/voiceCallPlayWorker.ts
@@ -8,6 +8,7 @@ import {
   MapToPubSubShape,
 } from '@signalwire/core'
 import type { Call } from '../Call'
+import { callingPlaybackTriggerEvent } from '../Call'
 
 export const voiceCallPlayWorker: SDKWorker<Call> = function* (
   options
@@ -38,6 +39,17 @@ export const voiceCallPlayWorker: SDKWorker<Call> = function* (
       tag: instance.tag,
       ...action.payload,
     }
+
+    /**
+     * Update the original CallPlayback object using the
+     * transform pipeline
+     */
+     yield sagaEffects.put(pubSubChannel, {
+      // @ts-ignore
+      type: callingPlaybackTriggerEvent,
+      // @ts-ignore
+      payload: payloadWithTag,
+    })
 
     switch (action.payload.state) {
       case 'playing': {

--- a/packages/realtime-api/src/voice/workers/voiceCallPromptWorker.ts
+++ b/packages/realtime-api/src/voice/workers/voiceCallPromptWorker.ts
@@ -74,7 +74,7 @@ export const voiceCallPromptWorker: SDKWorker<Call> = function* (
       })
 
       /**
-       * Dispatch an event to resolve `waitForResult` in CallPrompt
+       * Dispatch an event to resolve `ended` in CallPrompt
        * when ended
        */
       yield sagaEffects.put(pubSubChannel, {

--- a/packages/realtime-api/src/voice/workers/voiceCallRecordWorker.ts
+++ b/packages/realtime-api/src/voice/workers/voiceCallRecordWorker.ts
@@ -58,29 +58,16 @@ export const voiceCallRecordWorker: SDKWorker<Call> = function* (
         })
         break
       }
+
       case 'no_input':
-        yield sagaEffects.put(pubSubChannel, {
-          type: 'calling.recording.failed',
-          payload: payloadWithTag,
-        })
-
-        /**
-         * Dispatch an event to resolve `ended()` in CallRecord
-         * when ended
-         */
-         yield sagaEffects.put(pubSubChannel, {
-          type: 'calling.recording.failed',
-          payload: {
-            tag: controlId,
-            ...action.payload,
-          },
-        })
-
-        done()
-        break
       case 'finished': {
+        const typeToEmit =
+          action.payload.state === 'finished'
+            ? 'calling.recording.ended'
+            : 'calling.recording.failed'
+
         yield sagaEffects.put(pubSubChannel, {
-          type: 'calling.recording.ended',
+          type: typeToEmit,
           payload: payloadWithTag,
         })
 
@@ -89,7 +76,7 @@ export const voiceCallRecordWorker: SDKWorker<Call> = function* (
          * when ended
          */
         yield sagaEffects.put(pubSubChannel, {
-          type: 'calling.recording.ended',
+          type: typeToEmit,
           payload: {
             tag: controlId,
             ...action.payload,

--- a/packages/realtime-api/src/voice/workers/voiceCallRecordWorker.ts
+++ b/packages/realtime-api/src/voice/workers/voiceCallRecordWorker.ts
@@ -64,12 +64,36 @@ export const voiceCallRecordWorker: SDKWorker<Call> = function* (
           payload: payloadWithTag,
         })
 
+        /**
+         * Dispatch an event to resolve `ended()` in CallRecord
+         * when ended
+         */
+         yield sagaEffects.put(pubSubChannel, {
+          type: 'calling.recording.failed',
+          payload: {
+            tag: controlId,
+            ...action.payload,
+          },
+        })
+
         done()
         break
       case 'finished': {
         yield sagaEffects.put(pubSubChannel, {
           type: 'calling.recording.ended',
           payload: payloadWithTag,
+        })
+
+        /**
+         * Dispatch an event to resolve `ended()` in CallRecord
+         * when ended
+         */
+        yield sagaEffects.put(pubSubChannel, {
+          type: 'calling.recording.ended',
+          payload: {
+            tag: controlId,
+            ...action.payload,
+          },
         })
 
         done()

--- a/packages/realtime-api/src/voice/workers/voiceCallTapWorker.ts
+++ b/packages/realtime-api/src/voice/workers/voiceCallTapWorker.ts
@@ -63,6 +63,17 @@ export const voiceCallTapWorker: SDKWorker<Call> = function* (
           payload: payloadWithTag,
         })
 
+        /**
+         * Dispatch an event to resolve `ended()` in CallTap when ended
+         */
+        yield sagaEffects.put(pubSubChannel, {
+          type: 'calling.tap.ended',
+          payload: {
+            tag: controlId,
+            ...action.payload,
+          },
+        })
+
         done()
         break
       }


### PR DESCRIPTION
## Task list

- [x] `play()`
  - [x] deprecate `waitForEnded` in favour of `ended()`
  - [x] this should cover all the playX methods
- [x] `record()`
  - [x] add `ended()`
  - [x] this should cover all the recordX methods
- [x] `prompt()`
  - [x] deprecate `waitForResult` in favour of `ended()`
  - [x] this should cover all the promptX methods
- [ ] `tap()`
  - [ ] add `ended()`
  - [ ] this should cover all the tapX methods
- [x] `detect()`
  - [x] deprecate `waitForResult` in favour of `ended()`
  - [x] this should cover all the detectX methods
- [x] Check why we’re using `AutoApplyTransformsConsumer` on `CallPrompt` and not in other constructors -> normalize usage
- [x] `Call.waitFor` remains the same with the exception of fixing the internal typings (it currently accepts more than ended/ending)
- [x] `Call.waitForDisconnected` is deprecated in favour of `Call.disconnected()`
