### PR TITLE
Restore changesets removed for release

### DIFF
--- a/.changeset/hip-toys-sparkle.md
+++ b/.changeset/hip-toys-sparkle.md
@@ -1,0 +1,6 @@
+---
+'@signalwire/core': patch
+'@signalwire/realtime-api': patch
+---
+
+[internal] add `addContexts` and `removeContexts` methods

--- a/.changeset/new-donuts-return.md
+++ b/.changeset/new-donuts-return.md
@@ -1,0 +1,7 @@
+---
+'@signalwire/core': minor
+'@signalwire/js': minor
+'@signalwire/realtime-api': minor
+---
+
+Add `promote`/`demote` methods to RoomSession

--- a/.changeset/rotten-crews-hope.md
+++ b/.changeset/rotten-crews-hope.md
@@ -1,0 +1,6 @@
+---
+'@signalwire/core': patch
+'@signalwire/webrtc': patch
+---
+
+[internal] add worker to handle promoted/demoted events and trigger the proper renegotiation

--- a/.changeset/strong-lobsters-compete.md
+++ b/.changeset/strong-lobsters-compete.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/js': minor
+---
+
+[internal] Add RoomSession.joinAudience method

--- a/.changeset/three-mayflies-pretend.md
+++ b/.changeset/three-mayflies-pretend.md
@@ -1,0 +1,7 @@
+---
+'@signalwire/core': patch
+'@signalwire/js': patch
+'@signalwire/realtime-api': patch
+---
+
+Expose the `room.audience_count` event on the RoomSession


### PR DESCRIPTION
In https://github.com/signalwire/signalwire-js/pull/622 i skipped some changesets removing from them from tree. Just restoring them