### PR TITLE
hotfix: Skip cache usage for realtime-api clients

### DIFF
--- a/.changeset/fluffy-pears-dress.md
+++ b/.changeset/fluffy-pears-dress.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/realtime-api': patch
+---
+
+Stop caching realtime-api clients to avoid race on disconnect/reconnect.

--- a/internal/e2e-realtime-api/src/disconnectClient.test.ts
+++ b/internal/e2e-realtime-api/src/disconnectClient.test.ts
@@ -1,0 +1,68 @@
+import { PubSub } from '@signalwire/realtime-api'
+import { createTestRunner } from './utils'
+
+const handler = () => {
+  return new Promise<number>(async (resolve) => {
+    const clientOptions = {
+      host: process.env.RELAY_HOST,
+      project: process.env.RELAY_PROJECT,
+      token: process.env.RELAY_TOKEN,
+    }
+
+    const clientOne = new PubSub.Client({
+      ...clientOptions,
+      debug: {
+        logWsTraffic: false,
+      },
+    })
+
+    const channel = 'rw'
+    const meta = { foo: 'bar' }
+    const content = 'Hello World'
+
+    await clientOne.publish({
+      channel,
+      content,
+      meta,
+    })
+
+    clientOne.disconnect()
+
+    const clientTwo = new PubSub.Client({
+      ...clientOptions,
+      debug: {
+        logWsTraffic: false,
+      },
+    })
+
+    await clientTwo.subscribe(channel)
+    clientTwo.on('message', (message) => {
+      if (message.meta.foo === 'bar' && message.content === 'Hello World') {
+        resolve(0)
+      }
+    })
+
+    const clientThree = new PubSub.Client({
+      ...clientOptions,
+      debug: {
+        logWsTraffic: false,
+      },
+    })
+    await clientThree.publish({
+      channel,
+      content,
+      meta,
+    })
+  })
+}
+
+async function main() {
+  const runner = createTestRunner({
+    name: 'Disconnect Client Tests',
+    testHandler: handler,
+  })
+
+  await runner.run()
+}
+
+main()

--- a/packages/realtime-api/src/client/getClient.test.ts
+++ b/packages/realtime-api/src/client/getClient.test.ts
@@ -2,7 +2,7 @@ import { configureFullStack } from '../testUtils'
 import { getClient } from './getClient'
 
 describe('getClient', () => {
-  it('should cache clients by project and key', () => {
+  it.skip('should cache clients by project and key', () => {
     const { store, emitter, destroy } = configureFullStack()
     const options = {
       project: 'a-proj',

--- a/packages/realtime-api/src/client/getClient.ts
+++ b/packages/realtime-api/src/client/getClient.ts
@@ -18,15 +18,15 @@ export type ClientCache = Map<string, ClientConfig>
 
 const CLIENTS_MAP: ClientCache = new Map()
 
-const getClientKey = ({
-  project,
-  token,
-}: {
-  project: string
-  token: string
-}) => {
-  return `${project}:${token}`
-}
+// const getClientKey = ({
+//   project,
+//   token,
+// }: {
+//   project: string
+//   token: string
+// }) => {
+//   return `${project}:${token}`
+// }
 
 const createClient = (userOptions: {
   project: string
@@ -56,27 +56,27 @@ export const getClient = ({
   logLevel?: UserOptions['logLevel']
   cache?: ClientCache
 }): ClientConfig => {
-  const clientKey = getClientKey({
-    project: userOptions.project,
-    token: userOptions.token,
-  })
+  // const clientKey = getClientKey({
+  //   project: userOptions.project,
+  //   token: userOptions.token,
+  // })
 
-  if (cache.has(clientKey)) {
-    // @ts-expect-error
-    return cache.get(clientKey)
-  } else {
-    const { emitter, store } = setupInternals(userOptions)
-    const client = createClient({
-      ...userOptions,
-      store,
-      emitter,
-    })
-    const config: ClientConfig = {
-      client,
-      store,
-      emitter,
-    }
-    cache.set(clientKey, config)
-    return config
+  // if (cache.has(clientKey)) {
+  //   // @ts-expect-error
+  //   return cache.get(clientKey)
+  // } else {
+  const { emitter, store } = setupInternals(userOptions)
+  const client = createClient({
+    ...userOptions,
+    store,
+    emitter,
+  })
+  const config: ClientConfig = {
+    client,
+    store,
+    emitter,
   }
+  // cache.set(clientKey, config)
+  return config
+  // }
 }


### PR DESCRIPTION
Need to review the cache usage on realtime-api. This is an hotfix to resolve the issue on the next `@dev` version.