### PR TITLE
Fix member.updated event in case of missing entry in cache

### DIFF
--- a/.changeset/seven-houses-cheat.md
+++ b/.changeset/seven-houses-cheat.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/core': patch
+---
+
+Dispatch `member.updated` event in case of the local cache is empty.

--- a/packages/core/src/memberPosition/workers.ts
+++ b/packages/core/src/memberPosition/workers.ts
@@ -148,6 +148,16 @@ export const memberPositionWorker: SDKWorker<any> =
     const { swEventChannel } = channels
     let memberList = initializeMemberList(initialState)
 
+    const addToMemberList = (payload: VideoMemberUpdatedEventParams) => {
+      /**
+       * Add to memberList for both `member.joined` and `member.updated`
+       * note: changes made for audience users.
+       */
+      if (!memberList.has(payload.member.id)) {
+        memberList.set(payload.member.id, payload)
+      }
+    }
+
     while (true) {
       const action = yield sagaEffects.take(swEventChannel, (action: any) => {
         const istargetEvent =
@@ -164,6 +174,7 @@ export const memberPositionWorker: SDKWorker<any> =
 
       switch (action.type) {
         case 'video.member.updated': {
+          addToMemberList(action.payload)
           yield fork(memberUpdatedWorker, {
             action,
             channels,
@@ -173,8 +184,7 @@ export const memberPositionWorker: SDKWorker<any> =
           break
         }
         case 'video.member.joined': {
-          const member = action.payload.member
-          memberList.set(member.id, action.payload)
+          addToMemberList(action.payload)
           break
         }
         case 'video.member.left': {

--- a/packages/core/src/redux/features/session/sessionSaga.ts
+++ b/packages/core/src/redux/features/session/sessionSaga.ts
@@ -143,6 +143,7 @@ export function* sessionChannelWatcher({
       }
       case 'video.member.updated': {
         /**
+         * @see memberUpdatedWorker in packages/core/src/memberPosition/workers.ts
          * `video.member.updated` is handled by the
          * layoutWorker so to avoid dispatching the event
          * twice (or with incomplete data) we'll early


### PR DESCRIPTION
The new `audience` users can have the memberList cache empty. On member.updated, just fill the cache with the value from the backend to solve the issue.