### PR TITLE
Add new arguments to promote/demote methods

### DIFF
--- a/.changeset/honest-turtles-cheat.md
+++ b/.changeset/honest-turtles-cheat.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/core': patch
+---
+
+Add optional arguments on `promote` to pass meta, joinAudioMuted and joinVideoMuted. Add optional `meta` argument for `demote`.

--- a/internal/e2e-js/tests/roomSessionPromoteDemote.spec.ts
+++ b/internal/e2e-js/tests/roomSessionPromoteDemote.spec.ts
@@ -1,0 +1,176 @@
+import { test, expect } from '@playwright/test'
+import type { Video } from '@signalwire/js'
+import { createTestServer, createTestRoomSession } from '../utils'
+
+test.describe('RoomSession promote/demote methods', () => {
+  let server: any = null
+
+  test.beforeAll(async () => {
+    server = await createTestServer()
+    await server.start()
+  })
+
+  test.afterAll(async () => {
+    await server.close()
+  })
+
+  test('should promote/demote audience', async ({ context }) => {
+    const pageOne = await context.newPage()
+    const pageTwo = await context.newPage()
+
+    pageOne.on('console', (log) => console.log('[pageOne]', log))
+    pageTwo.on('console', (log) => console.log('[pageTwo]', log))
+
+    await Promise.all([pageOne.goto(server.url), pageTwo.goto(server.url)])
+
+    const memberSettings = {
+      vrt: {
+        room_name: 'promotion-room',
+        user_name: 'e2e_member',
+        auto_create_room: true,
+        permissions: ['room.member.demote', 'room.member.promote'],
+      },
+      initialEvents: ['member.joined', 'member.updated', 'member.left'],
+    }
+
+    const audienceSettings = {
+      vrt: {
+        room_name: 'promotion-room',
+        user_name: 'e2e_audience',
+        join_as: 'audience' as const,
+        auto_create_room: true,
+        permissions: [],
+      },
+      initialEvents: ['member.joined', 'member.updated', 'member.left'],
+    }
+
+    await Promise.all([
+      createTestRoomSession(pageOne, memberSettings),
+      createTestRoomSession(pageTwo, audienceSettings),
+    ])
+
+    const expectAudienceSDP = async (direction: string, value: boolean) => {
+      const pageTwoSDP = await pageTwo.evaluate(async () => {
+        // @ts-expect-error
+        const roomObj: Video.RoomSession = window._roomObj
+        // @ts-expect-error
+        return roomObj.peer.localSdp
+      })
+
+      expect(pageTwoSDP.split('m=')[1].includes(direction)).toBe(value)
+      expect(pageTwoSDP.split('m=')[2].includes(direction)).toBe(value)
+    }
+
+    // --------------- Joining from the 1st tab as member and resolve on 'room.joined' ---------------
+    await pageOne.evaluate(() => {
+      return new Promise((resolve) => {
+        // @ts-expect-error
+        const roomObj = window._roomObj
+        roomObj.on('room.joined', resolve)
+        roomObj.join()
+      })
+    })
+
+    // Checks that the video is visible on pageOne
+    await pageOne.waitForSelector('div[id^="sw-sdk-"] > video', {
+      timeout: 5000,
+    })
+
+    // --------------- Joining from the 2st tab as audience and resolve on 'room.joined' ---------------
+    const pageTwoRoomJoined: any = await pageTwo.evaluate(() => {
+      return new Promise((resolve) => {
+        // @ts-expect-error
+        const roomObj = window._roomObj
+        roomObj.on('room.joined', resolve)
+        roomObj.join()
+      })
+    })
+
+    // --------------- Check SDP/RTCPeer on audience (recvonly since audience) ---------------
+    expectAudienceSDP('recvonly', true)
+
+    // Checks that the video is visible on pageTwo
+    await pageTwo.waitForSelector('#rootElement video', {
+      timeout: 10000,
+    })
+
+    // --------------- Promote audience from pageOne and resolve on `member.joined` ---------------
+    await pageOne.evaluate(
+      async ({ promoteMemberId }) => {
+        // @ts-expect-error
+        const roomObj: Video.RoomSession = window._roomObj
+
+        const waitForMemberJoined = new Promise((resolve, reject) => {
+          roomObj.on('member.joined', ({ member }) => {
+            if (member.name === 'e2e_audience') {
+              resolve(true)
+            } else {
+              reject(new Error('[member.joined] Name is not "e2e_audience"'))
+            }
+          })
+        })
+
+        await roomObj.promote({
+          memberId: promoteMemberId,
+          permissions: ['room.list_available_layouts'],
+        })
+
+        return waitForMemberJoined
+      },
+      { promoteMemberId: pageTwoRoomJoined.member_id }
+    )
+
+    await pageTwo.waitForTimeout(2000)
+
+    // --------------- Check SDP/RTCPeer on audience (now member so sendrecv) ---------------
+    expectAudienceSDP('sendrecv', true)
+
+    await pageTwo.waitForTimeout(2000)
+
+    const pageTwoMemberId = await pageTwo.evaluate(async () => {
+      // @ts-expect-error
+      const roomObj: Video.RoomSession = window._roomObj
+      return roomObj.memberId
+    })
+
+    // --------------- Demote to audience again from pageOne and resolve on `member.left` ---------------
+    await pageOne.evaluate(
+      async ({ demoteMemberId }) => {
+        // @ts-expect-error
+        const roomObj: Video.RoomSession = window._roomObj
+
+        const waitForMemberLeft = new Promise((resolve, reject) => {
+          roomObj.on('member.left', ({ member }) => {
+            if (member.name === 'e2e_audience') {
+              resolve(true)
+            } else {
+              reject(new Error('[member.left] Name is not "e2e_audience"'))
+            }
+          })
+        })
+
+        await roomObj.demote({
+          memberId: demoteMemberId,
+        })
+
+        return waitForMemberLeft
+      },
+      { demoteMemberId: pageTwoMemberId }
+    )
+
+    await pageTwo.waitForTimeout(2000)
+
+    // --------------- Check SDP/RTCPeer on audience (audience again so recvonly) ---------------
+    expectAudienceSDP('recvonly', true)
+
+    await pageTwo.waitForTimeout(2000)
+
+    // --------------- Leaving the rooms ---------------
+    await Promise.all([
+      // @ts-expect-error
+      pageOne.evaluate(() => window._roomObj.leave()),
+      // @ts-expect-error
+      pageTwo.evaluate(() => window._roomObj.leave()),
+    ])
+  })
+})

--- a/internal/e2e-js/utils.ts
+++ b/internal/e2e-js/utils.ts
@@ -98,6 +98,8 @@ interface CreateTestVRTOptions {
   remove_at?: number | string
   remove_after_seconds_elapsed?: number
   auto_create_room?: boolean
+  join_as?: 'member' | 'audience'
+  media_allowed?: 'audio-only' | 'audio-only' | 'all'
 }
 
 export const createTestVRTToken = async (body: CreateTestVRTOptions) => {

--- a/packages/core/src/rooms/methods.ts
+++ b/packages/core/src/rooms/methods.ts
@@ -481,42 +481,61 @@ export const setInputSensitivityMember = createRoomMemberMethod<
 
 interface PromoteDemoteMemberParams extends Required<MemberCommandParams> {
   mediaAllowed?: MediaAllowed
+  meta?: VideoMeta
 }
 
-const createMemberPromoteDemoteMethod = <
-  OutputType,
-  ParamsType extends PromoteDemoteMemberParams
->(
-  method: 'video.member.promote' | 'video.member.demote'
-): RoomMethodDescriptor<OutputType, ParamsType> => {
-  return {
-    value: function ({ memberId, mediaAllowed, ...rest }) {
-      return this.execute<unknown, OutputType, ParamsType>(
-        {
-          method,
-          params: {
-            room_session_id: this.roomSessionId,
-            member_id: memberId,
-            media_allowed: mediaAllowed,
-            ...rest,
-          },
-        },
-        {
-          transformResolve: baseCodeTransform as any,
-        }
-      )
-    },
-  }
-}
 export interface PromoteMemberParams extends PromoteDemoteMemberParams {
   permissions?: string[]
+  joinAudioMuted?: boolean
+  joinVideoMuted?: boolean
 }
-export const promote: RoomMethodDescriptor<void, PromoteMemberParams> =
-  createMemberPromoteDemoteMethod('video.member.promote')
+export const promote: RoomMethodDescriptor<void, PromoteMemberParams> = {
+  value: function ({
+    memberId,
+    mediaAllowed,
+    joinAudioMuted,
+    joinVideoMuted,
+    ...rest
+  }) {
+    return this.execute<unknown, void, PromoteMemberParams>(
+      {
+        method: 'video.member.promote',
+        params: {
+          room_session_id: this.roomSessionId,
+          member_id: memberId,
+          media_allowed: mediaAllowed,
+          join_audio_muted: joinAudioMuted,
+          join_video_muted: joinVideoMuted,
+          ...rest,
+        },
+      },
+      {
+        transformResolve: baseCodeTransform as any,
+      }
+    )
+  },
+}
 
 export interface DemoteMemberParams extends PromoteDemoteMemberParams {}
-export const demote: RoomMethodDescriptor<void, DemoteMemberParams> =
-  createMemberPromoteDemoteMethod('video.member.demote')
+export const demote: RoomMethodDescriptor<void, DemoteMemberParams> = {
+  value: function ({ memberId, mediaAllowed, ...rest }) {
+    return this.execute<unknown, void, DemoteMemberParams>(
+      {
+        method: 'video.member.demote',
+        params: {
+          room_session_id: this.roomSessionId,
+          member_id: memberId,
+          media_allowed: mediaAllowed,
+          ...rest,
+        },
+      },
+      {
+        transformResolve: baseCodeTransform as any,
+      }
+    )
+  },
+}
+
 export interface SetMemberPositionParams extends MemberCommandParams {
   position: VideoPosition
 }


### PR DESCRIPTION
Replaces https://github.com/signalwire/signalwire-js/pull/632 (cherry-picked the only commit on it).

This PR also includes e2e tests for the whole promote/demote process.