### PR TITLE
E2E tests: stop recording after playback ended

### DIFF
--- a/.changeset/witty-adults-provide.md
+++ b/.changeset/witty-adults-provide.md
@@ -1,0 +1,5 @@
+---
+'@sw-internal/e2e-realtime-api': patch
+---
+
+[internal] Stop recording after playback ended

--- a/internal/e2e-realtime-api/src/voice.test.ts
+++ b/internal/e2e-realtime-api/src/voice.test.ts
@@ -53,14 +53,10 @@ const handler = () => {
           inputSensitivity: 60,
         })
         tap.ok(recording.id, 'Recording started')
-
-        console.log('Stopping the recording.')
-        recording.stop()
-        const recordingEndedResult = await recording.ended()
         tap.equal(
-          recordingEndedResult.state,
-          'finished',
-          'Recording state is "finished"'
+          recording.state,
+          'recording',
+          'Recording state is "recording"'
         )
 
         const playlist = new Voice.Playlist({ volume: 2 }).add(
@@ -80,6 +76,15 @@ const handler = () => {
           'Playback state is "finished"'
         )
         tap.pass('Playback ended')
+
+        console.log('Stopping the recording')
+        recording.stop()
+        const recordingEndedResult = await recording.ended()
+        tap.equal(
+          recordingEndedResult.state,
+          'finished',
+          'Recording state is "finished"'
+        )
 
         call.on('prompt.started', (p) => {
           tap.ok(p.id, 'Prompt has started')


### PR DESCRIPTION
Just moved the "recording stop" logic after the playback ended