### PR TITLE
Always reconnect on WS close

### DIFF
--- a/.changeset/many-turkeys-rule.md
+++ b/.changeset/many-turkeys-rule.md
@@ -1,0 +1,7 @@
+---
+'@signalwire/core': patch
+'@signalwire/js': patch
+'@signalwire/webrtc': patch
+---
+
+[internal] Review internals to always reconnect the SDKs expect for when the user disconnects the clients.

--- a/packages/core/src/BaseSession.ts
+++ b/packages/core/src/BaseSession.ts
@@ -251,8 +251,6 @@ export class BaseSession {
     this._closeConnection('disconnected')
 
     this.dispatch(sessionDisconnectedAction())
-    // yield put(pubSubChannel, sessionDisconnectedAction())
-    // yield put(destroyAction())
   }
 
   /**
@@ -349,7 +347,7 @@ export class BaseSession {
   }
 
   protected _onSocketClose(event: CloseEvent) {
-    this.logger.warn('_onSocketClose', event.type, event.code, event.reason)
+    this.logger.debug('_onSocketClose', event.type, event.code, event.reason)
     if (this._status !== 'disconnected') {
       this._status = 'reconnecting'
       this.dispatch(sessionReconnectingAction())

--- a/packages/core/src/BaseSession.ts
+++ b/packages/core/src/BaseSession.ts
@@ -32,7 +32,6 @@ import {
   authErrorAction,
   authSuccessAction,
   socketClosedAction,
-  socketErrorAction,
   socketMessageAction,
 } from './redux/actions'
 import { sessionActions } from './redux/features/session/sessionSlice'
@@ -332,7 +331,6 @@ export class BaseSession {
 
   protected _onSocketError(event: Event) {
     this.logger.debug('_onSocketError', event)
-    this.dispatch(socketErrorAction())
   }
 
   protected _onSocketClose(event: CloseEvent) {

--- a/packages/core/src/BaseSession.ts
+++ b/packages/core/src/BaseSession.ts
@@ -250,6 +250,7 @@ export class BaseSession {
     this._requests.clear()
     this._closeConnection('disconnected')
 
+    /** sessionDisconnectedAction() will destroy the rootSaga too */
     this.dispatch(sessionDisconnectedAction())
   }
 

--- a/packages/core/src/BaseSession.ts
+++ b/packages/core/src/BaseSession.ts
@@ -322,7 +322,6 @@ export class BaseSession {
   }
 
   authError(error: SessionAuthError) {
-    this.logger.error('Auth Error', error)
     /** Ignore WS events after the auth error and just disconnect */
     this._removeSocketListeners()
 
@@ -338,7 +337,8 @@ export class BaseSession {
       this._flushExecuteQueue()
       this.dispatch(authSuccessAction())
     } catch (error) {
-      this.authError(error) // FIXME: Use autherror on reauth too
+      this.logger.error('Auth Error', error)
+      this.authError(error)
     }
   }
 

--- a/packages/core/src/redux/actions.ts
+++ b/packages/core/src/redux/actions.ts
@@ -29,7 +29,6 @@ export const authSuccessAction = createAction('auth/success')
 export const authExpiringAction = createAction('auth/expiring')
 
 export const socketClosedAction = createAction('socket/closed')
-export const socketErrorAction = createAction('socket/error')
 export const socketMessageAction = createAction<JSONRPCRequest, string>(
   'socket/message'
 )

--- a/packages/core/src/redux/actions.ts
+++ b/packages/core/src/redux/actions.ts
@@ -28,7 +28,6 @@ export const authErrorAction = createAction<{ error: SessionAuthError }>(
 export const authSuccessAction = createAction('auth/success')
 export const authExpiringAction = createAction('auth/expiring')
 
-export const socketClosedAction = createAction('socket/closed')
 export const socketMessageAction = createAction<JSONRPCRequest, string>(
   'socket/message'
 )

--- a/packages/core/src/redux/features/session/sessionSaga.ts
+++ b/packages/core/src/redux/features/session/sessionSaga.ts
@@ -60,7 +60,7 @@ export function* executeActionWatcher(session: BaseSession): SagaIterator {
         )
       }
     } catch (error) {
-      getLogger().warn('worker error', componentId, JSON.stringify(error))
+      getLogger().warn('Execute error:', error)
       if (componentId && requestId) {
         yield put(
           componentActions.executeFailure({

--- a/packages/core/src/redux/rootSaga.test.ts
+++ b/packages/core/src/redux/rootSaga.test.ts
@@ -23,7 +23,6 @@ import {
   authSuccessAction,
   authErrorAction,
   authExpiringAction,
-  socketErrorAction,
   socketClosedAction,
   destroyAction,
   initAction,
@@ -77,7 +76,6 @@ describe('sessionStatusWatcher', () => {
     authSuccessAction.type,
     authErrorAction.type,
     authExpiringAction.type,
-    socketErrorAction.type,
     socketClosedAction.type,
     reauthAction.type,
   ]

--- a/packages/core/src/redux/rootSaga.test.ts
+++ b/packages/core/src/redux/rootSaga.test.ts
@@ -3,7 +3,6 @@ import { expectSaga, testSaga } from 'redux-saga-test-plan'
 import type { Task } from '@redux-saga/types'
 import { createMockTask } from '@redux-saga/testing-utils'
 import rootSaga, {
-  socketClosedWorker,
   sessionStatusWatcher,
   initSessionSaga,
   sessionAuthErrorSaga,
@@ -18,12 +17,12 @@ import { sessionActions } from './features'
 import {
   sessionConnectedAction,
   sessionDisconnectedAction,
+  sessionReconnectingAction,
   sessionAuthErrorAction,
   sessionExpiringAction,
   authSuccessAction,
   authErrorAction,
   authExpiringAction,
-  socketClosedAction,
   destroyAction,
   initAction,
   reauthAction,
@@ -31,53 +30,14 @@ import {
 import { AuthError } from '../CustomErrors'
 import { createPubSubChannel, createSwEventChannel } from '../testUtils'
 
-describe('socketClosedWorker', () => {
-  it('should try to reconnect when session status is reconnecting', () => {
-    const session = {
-      closed: true,
-      status: 'reconnecting',
-      connect: jest.fn(),
-    } as any
-    const timeout = 3000
-    const pubSubChannel = createPubSubChannel()
-    const sessionChannel = eventChannel(() => () => {})
-
-    return expectSaga(socketClosedWorker, {
-      session,
-      pubSubChannel,
-      sessionChannel,
-    })
-      .call(session.connect)
-      .run(timeout)
-  })
-
-  it('should close the session when session status is not reconnecting', () => {
-    const session = {
-      closed: true,
-      status: 'disconnected',
-      connect: jest.fn(),
-    } as any
-    const pubSubChannel = createPubSubChannel()
-    const sessionChannel = eventChannel(() => () => {})
-
-    return expectSaga(socketClosedWorker, {
-      session,
-      pubSubChannel,
-      sessionChannel,
-    })
-      .put(pubSubChannel, sessionDisconnectedAction())
-      .put(destroyAction())
-      .run()
-  })
-})
-
 describe('sessionStatusWatcher', () => {
   const actions = [
     authSuccessAction.type,
     authErrorAction.type,
     authExpiringAction.type,
-    socketClosedAction.type,
     reauthAction.type,
+    sessionReconnectingAction.type,
+    sessionDisconnectedAction.type,
   ]
   const session = {
     closed: true,
@@ -139,15 +99,6 @@ describe('sessionStatusWatcher', () => {
     )
   })
 
-  it('should fork socketClosedWorker on socketClosed action', () => {
-    const saga = testSaga(sessionStatusWatcher, options)
-
-    saga.next().take(actions)
-    saga.next(socketClosedAction()).fork(socketClosedWorker, options)
-    // Saga waits again for actions due to the while loop
-    saga.next().take(actions)
-  })
-
   it('should put sessionExpiringAction on authExpiringAction', () => {
     const saga = testSaga(sessionStatusWatcher, options)
 
@@ -155,6 +106,29 @@ describe('sessionStatusWatcher', () => {
     saga
       .next(authExpiringAction())
       .put(options.pubSubChannel, sessionExpiringAction())
+    // Saga waits again for actions due to the while loop
+    saga.next().take(actions)
+  })
+
+  it('should put sessionReconnectingAction on the pubSubChannel', () => {
+    const saga = testSaga(sessionStatusWatcher, options)
+
+    saga.next().take(actions)
+    saga
+      .next(sessionReconnectingAction())
+      .put(options.pubSubChannel, sessionReconnectingAction())
+    // Saga waits again for actions due to the while loop
+    saga.next().take(actions)
+  })
+
+  it('should put sessionDisconnectedAction on the pubSubChannel and put destroyAction', () => {
+    const saga = testSaga(sessionStatusWatcher, options)
+
+    saga.next().take(actions)
+    saga
+      .next(sessionDisconnectedAction())
+      .put(options.pubSubChannel, sessionDisconnectedAction())
+    saga.next().put(destroyAction())
     // Saga waits again for actions due to the while loop
     saga.next().take(actions)
   })

--- a/packages/core/src/redux/rootSaga.ts
+++ b/packages/core/src/redux/rootSaga.ts
@@ -228,18 +228,13 @@ export function* sessionAuthErrorSaga(
   getLogger().debug('sessionAuthErrorSaga [started]')
 
   try {
-    const { pubSubChannel, session, action } = options
+    const { pubSubChannel, action } = options
     const { error: authError } = action.payload
     const error = authError
       ? new AuthError(authError.code, authError.message)
       : new Error('Unauthorized')
 
     yield put(pubSubChannel, sessionAuthErrorAction(error))
-
-    /**
-     * Force-close the sessionChannel to disconnect the Session
-     */
-    yield call([session, session.disconnect])
   } finally {
     if (yield cancelled()) {
       getLogger().debug('sessionAuthErrorSaga [cancelled]')

--- a/packages/core/src/redux/rootSaga.ts
+++ b/packages/core/src/redux/rootSaga.ts
@@ -156,7 +156,7 @@ export function* reauthenticateWorker({
     }
   } catch (error) {
     getLogger().error('Reauthenticate Error', error)
-    yield put(authErrorAction({ error }))
+    session.authError(error)
   }
 }
 

--- a/packages/core/src/redux/rootSaga.ts
+++ b/packages/core/src/redux/rootSaga.ts
@@ -38,7 +38,6 @@ import {
   authSuccessAction,
   authExpiringAction,
   socketClosedAction,
-  socketErrorAction,
 } from './actions'
 import { AuthError } from '../CustomErrors'
 import { PubSubChannel } from './interfaces'
@@ -209,7 +208,6 @@ export function* sessionStatusWatcher(options: StartSagaOptions): SagaIterator {
         authSuccessAction.type,
         authErrorAction.type,
         authExpiringAction.type,
-        socketErrorAction.type,
         socketClosedAction.type,
         reauthAction.type,
       ])
@@ -233,13 +231,6 @@ export function* sessionStatusWatcher(options: StartSagaOptions): SagaIterator {
           yield put(options.pubSubChannel, sessionExpiringAction())
           break
         }
-        case socketErrorAction.type:
-          // TODO: define if we want to emit external events here.
-          // yield put(pubSubChannel, {
-          //   type: 'socket.error',
-          //   payload: {},
-          // })
-          break
         case socketClosedAction.type:
           yield fork(socketClosedWorker, options)
           break

--- a/packages/js/src/chat/Client.test.ts
+++ b/packages/js/src/chat/Client.test.ts
@@ -134,6 +134,8 @@ describe('ChatClient Object', () => {
     const connectMsg = JSON.parse(server.messages[0].toString())
     expect(connectMsg.method).toBe('signalwire.connect')
     expect(server.messages.length).toBe(3)
+
+    chat.disconnect()
   })
 
   it('should emit a single "signalwire.connect" at most when subscribing/publishing at the same time', async () => {
@@ -160,6 +162,8 @@ describe('ChatClient Object', () => {
         return parsedMessage.method === 'signalwire.connect'
       }).length
     ).toBe(1)
+
+    chat.disconnect()
   })
 
   describe('message handler', () => {
@@ -226,7 +230,9 @@ describe('ChatClient Object', () => {
 
         done()
       })
-      chat.subscribe(['test1'])
+      chat.subscribe(['test1']).then(() => {
+        chat.disconnect()
+      })
     })
   })
 
@@ -284,7 +290,9 @@ describe('ChatClient Object', () => {
         done()
       })
 
-      chat.subscribe(['test1'])
+      chat.subscribe(['test1']).then(() => {
+        chat.disconnect()
+      })
     })
 
     it('should return a ChatMember object on member.updated', (done) => {
@@ -324,7 +332,9 @@ describe('ChatClient Object', () => {
         done()
       })
 
-      chat.subscribe(['test1'])
+      chat.subscribe(['test1']).then(() => {
+        chat.disconnect()
+      })
     })
 
     it('should return a ChatMember object on member.left', (done) => {
@@ -360,7 +370,9 @@ describe('ChatClient Object', () => {
         done()
       })
 
-      chat.subscribe(['test1'])
+      chat.subscribe(['test1']).then(() => {
+        chat.disconnect()
+      })
     })
   })
 
@@ -380,6 +392,7 @@ describe('ChatClient Object', () => {
         { name: 'test2' },
         { name: 'test3' },
       ])
+      chat.disconnect()
     })
   })
 
@@ -407,6 +420,8 @@ describe('ChatClient Object', () => {
           expect(parsedMessage.params).toStrictEqual(params)
         }
       })
+
+      chat.disconnect()
     })
   })
 
@@ -427,6 +442,8 @@ describe('ChatClient Object', () => {
         { name: 'test2' },
         { name: 'test3' },
       ])
+
+      chat.disconnect()
     })
 
     it('should allow the user to .unsubscribe() from any subgroup of subscribed channels', async () => {
@@ -445,6 +462,8 @@ describe('ChatClient Object', () => {
       expect(
         await chat.unsubscribe(['test1', 'test2', 'test3'])
       ).toBeUndefined()
+
+      chat.disconnect()
     })
 
     it('should reject if its called before the session is authorized', async () => {
@@ -463,6 +482,8 @@ describe('ChatClient Object', () => {
           'You must be authenticated to unsubscribe from a channel'
         )
       }
+
+      chat.disconnect()
     })
 
     it("should reject if it's called without channels", async () => {
@@ -482,6 +503,8 @@ describe('ChatClient Object', () => {
       })
 
       await expect(() => chat.unsubscribe(['test1_error'])).rejects.toBeTruthy()
+
+      chat.disconnect()
     })
 
     it('should reject if the user calls .unsubscribe() with channels different than the ones they are subscribed to', async () => {
@@ -497,6 +520,8 @@ describe('ChatClient Object', () => {
       await expect(() =>
         chat.unsubscribe(['test1', 'test5_error'])
       ).rejects.toBeTruthy()
+
+      chat.disconnect()
     })
   })
 
@@ -522,6 +547,7 @@ describe('ChatClient Object', () => {
           },
         ],
       })
+      chat.disconnect()
     })
   })
 
@@ -560,6 +586,7 @@ describe('ChatClient Object', () => {
           after: 'after',
         },
       })
+      chat.disconnect()
     })
   })
 
@@ -587,6 +614,7 @@ describe('ChatClient Object', () => {
       })
 
       expect(response).toStrictEqual(undefined)
+      chat.disconnect()
     })
   })
 
@@ -620,6 +648,7 @@ describe('ChatClient Object', () => {
           },
         },
       })
+      chat.disconnect()
     })
 
     it('should send the proper RPC without (optional) channels', async () => {
@@ -649,6 +678,7 @@ describe('ChatClient Object', () => {
           },
         },
       })
+      chat.disconnect()
     })
   })
 })

--- a/packages/js/src/createClient.test.ts
+++ b/packages/js/src/createClient.test.ts
@@ -66,6 +66,7 @@ describe('createClient', () => {
     } catch (e) {
       expect(e).toBeInstanceOf(AuthError)
     }
+    client.disconnect()
   })
 
   it('should resolve `connect()` when the client is authorized', async () => {
@@ -82,6 +83,7 @@ describe('createClient', () => {
     })
 
     await client.connect()
+    client.disconnect()
   })
 
   it('should automatically resolve (without hitting the network) when calling `.connect()` if the session was already authorized', async () => {
@@ -113,5 +115,6 @@ describe('createClient', () => {
     await Promise.all([client.connect(), client.connect(), client.connect()])
 
     expect(messageHandler).toHaveBeenCalledTimes(1)
+    client.disconnect()
   })
 })

--- a/packages/js/src/createClient.test.ts
+++ b/packages/js/src/createClient.test.ts
@@ -34,6 +34,7 @@ describe('createClient', () => {
               error: authError,
             })
           )
+          return
         }
 
         socket.send(

--- a/packages/js/src/pubSub/Client.test.ts
+++ b/packages/js/src/pubSub/Client.test.ts
@@ -63,6 +63,7 @@ describe('PubSubClient Object', () => {
     expect(connectMsg.method).toBe('signalwire.connect')
 
     expect(server.messages.length).toBe(3)
+    pubSub.disconnect()
   })
 
   it('should emit a single "signalwire.connect" at most when subscribing/publishing at the same time', async () => {
@@ -89,6 +90,7 @@ describe('PubSubClient Object', () => {
         return parsedMessage.method === 'signalwire.connect'
       }).length
     ).toBe(1)
+    pubSub.disconnect()
   })
 
   describe('Subscribe', () => {
@@ -107,6 +109,7 @@ describe('PubSubClient Object', () => {
         { name: 'test2' },
         { name: 'test3' },
       ])
+      pubSub.disconnect()
     })
   })
 
@@ -134,6 +137,8 @@ describe('PubSubClient Object', () => {
           expect(parsedMessage.params).toStrictEqual(params)
         }
       })
+
+      pubSub.disconnect()
     })
   })
 
@@ -154,6 +159,7 @@ describe('PubSubClient Object', () => {
         { name: 'test2' },
         { name: 'test3' },
       ])
+      pubSub.disconnect()
     })
 
     it('should allow the user to .unsubscribe() from any subgroup of subscribed channels', async () => {
@@ -172,6 +178,7 @@ describe('PubSubClient Object', () => {
       expect(
         await pubSub.unsubscribe(['test1', 'test2', 'test3'])
       ).toBeUndefined()
+      pubSub.disconnect()
     })
 
     it('should reject if its called before the session is authorized', async () => {
@@ -190,6 +197,7 @@ describe('PubSubClient Object', () => {
           'You must be authenticated to unsubscribe from a channel'
         )
       }
+      pubSub.disconnect()
     })
 
     it("should reject if it's called without channels", async () => {
@@ -211,6 +219,7 @@ describe('PubSubClient Object', () => {
       await expect(() =>
         pubSub.unsubscribe(['test1_error'])
       ).rejects.toBeTruthy()
+      pubSub.disconnect()
     })
 
     it('should reject if the user calls .unsubscribe() with channels different than the ones they are subscribed to', async () => {
@@ -226,6 +235,7 @@ describe('PubSubClient Object', () => {
       await expect(() =>
         pubSub.unsubscribe(['test1', 'test5_error'])
       ).rejects.toBeTruthy()
+      pubSub.disconnect()
     })
   })
 })

--- a/packages/js/src/pubSub/Client.test.ts
+++ b/packages/js/src/pubSub/Client.test.ts
@@ -4,14 +4,6 @@ import { Client } from './Client'
 describe('PubSubClient Object', () => {
   const host = 'ws://localhost:1234'
   const token = '<jwt>'
-  const messages = [
-    {
-      id: '5fdc8fc5-b7fe-4fbd-8204-f2310dec2614',
-      sender_id: '1507e5f9-075c-463d-94ba-a8f9ec0c7d4e',
-      content: 'hello world',
-      published_at: 1641393396.153,
-    },
-  ]
 
   let server: WS
   beforeEach(async () => {
@@ -69,7 +61,6 @@ describe('PubSubClient Object', () => {
 
     const connectMsg = JSON.parse(server.messages[0].toString())
     expect(connectMsg.method).toBe('signalwire.connect')
-    console.log('server.messages--_>', server.messages);
 
     expect(server.messages.length).toBe(3)
   })
@@ -217,7 +208,9 @@ describe('PubSubClient Object', () => {
         content: 'test',
       })
 
-      await expect(() => pubSub.unsubscribe(['test1_error'])).rejects.toBeTruthy()
+      await expect(() =>
+        pubSub.unsubscribe(['test1_error'])
+      ).rejects.toBeTruthy()
     })
 
     it('should reject if the user calls .unsubscribe() with channels different than the ones they are subscribed to', async () => {

--- a/packages/realtime-api/src/chat/ChatClient.test.ts
+++ b/packages/realtime-api/src/chat/ChatClient.test.ts
@@ -108,8 +108,6 @@ describe('ChatClient', () => {
           message:
             'Authentication service failed with status ProtocolError, 401 Unauthorized: {}',
         })
-      } finally {
-        chat._session.disconnect()
       }
     })
   })

--- a/packages/realtime-api/src/video/VideoClient.test.ts
+++ b/packages/realtime-api/src/video/VideoClient.test.ts
@@ -36,6 +36,7 @@ describe('VideoClient', () => {
                 error: authError,
               })
             )
+            return
           }
 
           socket.send(
@@ -123,8 +124,6 @@ describe('VideoClient', () => {
           message:
             'Authentication service failed with status ProtocolError, 401 Unauthorized: {}',
         })
-      } finally {
-        video._session.disconnect()
       }
     })
   })

--- a/packages/webrtc/src/BaseConnection.ts
+++ b/packages/webrtc/src/BaseConnection.ts
@@ -289,7 +289,7 @@ export class BaseConnection<EventTypes extends EventEmitter.ValidEventTypes>
   }
 
   setActiveRTCPeer(rtcPeerId: string) {
-    this.peer = this.rtcPeerMap.get(rtcPeerId)
+    this.peer = this.getRTCPeerById(rtcPeerId)
   }
 
   /**


### PR DESCRIPTION
In this PR i also updated some unit tests to cleanup the WS connections and avoid the SDK to reconnect during tests (that created a lot of warnings from Jest and potential open handles).