### PR TITLE
E2E tests DX improvements

### DIFF
--- a/.changeset/honest-planes-repair.md
+++ b/.changeset/honest-planes-repair.md
@@ -1,0 +1,6 @@
+---
+'@sw-internal/e2e-js': patch
+'@sw-internal/test': patch
+---
+
+[internal] e2e dx improvement

--- a/internal/e2e-js/README.md
+++ b/internal/e2e-js/README.md
@@ -37,16 +37,18 @@ npm run -w=@sw-internal/e2e-js dev
 
 ## Launch a specific test
 
-Add a `testMatch` element inside the `projects` field of `PlaywrightTestConfig` in `playwright.config.ts` like:
-
 ```
-testMatch: ['roomSessionPromoteMeta.spec.ts'],
+npm run -w=@sw-internal/e2e-js dev -- <file1> <file2> <file3>
 ```
 
-Then you can use the usual command:
+> Example
 
 ```
-npm run -w=@sw-internal/e2e-js dev
+npm run -w=@sw-internal/e2e-js dev -- roomSession.spec.ts
 ```
 
-but only the one matching will be launched.
+Only `roomSession.spec.ts` will run.
+
+## Ignore a specific test
+
+Add the test you want to ignore within the `playwright.config.ts` > `testIgnore` array.

--- a/internal/e2e-js/fixtures.ts
+++ b/internal/e2e-js/fixtures.ts
@@ -1,0 +1,51 @@
+import { test as baseTest, expect, type Page } from '@playwright/test'
+import { enablePageLogs } from './utils'
+
+type CustomFixture = {
+  createCustomPage(options: { name: string }): Promise<Page>
+}
+
+const test = baseTest.extend<CustomFixture>({
+  createCustomPage: async ({ context }, use) => {
+    const maker = async (options: { name: string }) => {
+      const page = await context.newPage()
+      enablePageLogs(page, options.name)
+
+      return page
+    }
+    await use(maker)
+
+    console.log('Cleaning up pages..')
+
+    /**
+     * If we have a __roomObj in the page means we tested the VideoAPI
+     * so we must leave the room.
+     * Then double check the SDK elements got properly removed from the DOM.
+     */
+    const results = await Promise.all(
+      context.pages().map((page) => {
+        return page.evaluate(async () => {
+          // @ts-expect-error
+          if (window._roomObj) {
+            console.log('Fixture has room')
+            // @ts-expect-error
+            const roomObj: Video.RoomSession = window._roomObj
+            await roomObj.leave()
+          }
+
+          return {
+            videos: Array.from(document.querySelectorAll('video')).length,
+            rootEl: document.getElementById('rootElement')!.childElementCount,
+          }
+        })
+      })
+    )
+
+    results.forEach((row) => {
+      expect(row.videos).toBe(0)
+      expect(row.rootEl).toBe(0)
+    })
+  },
+})
+
+export { test, expect }

--- a/internal/e2e-js/fixtures.ts
+++ b/internal/e2e-js/fixtures.ts
@@ -36,7 +36,8 @@ const test = baseTest.extend<CustomFixture>({
 
           return {
             videos: Array.from(document.querySelectorAll('video')).length,
-            rootEl: document.getElementById('rootElement')!.childElementCount,
+            rootEl:
+              document.getElementById('rootElement')?.childElementCount ?? 0,
           }
         })
       })

--- a/internal/e2e-js/fixtures.ts
+++ b/internal/e2e-js/fixtures.ts
@@ -1,3 +1,4 @@
+import type { Video } from '@signalwire/js'
 import { test as baseTest, expect, type Page } from '@playwright/test'
 import { enablePageLogs } from './utils'
 
@@ -20,16 +21,16 @@ const test = baseTest.extend<CustomFixture>({
     /**
      * If we have a __roomObj in the page means we tested the VideoAPI
      * so we must leave the room.
+     * Invoke `.leave()` only if we have a valid `roomSessionId`.
      * Then double check the SDK elements got properly removed from the DOM.
      */
     const results = await Promise.all(
       context.pages().map((page) => {
         return page.evaluate(async () => {
           // @ts-expect-error
-          if (window._roomObj) {
-            console.log('Fixture has room')
-            // @ts-expect-error
-            const roomObj: Video.RoomSession = window._roomObj
+          const roomObj: Video.RoomSession = window._roomObj
+          if (roomObj && roomObj.roomSessionId) {
+            console.log('Fixture has room', roomObj.roomSessionId)
             await roomObj.leave()
           }
 

--- a/internal/e2e-js/playwright.config.ts
+++ b/internal/e2e-js/playwright.config.ts
@@ -9,7 +9,7 @@ const config: PlaywrightTestConfig = {
   testIgnore: [
     //   'roomSessionStreaming.spec.ts',
   ],
-  timeout: 120_000,
+  timeout: 90_000,
   expect: {
     // Default is 5000
     timeout: 10_000,

--- a/internal/e2e-js/playwright.config.ts
+++ b/internal/e2e-js/playwright.config.ts
@@ -2,10 +2,12 @@ require('dotenv').config()
 
 import { PlaywrightTestConfig, devices } from '@playwright/test'
 
+const testMatch = process.argv.slice(3)
+
 const config: PlaywrightTestConfig = {
   testDir: 'tests',
   globalSetup: require.resolve('./global-setup'),
-  testMatch: process.argv.slice(3),
+  testMatch: testMatch.length ? testMatch : undefined,
   testIgnore: [
     //   'roomSessionStreaming.spec.ts',
   ],

--- a/internal/e2e-js/playwright.config.ts
+++ b/internal/e2e-js/playwright.config.ts
@@ -11,7 +11,7 @@ const config: PlaywrightTestConfig = {
   testIgnore: [
     //   'roomSessionStreaming.spec.ts',
   ],
-  timeout: 90_000,
+  timeout: 120_000,
   expect: {
     // Default is 5000
     timeout: 10_000,

--- a/internal/e2e-js/playwright.config.ts
+++ b/internal/e2e-js/playwright.config.ts
@@ -5,7 +5,7 @@ import { PlaywrightTestConfig, devices } from '@playwright/test'
 const config: PlaywrightTestConfig = {
   testDir: 'tests',
   globalSetup: require.resolve('./global-setup'),
-  // testMatch: ['roomSessionStreamingAPI.spec.ts'],
+  testMatch: process.argv.slice(3),
   testIgnore: [
     //   'roomSessionStreaming.spec.ts',
   ],

--- a/internal/e2e-js/tests/roomSession.spec.ts
+++ b/internal/e2e-js/tests/roomSession.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, Page } from '@playwright/test'
+import { test, expect } from '@playwright/test'
 import type { Video } from '@signalwire/js'
 import {
   SERVER_URL,

--- a/internal/e2e-js/tests/roomSession.spec.ts
+++ b/internal/e2e-js/tests/roomSession.spec.ts
@@ -3,7 +3,6 @@ import type { Video } from '@signalwire/js'
 import {
   SERVER_URL,
   createTestRoomSession,
-  enablePageLogs,
   randomizeRoomName,
   setLayoutOnPage,
   expectLayoutChanged,
@@ -17,7 +16,6 @@ test.describe('RoomSession', () => {
   }) => {
     const page = await createCustomPage({ name: '[page]' })
     await page.goto(SERVER_URL)
-    enablePageLogs(page)
 
     const roomName = randomizeRoomName()
     const permissions = [

--- a/internal/e2e-js/tests/roomSessionAudienceCount.spec.ts
+++ b/internal/e2e-js/tests/roomSessionAudienceCount.spec.ts
@@ -1,11 +1,6 @@
 import { test, expect } from '@playwright/test'
 import { Video } from '@signalwire/js'
-import {
-  SERVER_URL,
-  createTestRoomSession,
-  enablePageLogs,
-  randomizeRoomName,
-} from '../utils'
+import { SERVER_URL, createTestRoomSession, randomizeRoomName } from '../utils'
 
 test.describe('RoomSession Audience Count', () => {
   test('should receive correct audience_count in events', async ({
@@ -21,8 +16,6 @@ test.describe('RoomSession Audience Count', () => {
     const [pageOne, pageTwo, pageThree, pageFour, pageFive] = allPages
     const audiencePages = [pageTwo, pageThree, pageFour, pageFive]
     await Promise.all(allPages.map((page) => page.goto(SERVER_URL)))
-    enablePageLogs(pageOne, '[pageOne]')
-    //enablePageLogs(pageTwo, '[pageTwo]')
 
     const room_name = randomizeRoomName()
 

--- a/internal/e2e-js/tests/roomSessionAudienceCount.spec.ts
+++ b/internal/e2e-js/tests/roomSessionAudienceCount.spec.ts
@@ -92,7 +92,7 @@ test.describe('RoomSession Audience Count', () => {
 
     const [_, ...pageThreeToFive] = audiencePages
     // join as audiences on pageThree to pageFive and resolve on `room.joined`
-    await Promise.all(pageThreeToFive.map(expectRoomJoined))
+    await Promise.all(pageThreeToFive.map((page) => expectRoomJoined(page)))
 
     // Need to wait for the room.audienceCount event that is throttled
     await pageOne.waitForTimeout(30000)

--- a/internal/e2e-js/tests/roomSessionDemote.spec.ts
+++ b/internal/e2e-js/tests/roomSessionDemote.spec.ts
@@ -167,13 +167,8 @@ test.describe('RoomSession demote participant', () => {
       { demoteMemberId: participant2Id }
     )
 
-    // FIXME: method to wait for room.joined only
-    const promiseAudienceRoomJoined = await pageTwo.evaluate<any>(() => {
-      return new Promise((resolve) => {
-        // @ts-expect-error
-        const roomObj = window._roomObj
-        roomObj.once('room.joined', resolve)
-      })
+    const promiseAudienceRoomJoined = await expectRoomJoined(pageTwo, {
+      invokeJoin: false,
     })
 
     // --------------- Make sure member_id is the same after promote and demote on pageTwo ---------------

--- a/internal/e2e-js/tests/roomSessionDemote.spec.ts
+++ b/internal/e2e-js/tests/roomSessionDemote.spec.ts
@@ -3,7 +3,6 @@ import type { Video } from '@signalwire/js'
 import {
   SERVER_URL,
   createTestRoomSession,
-  enablePageLogs,
   expectSDPDirection,
   expectInteractivityMode,
   expectMemberId,
@@ -12,9 +11,7 @@ import {
 test.describe('RoomSession demote participant', () => {
   test('should demote participant', async ({ context }) => {
     const pageOne = await context.newPage()
-    enablePageLogs(pageOne, '[pageOne]')
     const pageTwo = await context.newPage()
-    enablePageLogs(pageTwo, '[pageTwo]')
 
     await Promise.all([pageOne.goto(SERVER_URL), pageTwo.goto(SERVER_URL)])
 

--- a/internal/e2e-js/tests/roomSessionDemoteAudience.spec.ts
+++ b/internal/e2e-js/tests/roomSessionDemoteAudience.spec.ts
@@ -3,7 +3,6 @@ import type { Video } from '@signalwire/js'
 import {
   SERVER_URL,
   createTestRoomSession,
-  enablePageLogs,
   expectSDPDirection,
   expectInteractivityMode,
 } from '../utils'
@@ -11,9 +10,7 @@ import {
 test.describe('RoomSession demote method', () => {
   test('should not be able to to demote audience', async ({ context }) => {
     const pageOne = await context.newPage()
-    enablePageLogs(pageOne, '[pageOne]')
     const pageTwo = await context.newPage()
-    enablePageLogs(pageTwo, '[pageTwo]')
 
     await Promise.all([pageOne.goto(SERVER_URL), pageTwo.goto(SERVER_URL)])
 

--- a/internal/e2e-js/tests/roomSessionDemoteAudience.spec.ts
+++ b/internal/e2e-js/tests/roomSessionDemoteAudience.spec.ts
@@ -1,16 +1,20 @@
-import { test, expect } from '@playwright/test'
+import { test, expect } from '../fixtures'
 import type { Video } from '@signalwire/js'
 import {
   SERVER_URL,
   createTestRoomSession,
   expectSDPDirection,
   expectInteractivityMode,
+  expectRoomJoined,
+  expectMCUVisible,
 } from '../utils'
 
 test.describe('RoomSession demote method', () => {
-  test('should not be able to to demote audience', async ({ context }) => {
-    const pageOne = await context.newPage()
-    const pageTwo = await context.newPage()
+  test('should not be able to to demote audience', async ({
+    createCustomPage,
+  }) => {
+    const pageOne = await createCustomPage({ name: '[pageOne]' })
+    const pageTwo = await createCustomPage({ name: '[pageTwo]' })
 
     await Promise.all([pageOne.goto(SERVER_URL), pageTwo.goto(SERVER_URL)])
 
@@ -41,43 +45,16 @@ test.describe('RoomSession demote method', () => {
     ])
 
     // --------------- Joining from the 1st tab as member and resolve on 'room.joined' ---------------
-    await pageOne.evaluate(() => {
-      return new Promise((resolve) => {
-        // @ts-expect-error
-        const roomObj = window._roomObj
-        roomObj.on('room.joined', resolve)
-        roomObj.join()
-      })
-    })
-
-    // --------------- Make sure on pageOne we have a member ---------------
-    await expectInteractivityMode(pageOne, 'member')
+    await expectRoomJoined(pageOne)
 
     // Checks that the video is visible on pageOne
-    await pageOne.waitForSelector('div[id^="sw-sdk-"] > video', {
-      timeout: 5000,
-    })
+    await expectMCUVisible(pageOne)
 
     // --------------- Joining from the 2st tab as audience and resolve on 'room.joined' ---------------
-    const pageTwoRoomJoined: any = await pageTwo.evaluate(() => {
-      return new Promise((resolve) => {
-        // @ts-expect-error
-        const roomObj = window._roomObj
-        roomObj.once('room.joined', resolve)
-        roomObj.join()
-      })
-    })
-
-    // --------------- Make sure on pageTwo we have a audience ---------------
-    await expectInteractivityMode(pageTwo, 'audience')
-
-    // --------------- Check SDP/RTCPeer on audience (recvonly since audience) ---------------
-    await expectSDPDirection(pageTwo, 'recvonly', true)
+    const pageTwoRoomJoined: any = await expectRoomJoined(pageTwo)
 
     // Checks that the video is visible on pageTwo
-    await pageTwo.waitForSelector('#rootElement video', {
-      timeout: 10000,
-    })
+    await expectMCUVisible(pageTwo)
 
     // --------------- Demote audience from pageOne and resolve on 404 ---------------
     const errorCode = await pageOne.evaluate(
@@ -91,29 +68,16 @@ test.describe('RoomSession demote method', () => {
           })
           .catch((error) => error)
 
-        console.log('demote error', error.jsonrpc.code, error.jsonrpc.message)
         return error.jsonrpc.code
       },
       { demoteMemberId: pageTwoRoomJoined.member_id }
     )
     expect(errorCode).toBe('404')
 
-    await pageTwo.waitForTimeout(2000)
-
     // --------------- Make sure on pageTwo still have audience ---------------
     await expectInteractivityMode(pageTwo, 'audience')
 
     // --------------- Check SDP/RTCPeer on audience still have recvonly ---------------
     await expectSDPDirection(pageTwo, 'recvonly', true)
-
-    await pageTwo.waitForTimeout(2000)
-
-    // --------------- Leaving the rooms ---------------
-    await Promise.all([
-      // @ts-expect-error
-      pageOne.evaluate(() => window._roomObj.leave()),
-      // @ts-expect-error
-      pageTwo.evaluate(() => window._roomObj.leave()),
-    ])
   })
 })

--- a/internal/e2e-js/tests/roomSessionDemoteAudience.spec.ts
+++ b/internal/e2e-js/tests/roomSessionDemoteAudience.spec.ts
@@ -7,6 +7,7 @@ import {
   expectInteractivityMode,
   expectRoomJoined,
   expectMCUVisible,
+  expectMCUVisibleForAudience,
 } from '../utils'
 
 test.describe('RoomSession demote method', () => {
@@ -54,7 +55,7 @@ test.describe('RoomSession demote method', () => {
     const pageTwoRoomJoined: any = await expectRoomJoined(pageTwo)
 
     // Checks that the video is visible on pageTwo
-    await expectMCUVisible(pageTwo)
+    await expectMCUVisibleForAudience(pageTwo)
 
     // --------------- Demote audience from pageOne and resolve on 404 ---------------
     const errorCode = await pageOne.evaluate(

--- a/internal/e2e-js/tests/roomSessionDemotePromote.spec.ts
+++ b/internal/e2e-js/tests/roomSessionDemotePromote.spec.ts
@@ -1,21 +1,20 @@
-import { test, expect } from '@playwright/test'
+import { test } from '@playwright/test'
 import type { Video } from '@signalwire/js'
 import {
   SERVER_URL,
   createTestRoomSession,
-  enablePageLogs,
   expectSDPDirection,
   expectInteractivityMode,
   expectMemberId,
-  randomizeRoomName
+  randomizeRoomName,
 } from '../utils'
 
 test.describe('RoomSession demote participant and then promote again', () => {
-  test('should demote participant and then promote again', async ({ context }) => {
+  test('should demote participant and then promote again', async ({
+    context,
+  }) => {
     const pageOne = await context.newPage()
-    enablePageLogs(pageOne, '[pageOne]')
     const pageTwo = await context.newPage()
-    enablePageLogs(pageTwo, '[pageTwo]')
 
     await Promise.all([pageOne.goto(SERVER_URL), pageTwo.goto(SERVER_URL)])
 
@@ -120,9 +119,7 @@ test.describe('RoomSession demote participant and then promote again', () => {
               resolve(true)
             } else {
               reject(
-                new Error(
-                  '[member.left] Name is not "e2e_target_participant"'
-                )
+                new Error('[member.left] Name is not "e2e_target_participant"')
               )
             }
           })
@@ -160,7 +157,7 @@ test.describe('RoomSession demote participant and then promote again', () => {
     // --------------- Time to promote again at PageTwo ---------------
 
     await pageTwo.waitForTimeout(2000)
-    
+
     // --------------- Promote audience from pageOne and resolve on `member.joined` ---------------
     const promiseMemberWaitingForMemberJoin = pageOne.evaluate(
       async ({ promoteMemberId }) => {
@@ -169,11 +166,21 @@ test.describe('RoomSession demote participant and then promote again', () => {
 
         const waitForMemberJoined = new Promise((resolve, reject) => {
           roomObj.on('member.joined', ({ member }) => {
-            if (member.name === 'e2e_target_participant' && member.id === promoteMemberId) {
-              console.log("=======================> Member joined:", member.name)
+            if (
+              member.name === 'e2e_target_participant' &&
+              member.id === promoteMemberId
+            ) {
+              console.log(
+                '=======================> Member joined:',
+                member.name
+              )
               resolve(true)
             } else {
-              reject(new Error('[member.joined] Name is not "e2e_target_participant"'))
+              reject(
+                new Error(
+                  '[member.joined] Name is not "e2e_target_participant"'
+                )
+              )
             }
           })
         })
@@ -196,7 +203,10 @@ test.describe('RoomSession demote participant and then promote again', () => {
       })
     })
 
-    await Promise.all([promiseMemberWaitingForMemberJoin, promisePromotedRoomJoined])
+    await Promise.all([
+      promiseMemberWaitingForMemberJoin,
+      promisePromotedRoomJoined,
+    ])
 
     await expectMemberId(pageTwo, participant2Id)
     await expectInteractivityMode(pageTwo, 'member')

--- a/internal/e2e-js/tests/roomSessionDemotePromote.spec.ts
+++ b/internal/e2e-js/tests/roomSessionDemotePromote.spec.ts
@@ -170,13 +170,8 @@ test.describe('RoomSession demote participant and then promote again', () => {
       { promoteMemberId: participant2Id }
     )
 
-    // FIXME: method to wait for room.joined only
-    const promisePromotedRoomJoined = pageTwo.evaluate<any>(() => {
-      return new Promise((resolve) => {
-        // @ts-expect-error
-        const roomObj = window._roomObj
-        roomObj.once('room.joined', resolve)
-      })
+    const promisePromotedRoomJoined = expectRoomJoined(pageTwo, {
+      invokeJoin: false,
     })
 
     await Promise.all([

--- a/internal/e2e-js/tests/roomSessionJoinFrom.spec.ts
+++ b/internal/e2e-js/tests/roomSessionJoinFrom.spec.ts
@@ -41,7 +41,7 @@ test.describe('RoomSession join_from', () => {
     test(`should not be possible to join a room before the join_from [${row.testName}]`, async ({
       createCustomPage,
     }) => {
-      const buildRoomSession = () => {
+      const buildRoomSession = (opts = { expectToJoin: true }) => {
         return createTestRoomSession(page, {
           vrt: {
             room_name: row.roomName,
@@ -51,6 +51,7 @@ test.describe('RoomSession join_from', () => {
             join_from: row.autoCreateRoom ? joinFrom : undefined,
           },
           initialEvents: [],
+          expectToJoin: opts.expectToJoin,
         })
       }
       let roomData: any = {}
@@ -58,7 +59,7 @@ test.describe('RoomSession join_from', () => {
       const page = await createCustomPage({ name: '[joinFromPage]' })
       await page.goto(SERVER_URL)
 
-      const delay = 5_000
+      const delay = 10_000
       const joinFrom = new Date(Date.now() + delay).toISOString()
       if (!row.autoCreateRoom) {
         roomData = await createOrUpdateRoom({
@@ -67,7 +68,7 @@ test.describe('RoomSession join_from', () => {
         })
       }
 
-      await buildRoomSession()
+      await buildRoomSession({ expectToJoin: false })
 
       // --------------- Joining the room and expect an error ---------------
       const joinError: any = await page.evaluate(async () => {

--- a/internal/e2e-js/tests/roomSessionJoinFrom.spec.ts
+++ b/internal/e2e-js/tests/roomSessionJoinFrom.spec.ts
@@ -5,7 +5,6 @@ import {
   createTestRoomSession,
   createOrUpdateRoom,
   deleteRoom,
-  enablePageLogs,
   randomizeRoomName,
 } from '../utils'
 
@@ -56,7 +55,6 @@ test.describe('RoomSession join_from', () => {
       let roomData: any = {}
 
       await page.goto(SERVER_URL)
-      enablePageLogs(page)
 
       const delay = 5_000
       const joinFrom = new Date(Date.now() + delay).toISOString()

--- a/internal/e2e-js/tests/roomSessionJoinUntil.spec.ts
+++ b/internal/e2e-js/tests/roomSessionJoinUntil.spec.ts
@@ -5,7 +5,6 @@ import {
   createTestRoomSession,
   createOrUpdateRoom,
   deleteRoom,
-  enablePageLogs,
   randomizeRoomName,
 } from '../utils'
 
@@ -44,7 +43,6 @@ test.describe('RoomSession join_until', () => {
       let roomData: any = {}
 
       await page.goto(SERVER_URL)
-      enablePageLogs(page)
 
       const delay = 5_000
       const joinUntil = new Date(Date.now() + delay).toISOString()

--- a/internal/e2e-js/tests/roomSessionJoinUntil.spec.ts
+++ b/internal/e2e-js/tests/roomSessionJoinUntil.spec.ts
@@ -63,6 +63,7 @@ test.describe('RoomSession join_until', () => {
           join_until: row.autoCreateRoom ? joinUntil : undefined,
         },
         initialEvents: [],
+        expectToJoin: false,
       })
 
       await page.waitForTimeout(delay)

--- a/internal/e2e-js/tests/roomSessionJoinUntil.spec.ts
+++ b/internal/e2e-js/tests/roomSessionJoinUntil.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test'
+import { test, expect } from '../fixtures'
 import type { Video } from '@signalwire/js'
 import {
   SERVER_URL,
@@ -38,10 +38,11 @@ test.describe('RoomSession join_until', () => {
 
   tests.forEach((row) => {
     test(`should not be possible to join a room after the join_until [${row.testName}]`, async ({
-      page,
+      createCustomPage,
     }) => {
       let roomData: any = {}
 
+      const page = await createCustomPage({ name: '[joinUntilPage]' })
       await page.goto(SERVER_URL)
 
       const delay = 5_000
@@ -78,7 +79,7 @@ test.describe('RoomSession join_until', () => {
       expect(joinError.code).toEqual('403')
       expect(joinError.message).toEqual('Unauthorized')
 
-      // Checks that all the elements added by the SDK are gone.
+      // Checks that all the elements added by the SDK are not there.
       const targetElementsCount = await page.evaluate(() => {
         return {
           videos: Array.from(document.querySelectorAll('video')).length,

--- a/internal/e2e-js/tests/roomSessionMethodsOnNonExistingMembers.spec.ts
+++ b/internal/e2e-js/tests/roomSessionMethodsOnNonExistingMembers.spec.ts
@@ -1,18 +1,12 @@
 import { test, expect } from '@playwright/test'
 import type { Video } from '@signalwire/js'
-import {
-  SERVER_URL,
-  createTestRoomSession,
-  enablePageLogs,
-  randomizeRoomName,
-} from '../utils'
+import { SERVER_URL, createTestRoomSession, randomizeRoomName } from '../utils'
 
 test.describe('RoomSession methods on non existing members', () => {
   test('should handle joining a room, try to perform actions on members that does not exist and then leave the room', async ({
     page,
   }) => {
     await page.goto(SERVER_URL)
-    enablePageLogs(page)
 
     const roomName = randomizeRoomName('e2e-non-existing-member')
     const member_permissions: string[] = [
@@ -35,8 +29,7 @@ test.describe('RoomSession methods on non existing members', () => {
         auto_create_room: true,
         permissions: member_permissions,
       },
-      initialEvents: [
-      ],
+      initialEvents: [],
     })
 
     // --------------- Joining the room ---------------

--- a/internal/e2e-js/tests/roomSessionPromoteDemote.spec.ts
+++ b/internal/e2e-js/tests/roomSessionPromoteDemote.spec.ts
@@ -10,6 +10,7 @@ import {
   setLayoutOnPage,
   expectRoomJoined,
   expectMCUVisible,
+  expectMCUVisibleForAudience,
   expectTotalAudioEnergyToBeGreaterThan,
 } from '../utils'
 
@@ -73,7 +74,7 @@ test.describe('RoomSession promote/demote methods', () => {
     const audienceId = pageTwoRoomJoined.member_id
 
     // Checks that the video is visible on pageTwo
-    await expectMCUVisible(pageTwo)
+    await expectMCUVisibleForAudience(pageTwo)
 
     // --------------- Check that the audience member on pageTwo is receiving non-silence ---------------
     await pageOne.waitForTimeout(5000)

--- a/internal/e2e-js/tests/roomSessionPromoteDemote.spec.ts
+++ b/internal/e2e-js/tests/roomSessionPromoteDemote.spec.ts
@@ -10,6 +10,7 @@ import {
   setLayoutOnPage,
   expectRoomJoined,
   expectMCUVisible,
+  expectTotalAudioEnergyToBeGreaterThan,
 } from '../utils'
 
 test.describe('RoomSession promote/demote methods', () => {
@@ -75,57 +76,11 @@ test.describe('RoomSession promote/demote methods', () => {
     await expectMCUVisible(pageTwo)
 
     // --------------- Check that the audience member on pageTwo is receiving non-silence ---------------
-    async function getAudioStats() {
-      const audioStats = await pageTwo.evaluate(async () => {
-        // @ts-expect-error
-        const roomObj: Video.RoomSession = window._roomObj
-
-        // @ts-expect-error
-        const stats = await roomObj.peer.instance.getStats(null)
-
-        const filter = {
-          'inbound-rtp': [
-            'audioLevel',
-            'totalAudioEnergy',
-            'totalSamplesDuration',
-          ],
-        }
-        let result: any = {}
-        Object.keys(filter).forEach((entry) => {
-          result[entry] = {}
-        })
-
-        stats.forEach((report: any) => {
-          for (const [key, value] of Object.entries(filter)) {
-            //console.log(key, value, report.type)
-            if (report.type == key) {
-              value.forEach((entry) => {
-                //console.log(key, entry, report[entry])
-                if (report[entry]) {
-                  result[key][entry] = report[entry]
-                }
-              })
-            }
-          }
-        }, {})
-        return result
-      })
-      return audioStats
-    }
-
-    // --------------- Wait a bit for the media to flow ---------------
     await pageOne.waitForTimeout(5000)
-    let audioLevelStats: any = await getAudioStats()
-    console.log('audience audioLevelStats 1', audioLevelStats)
-    expect(audioLevelStats['inbound-rtp']['totalAudioEnergy']).toBeGreaterThan(
-      0.1
-    )
+    await expectTotalAudioEnergyToBeGreaterThan(pageTwo, 0.1)
+
     await pageOne.waitForTimeout(5000)
-    audioLevelStats = await getAudioStats()
-    console.log('audience audioLevelStats 2', audioLevelStats)
-    expect(audioLevelStats['inbound-rtp']['totalAudioEnergy']).toBeGreaterThan(
-      0.5
-    )
+    await expectTotalAudioEnergyToBeGreaterThan(pageTwo, 0.5)
 
     // --------------- Make sure a `layout.changed` reached both member and audience --------------
 

--- a/internal/e2e-js/tests/roomSessionPromoteDemote.spec.ts
+++ b/internal/e2e-js/tests/roomSessionPromoteDemote.spec.ts
@@ -3,7 +3,6 @@ import type { Video } from '@signalwire/js'
 import {
   SERVER_URL,
   createTestRoomSession,
-  enablePageLogs,
   expectSDPDirection,
   expectInteractivityMode,
   expectMemberId,
@@ -14,9 +13,7 @@ import {
 test.describe('RoomSession promote/demote methods', () => {
   test('should promote/demote audience', async ({ context }) => {
     const pageOne = await context.newPage()
-    enablePageLogs(pageOne, '[pageOne]')
     const pageTwo = await context.newPage()
-    enablePageLogs(pageTwo, '[pageTwo]')
 
     await Promise.all([pageOne.goto(SERVER_URL), pageTwo.goto(SERVER_URL)])
 

--- a/internal/e2e-js/tests/roomSessionPromoteDemote.spec.ts
+++ b/internal/e2e-js/tests/roomSessionPromoteDemote.spec.ts
@@ -182,13 +182,8 @@ test.describe('RoomSession promote/demote methods', () => {
 
     await pageTwo.waitForTimeout(2000)
 
-    // FIXME: method to wait for room.joined only
-    const promiseAudienceRoomJoined = pageTwo.evaluate<any>(() => {
-      return new Promise((resolve) => {
-        // @ts-expect-error
-        const roomObj = window._roomObj
-        roomObj.once('room.joined', resolve)
-      })
+    const promiseAudienceRoomJoined = expectRoomJoined(pageTwo, {
+      invokeJoin: false,
     })
 
     // --------------- Demote to audience again from pageOne and resolve on `member.left` amd `layout.changed` with position off-canvas ---------------

--- a/internal/e2e-js/tests/roomSessionPromoteMeta.spec.ts
+++ b/internal/e2e-js/tests/roomSessionPromoteMeta.spec.ts
@@ -1,18 +1,20 @@
-import { test } from '@playwright/test'
+import { test } from '../fixtures'
 import type { Video } from '@signalwire/js'
 import {
   SERVER_URL,
   createTestRoomSession,
   expectSDPDirection,
   expectInteractivityMode,
+  expectRoomJoined,
+  expectMCUVisible,
 } from '../utils'
 
 test.describe('RoomSession promote updating member meta', () => {
   test('should promote audience setting the meta field', async ({
-    context,
+    createCustomPage,
   }) => {
-    const pageOne = await context.newPage()
-    const pageTwo = await context.newPage()
+    const pageOne = await createCustomPage({ name: '[pageOne]' })
+    const pageTwo = await createCustomPage({ name: '[pageTwo]' })
 
     await Promise.all([pageOne.goto(SERVER_URL), pageTwo.goto(SERVER_URL)])
 
@@ -43,43 +45,16 @@ test.describe('RoomSession promote updating member meta', () => {
     ])
 
     // --------------- Joining from the 1st tab as member and resolve on 'room.joined' ---------------
-    await pageOne.evaluate(() => {
-      return new Promise((resolve) => {
-        // @ts-expect-error
-        const roomObj = window._roomObj
-        roomObj.on('room.joined', resolve)
-        roomObj.join()
-      })
-    })
-
-    // --------------- Make sure on pageOne we have a member ---------------
-    await expectInteractivityMode(pageOne, 'member')
+    await expectRoomJoined(pageOne)
 
     // Checks that the video is visible on pageOne
-    await pageOne.waitForSelector('div[id^="sw-sdk-"] > video', {
-      timeout: 5000,
-    })
+    await expectMCUVisible(pageOne)
 
     // --------------- Joining from the 2st tab as audience and resolve on 'room.joined' ---------------
-    const pageTwoRoomJoined: any = await pageTwo.evaluate(() => {
-      return new Promise((resolve) => {
-        // @ts-expect-error
-        const roomObj = window._roomObj
-        roomObj.once('room.joined', resolve)
-        roomObj.join()
-      })
-    })
-
-    // --------------- Make sure on pageTwo we have a audience ---------------
-    await expectInteractivityMode(pageTwo, 'audience')
-
-    // --------------- Check SDP/RTCPeer on audience (recvonly since audience) ---------------
-    await expectSDPDirection(pageTwo, 'recvonly', true)
+    const pageTwoRoomJoined = await expectRoomJoined(pageTwo)
 
     // Checks that the video is visible on pageTwo
-    await pageTwo.waitForSelector('#rootElement video', {
-      timeout: 10000,
-    })
+    await expectMCUVisible(pageTwo)
 
     // ------- Promote audience from pageOne and resolve on `member.joined` and pageTwo room.joined ----
     const promiseAudienceRoomSubscribed = pageTwo.evaluate(() => {
@@ -87,7 +62,7 @@ test.describe('RoomSession promote updating member meta', () => {
         // @ts-expect-error
         const roomObj: Video.RoomSession = window._roomObj
 
-        roomObj.on('room.joined', ({ room_session }) => {
+        roomObj.once('room.joined', ({ room_session }) => {
           for (let member of room_session.members) {
             if (member.name === 'e2e_audience_meta') {
               if (member.meta && member.meta['vip'] === true) {
@@ -148,15 +123,5 @@ test.describe('RoomSession promote updating member meta', () => {
 
     // --------------- Check SDP/RTCPeer on audience (now member so sendrecv) ---------------
     await expectSDPDirection(pageTwo, 'sendrecv', true)
-
-    await pageTwo.waitForTimeout(2000)
-
-    // --------------- Leaving the rooms ---------------
-    await Promise.all([
-      // @ts-expect-error
-      pageOne.evaluate(() => window._roomObj.leave()),
-      // @ts-expect-error
-      pageTwo.evaluate(() => window._roomObj.leave()),
-    ])
   })
 })

--- a/internal/e2e-js/tests/roomSessionPromoteMeta.spec.ts
+++ b/internal/e2e-js/tests/roomSessionPromoteMeta.spec.ts
@@ -7,6 +7,7 @@ import {
   expectInteractivityMode,
   expectRoomJoined,
   expectMCUVisible,
+  expectMCUVisibleForAudience,
 } from '../utils'
 
 test.describe('RoomSession promote updating member meta', () => {
@@ -54,7 +55,7 @@ test.describe('RoomSession promote updating member meta', () => {
     const pageTwoRoomJoined = await expectRoomJoined(pageTwo)
 
     // Checks that the video is visible on pageTwo
-    await expectMCUVisible(pageTwo)
+    await expectMCUVisibleForAudience(pageTwo)
 
     // ------- Promote audience from pageOne and resolve on `member.joined` and pageTwo room.joined ----
     const promiseAudienceRoomSubscribed = pageTwo.evaluate(() => {

--- a/internal/e2e-js/tests/roomSessionPromoteMeta.spec.ts
+++ b/internal/e2e-js/tests/roomSessionPromoteMeta.spec.ts
@@ -3,7 +3,6 @@ import type { Video } from '@signalwire/js'
 import {
   SERVER_URL,
   createTestRoomSession,
-  enablePageLogs,
   expectSDPDirection,
   expectInteractivityMode,
 } from '../utils'
@@ -13,9 +12,7 @@ test.describe('RoomSession promote updating member meta', () => {
     context,
   }) => {
     const pageOne = await context.newPage()
-    enablePageLogs(pageOne, '[pageOne]')
     const pageTwo = await context.newPage()
-    enablePageLogs(pageTwo, '[pageTwo]')
 
     await Promise.all([pageOne.goto(SERVER_URL), pageTwo.goto(SERVER_URL)])
 

--- a/internal/e2e-js/tests/roomSessionPromoteParticipant.spec.ts
+++ b/internal/e2e-js/tests/roomSessionPromoteParticipant.spec.ts
@@ -1,14 +1,17 @@
-import { test, expect } from '@playwright/test'
+import { test, expect } from '../fixtures'
 import type { Video } from '@signalwire/js'
 import {
   createTestRoomSession,
-  expectInteractivityMode,
   SERVER_URL,
+  expectRoomJoined,
+  expectMCUVisible,
 } from '../utils'
 
 test.describe('RoomSession promote myself', () => {
-  test('should get 202 on trying to promote a member', async ({ context }) => {
-    const pageOne = await context.newPage()
+  test('should get 202 on trying to promote a member', async ({
+    createCustomPage,
+  }) => {
+    const pageOne = await createCustomPage({ name: '[page]' })
 
     await pageOne.goto(SERVER_URL)
 
@@ -25,24 +28,10 @@ test.describe('RoomSession promote myself', () => {
     await createTestRoomSession(pageOne, memberSettings)
 
     // --------------- Joining from the 1st tab as member and resolve on 'room.joined' ---------------
-    await pageOne.evaluate(() => {
-      return new Promise((resolve) => {
-        // @ts-expect-error
-        const roomObj = window._roomObj
-        roomObj.on('room.joined', resolve)
-        roomObj.join()
-      })
-    })
-
-    // --------------- Make sure on pageOne we have a member ---------------
-    await expectInteractivityMode(pageOne, 'member')
+    await expectRoomJoined(pageOne)
 
     // Checks that the video is visible on pageOne
-    await pageOne.waitForSelector('div[id^="sw-sdk-"] > video', {
-      timeout: 5000,
-    })
-
-    await pageOne.waitForTimeout(2000)
+    await expectMCUVisible(pageOne)
 
     // --------------- Promote participant from pageOne and resolve on error ---------------
     const promoteResponse: any = await pageOne.evaluate(() => {
@@ -59,9 +48,5 @@ test.describe('RoomSession promote myself', () => {
     })
 
     expect(promoteResponse).toBe(true)
-
-    // --------------- Leaving the rooms ---------------
-    // @ts-expect-error
-    await pageOne.evaluate(() => window._roomObj.leave())
   })
 })

--- a/internal/e2e-js/tests/roomSessionPromoteParticipant.spec.ts
+++ b/internal/e2e-js/tests/roomSessionPromoteParticipant.spec.ts
@@ -2,7 +2,6 @@ import { test, expect } from '@playwright/test'
 import type { Video } from '@signalwire/js'
 import {
   createTestRoomSession,
-  enablePageLogs,
   expectInteractivityMode,
   SERVER_URL,
 } from '../utils'
@@ -10,7 +9,6 @@ import {
 test.describe('RoomSession promote myself', () => {
   test('should get 202 on trying to promote a member', async ({ context }) => {
     const pageOne = await context.newPage()
-    enablePageLogs(pageOne, '[pageOne]')
 
     await pageOne.goto(SERVER_URL)
 

--- a/internal/e2e-js/tests/roomSessionRemoveAfterSecondsElapsed.spec.ts
+++ b/internal/e2e-js/tests/roomSessionRemoveAfterSecondsElapsed.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test'
+import { test, expect } from '../fixtures'
 import type { Video } from '@signalwire/js'
 import {
   SERVER_URL,
@@ -38,10 +38,13 @@ test.describe('RoomSession remove_after_seconds_elapsed', () => {
 
   tests.forEach((row) => {
     test(`should remove the member after X seconds elapsed [${row.testName}]`, async ({
-      page,
+      createCustomPage,
     }) => {
       let roomData: any = {}
 
+      const page = await createCustomPage({
+        name: '[removeAfterSecElapsedPage]',
+      })
       await page.goto(SERVER_URL)
 
       const removeAfter = 5
@@ -67,7 +70,7 @@ test.describe('RoomSession remove_after_seconds_elapsed', () => {
 
       // --------------- Joining the room and wait first `room.joined` and then `room.left` ---------------
       await page.evaluate(async () => {
-        return new Promise((resolve) => {
+        return new Promise(async (resolve) => {
           // @ts-expect-error
           const roomObj: Video.RoomSession = window._roomObj
           roomObj.on('room.joined', () => {
@@ -76,7 +79,7 @@ test.describe('RoomSession remove_after_seconds_elapsed', () => {
             })
           })
 
-          roomObj.join()
+          await roomObj.join()
         })
       })
 

--- a/internal/e2e-js/tests/roomSessionRemoveAfterSecondsElapsed.spec.ts
+++ b/internal/e2e-js/tests/roomSessionRemoveAfterSecondsElapsed.spec.ts
@@ -5,7 +5,6 @@ import {
   createTestRoomSession,
   createOrUpdateRoom,
   deleteRoom,
-  enablePageLogs,
   randomizeRoomName,
 } from '../utils'
 
@@ -44,7 +43,6 @@ test.describe('RoomSession remove_after_seconds_elapsed', () => {
       let roomData: any = {}
 
       await page.goto(SERVER_URL)
-      enablePageLogs(page)
 
       const removeAfter = 5
       if (!row.autoCreateRoom) {

--- a/internal/e2e-js/tests/roomSessionRemoveAt.spec.ts
+++ b/internal/e2e-js/tests/roomSessionRemoveAt.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test'
+import { test, expect } from '../fixtures'
 import type { Video } from '@signalwire/js'
 import {
   SERVER_URL,
@@ -38,10 +38,13 @@ test.describe('RoomSession remove_at', () => {
 
   tests.forEach((row) => {
     test(`should remove all members after the remove_at value [${row.testName}]`, async ({
-      page,
+      createCustomPage,
     }) => {
       let roomData: any = {}
 
+      const page = await createCustomPage({
+        name: '[removeAtPage]',
+      })
       await page.goto(SERVER_URL)
 
       const delay = 10_000

--- a/internal/e2e-js/tests/roomSessionRemoveAt.spec.ts
+++ b/internal/e2e-js/tests/roomSessionRemoveAt.spec.ts
@@ -5,7 +5,6 @@ import {
   createTestRoomSession,
   createOrUpdateRoom,
   deleteRoom,
-  enablePageLogs,
   randomizeRoomName,
 } from '../utils'
 
@@ -44,7 +43,6 @@ test.describe('RoomSession remove_at', () => {
       let roomData: any = {}
 
       await page.goto(SERVER_URL)
-      enablePageLogs(page)
 
       const delay = 10_000
       const removeAt = new Date(Date.now() + delay).toISOString()

--- a/internal/e2e-js/tests/roomSessionStreaming.spec.ts
+++ b/internal/e2e-js/tests/roomSessionStreaming.spec.ts
@@ -1,15 +1,12 @@
 import { test, expect } from '@playwright/test'
 import type { Video } from '@signalwire/js'
-import { SERVER_URL, createTestRoomSession, enablePageLogs } from '../utils'
+import { SERVER_URL, createTestRoomSession } from '../utils'
 
 test.describe('RoomSession', () => {
   test('should handle Stream events and methods', async ({ context }) => {
     const pageOne = await context.newPage()
-    enablePageLogs(pageOne, '[pageOne]')
     const pageTwo = await context.newPage()
-    enablePageLogs(pageTwo, '[pageTwo]')
     const pageThree = await context.newPage()
-    enablePageLogs(pageThree, '[pageThree]')
 
     await Promise.all([
       pageOne.goto(SERVER_URL),

--- a/internal/e2e-js/tests/roomSessionStreamingAPI.spec.ts
+++ b/internal/e2e-js/tests/roomSessionStreamingAPI.spec.ts
@@ -2,7 +2,6 @@ import { test } from '@playwright/test'
 import {
   SERVER_URL,
   createTestRoomSession,
-  enablePageLogs,
   createOrUpdateRoom,
   randomizeRoomName,
   createStreamForRoom,
@@ -13,8 +12,6 @@ test.describe('Room Streaming from REST API', () => {
   test('should start a stream using the REST API', async ({ context }) => {
     const pageOne = await context.newPage()
     const pageTwo = await context.newPage()
-    enablePageLogs(pageOne, '[pageOne]')
-    enablePageLogs(pageTwo, '[pageTwo]')
 
     await pageOne.goto(SERVER_URL)
 

--- a/internal/e2e-js/tests/roomSessionTalkingEventsToAudience.spec.ts
+++ b/internal/e2e-js/tests/roomSessionTalkingEventsToAudience.spec.ts
@@ -1,16 +1,17 @@
-import { test } from '@playwright/test'
+import { test } from '../fixtures'
 import {
   SERVER_URL,
   createTestRoomSession,
-  expectSDPDirection,
-  expectInteractivityMode,
-  expectMemberId,
+  expectRoomJoined,
+  expectMCUVisible,
 } from '../utils'
 
 test.describe('RoomSession talking events to audience', () => {
-  test('audience should receive talking events', async ({ context }) => {
-    const pageOne = await context.newPage()
-    const pageTwo = await context.newPage()
+  test('audience should receive talking events', async ({
+    createCustomPage,
+  }) => {
+    const pageOne = await createCustomPage({ name: '[pageOne]' })
+    const pageTwo = await createCustomPage({ name: '[pageTwo]' })
 
     await Promise.all([pageOne.goto(SERVER_URL), pageTwo.goto(SERVER_URL)])
 
@@ -41,28 +42,10 @@ test.describe('RoomSession talking events to audience', () => {
     ])
 
     // --------------- Joining from the 2nd tab as audience and resolve on 'room.joined' ---------------
-    const pageTwoRoomJoined: any = await pageTwo.evaluate(() => {
-      return new Promise((resolve) => {
-        // @ts-expect-error
-        const roomObj = window._roomObj
-        roomObj.once('room.joined', resolve)
-        roomObj.join()
-      })
-    })
-
-    // --------------- Make sure pageTwo exposes the correct memberId  ---------------
-    await expectMemberId(pageTwo, pageTwoRoomJoined.member_id)
-
-    // --------------- Make sure on pageTwo we have a audience ---------------
-    await expectInteractivityMode(pageTwo, 'audience')
-
-    // --------------- Check SDP/RTCPeer on audience (recvonly since audience) ---------------
-    await expectSDPDirection(pageTwo, 'recvonly', true)
+    await expectRoomJoined(pageTwo)
 
     // Checks that the video is visible on pageTwo
-    await pageTwo.waitForSelector('#rootElement video', {
-      timeout: 10000,
-    })
+    await expectMCUVisible(pageTwo)
 
     // --------------- Resolve when audience receives member.talking ----------
     const audienceMemberTalkingPromise = pageTwo.evaluate(async () => {
@@ -76,35 +59,12 @@ test.describe('RoomSession talking events to audience', () => {
     await pageTwo.waitForTimeout(1000)
 
     // --------------- Joining from the 1st tab as member and resolve on 'room.joined' ---------------
-    await pageOne.evaluate(() => {
-      return new Promise((resolve) => {
-        // @ts-expect-error
-        const roomObj = window._roomObj
-        roomObj.on('room.joined', resolve)
-        roomObj.join()
-      })
-    })
-
-    // --------------- Make sure on pageOne we have a member ---------------
-    await expectInteractivityMode(pageOne, 'member')
-
-    // --------------- Check SDP/RTCPeer on member (sendrecv since member) ---------------
-    await expectSDPDirection(pageOne, 'sendrecv', true)
+    await expectRoomJoined(pageOne)
 
     // Checks that the video is visible on pageOne
-    await pageOne.waitForSelector('div[id^="sw-sdk-"] > video', {
-      timeout: 5000,
-    })
+    await expectMCUVisible(pageOne)
 
     // Wait for `member.talking` on pageTwo
     await audienceMemberTalkingPromise
-
-    // --------------- Leaving the rooms ---------------
-    await Promise.all([
-      // @ts-expect-error
-      pageOne.evaluate(() => window._roomObj.leave()),
-      // @ts-expect-error
-      pageTwo.evaluate(() => window._roomObj.leave()),
-    ])
   })
 })

--- a/internal/e2e-js/tests/roomSessionTalkingEventsToAudience.spec.ts
+++ b/internal/e2e-js/tests/roomSessionTalkingEventsToAudience.spec.ts
@@ -4,6 +4,7 @@ import {
   createTestRoomSession,
   expectRoomJoined,
   expectMCUVisible,
+  expectMCUVisibleForAudience,
 } from '../utils'
 
 test.describe('RoomSession talking events to audience', () => {
@@ -45,7 +46,7 @@ test.describe('RoomSession talking events to audience', () => {
     await expectRoomJoined(pageTwo)
 
     // Checks that the video is visible on pageTwo
-    await expectMCUVisible(pageTwo)
+    await expectMCUVisibleForAudience(pageTwo)
 
     // --------------- Resolve when audience receives member.talking ----------
     const audienceMemberTalkingPromise = pageTwo.evaluate(async () => {

--- a/internal/e2e-js/tests/roomSessionTalkingEventsToAudience.spec.ts
+++ b/internal/e2e-js/tests/roomSessionTalkingEventsToAudience.spec.ts
@@ -2,7 +2,6 @@ import { test } from '@playwright/test'
 import {
   SERVER_URL,
   createTestRoomSession,
-  enablePageLogs,
   expectSDPDirection,
   expectInteractivityMode,
   expectMemberId,
@@ -11,9 +10,7 @@ import {
 test.describe('RoomSession talking events to audience', () => {
   test('audience should receive talking events', async ({ context }) => {
     const pageOne = await context.newPage()
-    enablePageLogs(pageOne, '[pageOne]')
     const pageTwo = await context.newPage()
-    enablePageLogs(pageTwo, '[pageTwo]')
 
     await Promise.all([pageOne.goto(SERVER_URL), pageTwo.goto(SERVER_URL)])
 

--- a/internal/e2e-js/tests/roomSessionUnauthorized.spec.ts
+++ b/internal/e2e-js/tests/roomSessionUnauthorized.spec.ts
@@ -5,7 +5,7 @@ import {
   createTestRoomSession,
   randomizeRoomName,
   expectRoomJoined,
-  expectMCUVisible,
+  expectMCUVisibleForAudience,
 } from '../utils'
 
 test.describe('RoomSession unauthorized methods for audience', () => {
@@ -47,7 +47,7 @@ test.describe('RoomSession unauthorized methods for audience', () => {
     expect(joinParams.room.name).toBe(roomName)
 
     // Checks that the video is visible, as audience
-    await expectMCUVisible(page)
+    await expectMCUVisibleForAudience(page)
 
     const roomPermissions: any = await page.evaluate(() => {
       // @ts-expect-error

--- a/internal/e2e-js/tests/roomSessionUnauthorized.spec.ts
+++ b/internal/e2e-js/tests/roomSessionUnauthorized.spec.ts
@@ -1,15 +1,22 @@
-import { test, expect } from '@playwright/test'
+import { test, expect } from '../fixtures'
 import type { Video } from '@signalwire/js'
-import { SERVER_URL, createTestRoomSession, randomizeRoomName } from '../utils'
+import {
+  SERVER_URL,
+  createTestRoomSession,
+  randomizeRoomName,
+  expectRoomJoined,
+  expectMCUVisible,
+} from '../utils'
 
 test.describe('RoomSession unauthorized methods for audience', () => {
   test('should handle joining a room, try to perform unauthorized actions and then leave the room', async ({
-    page,
+    createCustomPage,
   }) => {
+    const page = await createCustomPage({ name: '[page]' })
     await page.goto(SERVER_URL)
 
     const roomName = randomizeRoomName('e2e-403')
-    const audience_permissions: string[] = []
+    const audiencePermissions: string[] = []
 
     await createTestRoomSession(page, {
       vrt: {
@@ -17,7 +24,7 @@ test.describe('RoomSession unauthorized methods for audience', () => {
         user_name: 'e2e_test_403',
         join_as: 'audience' as const,
         auto_create_room: true,
-        permissions: audience_permissions,
+        permissions: audiencePermissions,
       },
       initialEvents: [
         'member.joined',
@@ -33,59 +40,30 @@ test.describe('RoomSession unauthorized methods for audience', () => {
     })
 
     // --------------- Joining the room ---------------
-    const joinParams: any = await page.evaluate(() => {
-      return new Promise((r) => {
-        // @ts-expect-error
-        const roomObj = window._roomObj
-        roomObj.on('room.joined', (params: any) => r(params))
-        roomObj.join()
-      })
-    })
+    const joinParams = await expectRoomJoined(page)
 
     expect(joinParams.room).toBeDefined()
     expect(joinParams.room_session).toBeDefined()
     expect(joinParams.room.name).toBe(roomName)
 
     // Checks that the video is visible, as audience
-    await page.waitForSelector('#rootElement video', {
-      timeout: 10000,
-    })
+    await expectMCUVisible(page)
 
     const roomPermissions: any = await page.evaluate(() => {
       // @ts-expect-error
       const roomObj: Video.RoomSession = window._roomObj
       return roomObj.permissions
     })
-    expect(roomPermissions).toStrictEqual(audience_permissions)
+    expect(roomPermissions).toStrictEqual(audiencePermissions)
 
     // --------------- Unmuting Audio (self) and expecting 403 ---------------
     const errorCode: any = await page.evaluate(async () => {
       // @ts-expect-error
       const roomObj: Video.RoomSession = window._roomObj
       const error = await roomObj.audioUnmute().catch((error) => error)
-      console.log(
-        'audioUnmute error',
-        error.jsonrpc.code,
-        error.jsonrpc.message
-      )
+
       return error.jsonrpc.code
     })
     expect(errorCode).toBe('403')
-
-    // --------------- Leaving the room ---------------
-    await page.evaluate(() => {
-      // @ts-expect-error
-      return window._roomObj.leave()
-    })
-
-    // Checks that all the elements added by the SDK are gone.
-    const targetElementsCount = await page.evaluate(() => {
-      return {
-        videos: Array.from(document.querySelectorAll('video')).length,
-        rootEl: document.getElementById('rootElement')!.childElementCount,
-      }
-    })
-    expect(targetElementsCount.videos).toBe(0)
-    expect(targetElementsCount.rootEl).toBe(0)
   })
 })

--- a/internal/e2e-js/tests/roomSessionUnauthorized.spec.ts
+++ b/internal/e2e-js/tests/roomSessionUnauthorized.spec.ts
@@ -1,18 +1,12 @@
 import { test, expect } from '@playwright/test'
 import type { Video } from '@signalwire/js'
-import {
-  SERVER_URL,
-  createTestRoomSession,
-  enablePageLogs,
-  randomizeRoomName,
-} from '../utils'
+import { SERVER_URL, createTestRoomSession, randomizeRoomName } from '../utils'
 
 test.describe('RoomSession unauthorized methods for audience', () => {
   test('should handle joining a room, try to perform unauthorized actions and then leave the room', async ({
     page,
   }) => {
     await page.goto(SERVER_URL)
-    enablePageLogs(page)
 
     const roomName = randomizeRoomName('e2e-403')
     const audience_permissions: string[] = []

--- a/internal/e2e-js/tests/roomSettings.spec.ts
+++ b/internal/e2e-js/tests/roomSettings.spec.ts
@@ -5,7 +5,6 @@ import {
   createTestRoomSession,
   createOrUpdateRoom,
   deleteRoom,
-  enablePageLogs,
   CreateOrUpdateRoomOptions,
   randomizeRoomName,
 } from '../utils'
@@ -45,7 +44,6 @@ test.describe('Room Settings', () => {
   tests.forEach((row) => {
     test(row.testName, async ({ page }) => {
       await page.goto(SERVER_URL)
-      enablePageLogs(page)
 
       const roomData = await createOrUpdateRoom({
         name: row.roomName,

--- a/internal/e2e-js/utils.ts
+++ b/internal/e2e-js/utils.ts
@@ -238,7 +238,7 @@ export const expectRoomJoined = (page: Page) => {
 }
 
 export const expectMCUVisible = async (page: Page) => {
-  await page.waitForSelector('div[id^="sw-sdk-"] > video', { timeout: 5000 })
+  await page.waitForSelector('div[id^="sw-sdk-"] > video')
 }
 
 export const randomizeRoomName = (prefix: string = 'e2e') => {

--- a/internal/e2e-js/utils.ts
+++ b/internal/e2e-js/utils.ts
@@ -73,9 +73,9 @@ export const createTestRoomSession = async (
         rootElement: document.getElementById('rootElement'),
         audio: true,
         video: true,
-        logLevel: process.env.CI ? 'warn' : 'debug',
+        logLevel: options.CI ? 'warn' : 'debug',
         debug: {
-          logWsTraffic: !process.env.CI,
+          logWsTraffic: !options.CI,
         },
       })
 
@@ -92,6 +92,7 @@ export const createTestRoomSession = async (
       RELAY_HOST: process.env.RELAY_HOST,
       API_TOKEN: vrt,
       initialEvents: options.initialEvents,
+      CI: process.env.CI,
     }
   )
 }
@@ -209,6 +210,21 @@ export const setLayoutOnPage = (page: Page, layoutName: string) => {
     },
     { layoutName }
   )
+}
+
+export const expectRoomJoined = (page: Page) => {
+  return page.evaluate(() => {
+    return new Promise<any>(async (resolve) => {
+      // @ts-expect-error
+      const roomObj: Video.RoomSession = window._roomObj
+      roomObj.on('room.joined', resolve)
+      await roomObj.join()
+    })
+  })
+}
+
+export const expectMCUVisible = async (page: Page) => {
+  await page.waitForSelector('div[id^="sw-sdk-"] > video', { timeout: 5000 })
 }
 
 export const randomizeRoomName = (prefix: string = 'e2e') => {

--- a/internal/e2e-js/utils.ts
+++ b/internal/e2e-js/utils.ts
@@ -226,15 +226,21 @@ export const setLayoutOnPage = (page: Page, layoutName: string) => {
   )
 }
 
-export const expectRoomJoined = (page: Page) => {
-  return page.evaluate(() => {
+export const expectRoomJoined = (
+  page: Page,
+  options: { invokeJoin: boolean } = { invokeJoin: true }
+) => {
+  return page.evaluate(({ invokeJoin }) => {
     return new Promise<any>(async (resolve) => {
       // @ts-expect-error
       const roomObj: Video.RoomSession = window._roomObj
       roomObj.once('room.joined', resolve)
-      await roomObj.join()
+
+      if (invokeJoin) {
+        await roomObj.join()
+      }
     })
-  })
+  }, options)
 }
 
 export const expectMCUVisible = async (page: Page) => {

--- a/internal/e2e-js/utils.ts
+++ b/internal/e2e-js/utils.ts
@@ -57,6 +57,7 @@ export const createTestRoomSession = async (
     vrt: CreateTestVRTOptions
     /** set of events to automatically subscribe before room.join() */
     initialEvents?: string[]
+    expectToJoin?: boolean
   }
 ) => {
   const vrt = await createTestVRTToken(options.vrt)
@@ -97,15 +98,17 @@ export const createTestRoomSession = async (
     }
   )
 
-  expectRoomJoined(page).then(async (params) => {
-    await expectMemberId(page, params.member_id)
+  if (options.expectToJoin !== false) {
+    expectRoomJoined(page, { invokeJoin: false }).then(async (params) => {
+      await expectMemberId(page, params.member_id)
 
-    const dir = options.vrt.join_as === 'audience' ? 'recvonly' : 'sendrecv'
-    await expectSDPDirection(page, dir, true)
+      const dir = options.vrt.join_as === 'audience' ? 'recvonly' : 'sendrecv'
+      await expectSDPDirection(page, dir, true)
 
-    const mode = options.vrt.join_as === 'audience' ? 'audience' : 'member'
-    await expectInteractivityMode(page, mode)
-  })
+      const mode = options.vrt.join_as === 'audience' ? 'audience' : 'member'
+      await expectInteractivityMode(page, mode)
+    })
+  }
 
   return roomSession
 }

--- a/internal/e2e-js/utils.ts
+++ b/internal/e2e-js/utils.ts
@@ -250,6 +250,10 @@ export const expectMCUVisible = async (page: Page) => {
   await page.waitForSelector('div[id^="sw-sdk-"] > video')
 }
 
+export const expectMCUVisibleForAudience = async (page: Page) => {
+  await page.waitForSelector('#rootElement video')
+}
+
 export const randomizeRoomName = (prefix: string = 'e2e') => {
   return `${prefix}${uuid()}`
 }

--- a/internal/e2e-js/utils.ts
+++ b/internal/e2e-js/utils.ts
@@ -73,10 +73,10 @@ export const createTestRoomSession = async (
         rootElement: document.getElementById('rootElement'),
         audio: true,
         video: true,
-        logLevel: 'warn',
-        // debug: {
-        //   logWsTraffic: true,
-        // },
+        logLevel: process.env.CI ? 'warn' : 'debug',
+        debug: {
+          logWsTraffic: !process.env.CI,
+        },
       })
 
       options.initialEvents?.forEach((event) => {

--- a/internal/e2e-js/utils.ts
+++ b/internal/e2e-js/utils.ts
@@ -217,7 +217,7 @@ export const expectRoomJoined = (page: Page) => {
     return new Promise<any>(async (resolve) => {
       // @ts-expect-error
       const roomObj: Video.RoomSession = window._roomObj
-      roomObj.on('room.joined', resolve)
+      roomObj.once('room.joined', resolve)
       await roomObj.join()
     })
   })

--- a/internal/e2e-js/utils.ts
+++ b/internal/e2e-js/utils.ts
@@ -122,7 +122,7 @@ interface CreateTestVRTOptions {
   remove_after_seconds_elapsed?: number
   auto_create_room?: boolean
   join_as?: 'member' | 'audience'
-  media_allowed?: 'audio-only' | 'audio-only' | 'all'
+  media_allowed?: 'audio-only' | 'video-only' | 'all'
 }
 
 export const createTestVRTToken = async (body: CreateTestVRTOptions) => {

--- a/internal/e2e-js/utils.ts
+++ b/internal/e2e-js/utils.ts
@@ -73,8 +73,6 @@ export const createTestRoomSession = async (
         host: options.RELAY_HOST,
         token: options.API_TOKEN,
         rootElement: document.getElementById('rootElement'),
-        audio: true,
-        video: true,
         logLevel: options.CI ? 'warn' : 'debug',
         debug: {
           logWsTraffic: !options.CI,

--- a/scripts/sw-test/index.js
+++ b/scripts/sw-test/index.js
@@ -70,7 +70,9 @@ const runTests = (mode, config) => {
           : runCommand
       try {
         console.time('Playwright Tests')
-        execSync(command, { stdio: 'inherit' })
+        execSync(`${command} ${process.argv.slice(3).join(' ')}`, {
+          stdio: 'inherit',
+        })
         console.log('\n')
         console.timeEnd('Playwright Tests')
         console.log(`Playwright Done ${new Date().toISOString()}`)


### PR DESCRIPTION
This PR includes some improvements for the e2e tests:

- custom fixture to have a single place where we use `.leave()` to leave the RoomSession and clean up the `page`
- DRY the code a bit moving some logic within util functions

Note: for now i've changed the `roomSession.spec.ts` file only, when we agree on these patterns i can apply the changes on all the the other files.


- [x] Move audio stats to utils