### PR TITLE
e2e test: improve AudienceCount

### DIFF
--- a/internal/e2e-js/tests/roomSessionAudienceCount.spec.ts
+++ b/internal/e2e-js/tests/roomSessionAudienceCount.spec.ts
@@ -116,7 +116,8 @@ test.describe('RoomSession Audience Count', () => {
       audienceCountPageTwoPromise,
     ])
 
-    await pageOne.waitForTimeout(20_000)
+    // audience_count events come "every" 20s so wait for 25s to avoid race
+    await pageOne.waitForTimeout(25_000)
 
     const totalsPageOne = await expectorPageOne.getTotals()
     expect(totalsPageOne.totalFromAudienceCount).toBe(expectedAudienceCount)


### PR DESCRIPTION
Instead of waiting for 30 seconds and expect that the count is then correct, let's wait until the event provides the right count.
This accounts also for cases where for any reason the count goes beyond the correct number temporarily.