### PR TITLE
e2e audio energy level review

### DIFF
--- a/internal/e2e-js/tests/roomSessionDemote.spec.ts
+++ b/internal/e2e-js/tests/roomSessionDemote.spec.ts
@@ -8,7 +8,7 @@ import {
   expectMemberId,
   expectRoomJoined,
   expectMCUVisible,
-  expectTotalAudioEnergyToBeGreaterThan,
+  expectPageReceiveAudio,
 } from '../utils'
 
 test.describe('RoomSession demote participant', () => {
@@ -43,34 +43,20 @@ test.describe('RoomSession demote participant', () => {
       createTestRoomSession(pageTwo, participant2Settings),
     ])
 
-    // --------------- Joining from the 1st tab as member and resolve on 'room.joined' ---------------
     await expectRoomJoined(pageOne)
-
-    // Checks that the video is visible on pageOne
     await expectMCUVisible(pageOne)
 
-    // --------------- Joining from the 2st tab as audience and resolve on 'room.joined' ---------------
     const pageTwoRoomJoined = await expectRoomJoined(pageTwo)
-
-    // Stable ref of the initial memberId
     const participant2Id = pageTwoRoomJoined.member_id
-
-    // --------------- Make sure pageTwo exposes the correct memberId  ---------------
     await expectMemberId(pageTwo, participant2Id)
-
-    // Checks that the video is visible on pageTwo
     await expectMCUVisible(pageTwo)
 
-    // --------------- Check that the participant on pageTwo is receiving non-silence ---------------
-    // --------------- Wait a bit for the media to flow ---------------
+    // Wait five seconds before demoting
     await pageOne.waitForTimeout(5000)
-    await expectTotalAudioEnergyToBeGreaterThan(pageTwo, 0.1)
 
-    await pageOne.waitForTimeout(5000)
-    await expectTotalAudioEnergyToBeGreaterThan(pageTwo, 0.5)
-
-    // --------------- Demote participant on pageTwo to audience from pageOne
-    // and resolve on `member.left` amd `layout.changed` with position off-canvas ---------------
+    // Demote participant on pageTwo to audience from pageOne
+    // and resolve on `member.left` amd `layout.changed` with
+    // position off-canvas
     await pageOne.evaluate(
       async ({ demoteMemberId }) => {
         // @ts-expect-error
@@ -80,7 +66,6 @@ test.describe('RoomSession demote participant', () => {
           (resolve, reject) => {
             roomObj.on('layout.changed', ({ layout }) => {
               for (const layer of layout.layers) {
-                // console.log("Layer member ID:", layer.member_id, "Demoted member ID:", demoteMemberId, " Position:", layer.position)
                 if (
                   layer.member_id === demoteMemberId &&
                   layer.visible === true
@@ -127,14 +112,12 @@ test.describe('RoomSession demote participant', () => {
       invokeJoin: false,
     })
 
-    // --------------- Make sure member_id is the same after promote and demote on pageTwo ---------------
-    await expectMemberId(pageTwo, participant2Id) // before promote
-    await expectMemberId(pageTwo, promiseAudienceRoomJoined.member_id) // after promote
-
-    // --------------- Make sure on pageTwo he is an audience member ---------------
+     // Expect same member ID as before demote
+    await expectMemberId(pageTwo, participant2Id)
+    await expectMemberId(pageTwo, promiseAudienceRoomJoined.member_id)
     await expectInteractivityMode(pageTwo, 'audience')
-
-    // --------------- Check SDP/RTCPeer on audience (audience again so recvonly) ---------------
     await expectSDPDirection(pageTwo, 'recvonly', true)
+
+    await expectPageReceiveAudio(pageTwo)
   })
 })

--- a/internal/e2e-js/tests/roomSessionPromoteDemote.spec.ts
+++ b/internal/e2e-js/tests/roomSessionPromoteDemote.spec.ts
@@ -11,7 +11,7 @@ import {
   expectRoomJoined,
   expectMCUVisible,
   expectMCUVisibleForAudience,
-  expectTotalAudioEnergyToBeGreaterThan,
+  expectPageReceiveAudio
 } from '../utils'
 
 test.describe('RoomSession promote/demote methods', () => {
@@ -61,27 +61,13 @@ test.describe('RoomSession promote/demote methods', () => {
       createTestRoomSession(pageTwo, audienceSettings),
     ])
 
-    // --------------- Joining from the 1st tab as member and resolve on 'room.joined' ---------------
     await expectRoomJoined(pageOne)
-
-    // Checks that the video is visible on pageOne
     await expectMCUVisible(pageOne)
 
-    // --------------- Joining from the 2st tab as audience and resolve on 'room.joined' ---------------
     const pageTwoRoomJoined = await expectRoomJoined(pageTwo)
-
-    // Stable ref of the initial memberId for the audience
     const audienceId = pageTwoRoomJoined.member_id
-
-    // Checks that the video is visible on pageTwo
     await expectMCUVisibleForAudience(pageTwo)
-
-    // --------------- Check that the audience member on pageTwo is receiving non-silence ---------------
-    await pageOne.waitForTimeout(5000)
-    await expectTotalAudioEnergyToBeGreaterThan(pageTwo, 0.1)
-
-    await pageOne.waitForTimeout(5000)
-    await expectTotalAudioEnergyToBeGreaterThan(pageTwo, 0.5)
+    await expectPageReceiveAudio(pageTwo)
 
     // --------------- Make sure a `layout.changed` reached both member and audience --------------
 

--- a/internal/e2e-js/utils.ts
+++ b/internal/e2e-js/utils.ts
@@ -73,7 +73,7 @@ export const createTestRoomSession = async (
         host: options.RELAY_HOST,
         token: options.API_TOKEN,
         rootElement: document.getElementById('rootElement'),
-        logLevel: 'debug',
+        logLevel: options.CI ? 'warn' : 'debug',
         debug: {
           logWsTraffic: !options.CI,
         },

--- a/internal/e2e-js/utils.ts
+++ b/internal/e2e-js/utils.ts
@@ -73,7 +73,7 @@ export const createTestRoomSession = async (
         host: options.RELAY_HOST,
         token: options.API_TOKEN,
         rootElement: document.getElementById('rootElement'),
-        logLevel: options.CI ? 'warn' : 'debug',
+        logLevel: 'debug',
         debug: {
           logWsTraffic: !options.CI,
         },
@@ -273,10 +273,25 @@ export const expectTotalAudioEnergyToBeGreaterThan = async (
   const audioStats = await page.evaluate(async () => {
     // @ts-expect-error
     const roomObj: Video.RoomSession = window._roomObj
+
+    // @ts-expect-error
+    const audioTrackId = roomObj.peer._getReceiverByKind('audio').track.id
+
     // @ts-expect-error
     const stats = await roomObj.peer.instance.getStats(null)
     const filter = {
-      'inbound-rtp': ['audioLevel', 'totalAudioEnergy', 'totalSamplesDuration'],
+      'inbound-rtp': [
+        'audioLevel',
+        'totalAudioEnergy',
+        'totalSamplesDuration',
+        'totalSamplesReceived',
+        'packetsDiscarded',
+        'lastPacketReceivedTimestamp',
+        'bytesReceived',
+        'packetsReceived',
+        'packetsLost',
+        'packetsRetransmitted',
+      ],
     }
     const result: any = {}
     Object.keys(filter).forEach((entry) => {
@@ -285,10 +300,10 @@ export const expectTotalAudioEnergyToBeGreaterThan = async (
 
     stats.forEach((report: any) => {
       for (const [key, value] of Object.entries(filter)) {
-        //console.log(key, value, report.type)
-        if (report.type == key) {
+        if (report.type == key &&
+          report["mediaType"] === "audio" &&
+          report["trackIdentifier"] === audioTrackId) {
           value.forEach((entry) => {
-            //console.log(key, entry, report[entry])
             if (report[entry]) {
               result[key][entry] = report[entry]
             }
@@ -392,4 +407,9 @@ export const deleteRoom = async (id: string) => {
       Authorization: `Basic ${Buffer.from(authCreds).toString('base64')}`,
     },
   })
+}
+
+export const expectPageReceiveAudio = async (page: Page) => {
+  await page.waitForTimeout(10000)
+  await expectTotalAudioEnergyToBeGreaterThan(page, 0.5)
 }


### PR DESCRIPTION
- `roomSessionDemote`: move check for audio received to after promotion
- Encapsulate checks for audio received
- Relax threshold for `totalAudioEnergy`