### PR TITLE
e2e tests: Reattach with wrong call id

### DIFF
--- a/internal/e2e-js/playwright.config.ts
+++ b/internal/e2e-js/playwright.config.ts
@@ -8,7 +8,7 @@ const config: PlaywrightTestConfig = {
   testDir: 'tests',
   globalSetup: require.resolve('./global-setup'),
   testMatch: testMatch.length ? testMatch : undefined,
-  testIgnore: ['roomSessionReattachWrongCallId.spec.ts'],
+  testIgnore: [],
   timeout: 120_000,
   expect: {
     // Default is 5000

--- a/internal/e2e-js/playwright.config.ts
+++ b/internal/e2e-js/playwright.config.ts
@@ -8,7 +8,7 @@ const config: PlaywrightTestConfig = {
   testDir: 'tests',
   globalSetup: require.resolve('./global-setup'),
   testMatch: testMatch.length ? testMatch : undefined,
-  testIgnore: [],
+  testIgnore: ['roomSessionReattachWrongCallId.spec.ts'],
   timeout: 120_000,
   expect: {
     // Default is 5000

--- a/internal/e2e-js/tests/roomSessionReattachWrongCallId.spec.ts
+++ b/internal/e2e-js/tests/roomSessionReattachWrongCallId.spec.ts
@@ -7,91 +7,114 @@ import {
   randomizeRoomName,
   expectRoomJoined,
   expectMCUVisible,
+  expectMCUVisibleForAudience,
 } from '../utils'
 
+type Test = {
+  join_as: 'member' | 'audience'
+  expectMCU: typeof expectMCUVisible | typeof expectMCUVisibleForAudience
+}
+
 test.describe('RoomSessionReattachWrongCallId', () => {
-  test('should handle joining a room, reattaching with wrong callID and then leaving the room', async ({
-    createCustomPage,
-  }) => {
-    const page = await createCustomPage({ name: '[reattach-bad-call-id]' })
-    await page.goto(SERVER_URL)
+  /**
+   * Test both member and audience
+   */
+  const tests: Test[] = [
+    { join_as: 'member', expectMCU: expectMCUVisible },
+    { join_as: 'audience', expectMCU: expectMCUVisibleForAudience },
+  ]
 
-    const roomName = randomizeRoomName()
-    const permissions: any = []
-    const connectionSettings = {
-      vrt: {
-        room_name: roomName,
-        user_name: 'e2e_reattach_test_wrong_call_id',
-        auto_create_room: true,
-        permissions,
-      },
-      initialEvents: [],
-      roomSessionOptions: {
-        reattach: true, // FIXME: to remove
-      },
-    }
-    await createTestRoomSession(page, connectionSettings)
+  tests.forEach((row) => {
+    test(`should try reattaching to a room with a wrong call Id for ${row.join_as}`, async ({
+      createCustomPage,
+    }) => {
+      const page = await createCustomPage({ name: `[reattach-callid-${row.join_as}]` })
+      await page.goto(SERVER_URL)
 
-    // --------------- Joining the room ---------------
-    const joinParams: any = await expectRoomJoined(page)
+      const roomName = randomizeRoomName()
+      const permissions: any = []
+      const connectionSettings = {
+        vrt: {
+          room_name: roomName,
+          user_name: `e2e_reattach_wrong_callid_${row.join_as}`,
+          join_as: row.join_as,
+          auto_create_room: true,
+          permissions,
+        },
+        initialEvents: [],
+        roomSessionOptions: {
+          reattach: true, // FIXME: to remove
+        },
+      }
+      await createTestRoomSession(page, connectionSettings)
 
-    expect(joinParams.room).toBeDefined()
-    expect(joinParams.room_session).toBeDefined()
-    expect(
-      joinParams.room.members.some(
-        (member: any) => member.id === joinParams.member_id
-      )
-    ).toBeTruthy()
-    expect(joinParams.room_session.name).toBe(roomName)
-    expect(joinParams.room.name).toBe(roomName)
+      // --------------- Joining the room ---------------
+      const joinParams: any = await expectRoomJoined(page)
 
-    // Checks that the video is visible
-    await expectMCUVisible(page)
+      expect(joinParams.room).toBeDefined()
+      expect(joinParams.room_session).toBeDefined()
+      if (row.join_as === 'member') {
+        expect(
+          joinParams.room.members.some(
+            (member: any) => member.id === joinParams.member_id
+          )
+        ).toBeTruthy()
+      }
+      expect(joinParams.room_session.name).toBe(roomName)
+      expect(joinParams.room.name).toBe(roomName)
 
-    const roomPermissions: any = await page.evaluate(() => {
-      // @ts-expect-error
-      const roomObj: Video.RoomSession = window._roomObj
-      return roomObj.permissions
-    })
-    expect(roomPermissions).toStrictEqual(permissions)
+      // Checks that the video is visible
+      await row.expectMCU(page)
 
-    // --------------- Reattaching ---------------
-    await page.reload()
-
-    await createTestRoomSession(page, connectionSettings)
-
-    // Try to join but expect to join with a different callId/memberId
-    const reattachParams: any = await page.evaluate(() => {
-      return new Promise((resolve) => {
+      const roomPermissions: any = await page.evaluate(() => {
         // @ts-expect-error
-        const roomObj = window._roomObj
-        roomObj.on('room.joined', resolve)
-
-        const mockId = uuid()
-        window.sessionStorage.setItem('callId', mockId)
-        console.log('Injected callId with value', mockId)
-
-        return roomObj.join()
+        const roomObj: Video.RoomSession = window._roomObj
+        return roomObj.permissions
       })
+      expect(roomPermissions).toStrictEqual(permissions)
+
+      // --------------- Reattaching ---------------
+      await page.reload()
+
+      await createTestRoomSession(page, connectionSettings)
+
+      console.time('reattach')
+      // Try to join but expect to join with a different callId
+      const reattachParams: any = await page.evaluate(() => {
+        return new Promise((resolve) => {
+          // @ts-expect-error
+          const roomObj = window._roomObj
+          roomObj.on('room.joined', resolve)
+
+          const mockId = uuid()
+          window.sessionStorage.setItem('callId', mockId)
+          console.log('Injected callId with value', mockId)
+
+          return roomObj.join()
+        })
+      })
+      console.timeEnd('reattach')
+
+      expect(reattachParams.room).toBeDefined()
+      expect(reattachParams.room_session).toBeDefined()
+      if (row.join_as === 'member') {
+        expect(
+          reattachParams.room.members.some(
+            (member: any) => member.id === reattachParams.member_id
+          )
+        ).toBeTruthy()
+      }
+      expect(reattachParams.room_session.name).toBe(roomName)
+      expect(reattachParams.room.name).toBe(roomName)
+      // Make sure the member_id is stable
+      expect(reattachParams.member_id).toBeDefined()
+      expect(reattachParams.member_id).toBe(joinParams.member_id)
+      // Also call_id must remain the same
+      expect(reattachParams.call_id).toBeDefined()
+      expect(reattachParams.call_id).toBe(joinParams.call_id)
+
+      // Checks that the video is visible
+      await row.expectMCU(page)
     })
-
-    expect(reattachParams.room).toBeDefined()
-    expect(reattachParams.room_session).toBeDefined()
-    expect(
-      reattachParams.room.members.some(
-        (member: any) => member.id === reattachParams.member_id
-      )
-    ).toBeTruthy()
-    expect(reattachParams.room_session.name).toBe(roomName)
-    expect(reattachParams.room.name).toBe(roomName)
-
-    // Same room_session_id
-    expect(reattachParams.room_session.id).toBe(joinParams.room_session.id)
-    // Different memberId and callId
-    expect(reattachParams.member_id).not.toBe(joinParams.member_id)
-    expect(reattachParams.call_id).not.toBe(joinParams.call_id)
-
-    // Checks that the video is visible
-    await expectMCUVisible(page)
   })
 })


### PR DESCRIPTION
Refactored to test both participant and audience and with new error code.