### PR TITLE
Valid interface for call.collect method

### DIFF
--- a/.changeset/quiet-insects-develop.md
+++ b/.changeset/quiet-insects-develop.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/core': patch
+---
+
+Valid typescript interface for call.collect method

--- a/package-lock.json
+++ b/package-lock.json
@@ -22433,7 +22433,8 @@
       }
     },
     "jsonwebtoken": {
-      "version": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.0.tgz",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.0.tgz",
       "integrity": "sha512-tuGfYXxkQGDPnLJ7SibiQgVgeDgfbPq2k2ICcbgqW8WxWLBAxKQM/ZCu/IT8SOSwmaYl4dpTFCW5xZv7YbbWUw==",
       "requires": {
         "jws": "^3.2.2",
@@ -26221,7 +26222,7 @@
         "axios": "^0.26.1",
         "dayjs": "^1.8.29",
         "https-proxy-agent": "^5.0.0",
-        "jsonwebtoken": "^8.5.1",
+        "jsonwebtoken": "9.0.0",
         "lodash": "^4.17.21",
         "q": "2.0.x",
         "qs": "^6.9.4",

--- a/packages/core/src/types/voiceCall.ts
+++ b/packages/core/src/types/voiceCall.ts
@@ -339,9 +339,9 @@ export interface VoiceCallTapAudioMethodParams {
 export type VoiceCallCollectMethodParams = SpeechOrDigits & {
   initialTimeout?: number
   partialResults?: boolean
-  continuous: boolean
-  sendStartOfInput: boolean
-  startInputTimers: boolean
+  continuous?: boolean
+  sendStartOfInput?: boolean
+  startInputTimers?: boolean
 }
 
 export type VoiceCallConnectMethodParams =


### PR DESCRIPTION
Based on the relay-apis [documentation](https://github.com/signalwire/relay-apis/blob/master/public/signalwire_calling.md#callingcollect), the interface for the `collect` method is updated.