### PR TITLE
Resume after a temporary disconnect

### DIFF
--- a/.changeset/chilly-kids-help.md
+++ b/.changeset/chilly-kids-help.md
@@ -1,0 +1,6 @@
+---
+'@signalwire/webrtc': patch
+'@signalwire/core': patch
+---
+
+Allow WebRTC connection to reconnect after a network change or temporary blip.

--- a/.changeset/good-stingrays-return.md
+++ b/.changeset/good-stingrays-return.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/js': minor
+---
+
+Expose new events on the RoomSession to detect the media state: `media.connected`, `media.disconnected` and `media.reconnecting`.

--- a/.changeset/itchy-dingos-retire.md
+++ b/.changeset/itchy-dingos-retire.md
@@ -1,0 +1,6 @@
+---
+'@sw-internal/playground-js': patch
+'@sw-internal/e2e-js': patch
+---
+
+[internal] Update playground and e2e tests for resume

--- a/.drone.yml
+++ b/.drone.yml
@@ -2,56 +2,56 @@ kind: pipeline
 name: default
 
 steps:
-  # - name: test
-  #   image: node:16-alpine
-  #   commands:
-  #     - npm install
-  #     - npm run build
-  #     - npm test
+  - name: test
+    image: node:16-alpine
+    commands:
+      - npm install
+      - npm run build
+      - npm test
 
-  # - name: stack-tests
-  #   depends_on:
-  #     - test
-  #   image: node:16-alpine
-  #   commands:
-  #     - npm install
-  #     - npm run build
-  #     - npm run -w=@sw-internal/stack-tests dev
-  #   environment:
-  #     RELAY_HOST:
-  #       from_secret: RELAY_HOST
-  #     RELAY_PROJECT:
-  #       from_secret: RELAY_PROJECT
-  #     RELAY_TOKEN:
-  #       from_secret: RELAY_TOKEN
+  - name: stack-tests
+    depends_on:
+      - test
+    image: node:16-alpine
+    commands:
+      - npm install
+      - npm run build
+      - npm run -w=@sw-internal/stack-tests dev
+    environment:
+      RELAY_HOST:
+        from_secret: RELAY_HOST
+      RELAY_PROJECT:
+        from_secret: RELAY_PROJECT
+      RELAY_TOKEN:
+        from_secret: RELAY_TOKEN
 
-  # - name: stage-e2e-realtime-api
-  #   depends_on:
-  #     - stack-tests
-  #   image: node:16-alpine
-  #   commands:
-  #     - npm install
-  #     - npm run build
-  #     - npm run -w=@sw-internal/e2e-realtime-api dev
-  #   environment:
-  #     SW_TEST_CONFIG:
-  #       from_secret: STAGING_E2E_REALTIME_SW_TEST_CONFIG
+  - name: stage-e2e-realtime-api
+    depends_on:
+      - stack-tests
+    image: node:16-alpine
+    commands:
+      - npm install
+      - npm run build
+      - npm run -w=@sw-internal/e2e-realtime-api dev
+    environment:
+      SW_TEST_CONFIG:
+        from_secret: STAGING_E2E_REALTIME_SW_TEST_CONFIG
 
-  # - name: prod-e2e-realtime-api
-  #   depends_on:
-  #     - stack-tests
-  #   image: node:16-alpine
-  #   commands:
-  #     - npm install
-  #     - npm run build
-  #     - npm run -w=@sw-internal/e2e-realtime-api dev
-  #   environment:
-  #     SW_TEST_CONFIG:
-  #       from_secret: PRODUCTION_E2E_REALTIME_SW_TEST_CONFIG
+  - name: prod-e2e-realtime-api
+    depends_on:
+      - stack-tests
+    image: node:16-alpine
+    commands:
+      - npm install
+      - npm run build
+      - npm run -w=@sw-internal/e2e-realtime-api dev
+    environment:
+      SW_TEST_CONFIG:
+        from_secret: PRODUCTION_E2E_REALTIME_SW_TEST_CONFIG
 
   - name: stage-e2e-js
-    # depends_on:
-    #   - stack-tests
+    depends_on:
+      - stack-tests
     image: mcr.microsoft.com/playwright:v1.29.2-focal
     commands:
       - npm install
@@ -61,17 +61,17 @@ steps:
       SW_TEST_CONFIG:
         from_secret: STAGING_E2E_JS_SW_TEST_CONFIG
 
-  # - name: prod-e2e-js
-  #   depends_on:
-  #     - stack-tests
-  #   image: mcr.microsoft.com/playwright:v1.29.2-focal
-  #   commands:
-  #     - npm install
-  #     - npm run build
-  #     - npm run -w=@sw-internal/e2e-js dev
-  #   environment:
-  #     SW_TEST_CONFIG:
-  #       from_secret: PRODUCTION_E2E_JS_SW_TEST_CONFIG
+  - name: prod-e2e-js
+    depends_on:
+      - stack-tests
+    image: mcr.microsoft.com/playwright:v1.29.2-focal
+    commands:
+      - npm install
+      - npm run build
+      - npm run -w=@sw-internal/e2e-js dev
+    environment:
+      SW_TEST_CONFIG:
+        from_secret: PRODUCTION_E2E_JS_SW_TEST_CONFIG
 
 trigger:
   event: push

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,77 @@
+kind: pipeline
+name: default
+
+steps:
+  # - name: test
+  #   image: node:16-alpine
+  #   commands:
+  #     - npm install
+  #     - npm run build
+  #     - npm test
+
+  # - name: stack-tests
+  #   depends_on:
+  #     - test
+  #   image: node:16-alpine
+  #   commands:
+  #     - npm install
+  #     - npm run build
+  #     - npm run -w=@sw-internal/stack-tests dev
+  #   environment:
+  #     RELAY_HOST:
+  #       from_secret: RELAY_HOST
+  #     RELAY_PROJECT:
+  #       from_secret: RELAY_PROJECT
+  #     RELAY_TOKEN:
+  #       from_secret: RELAY_TOKEN
+
+  # - name: stage-e2e-realtime-api
+  #   depends_on:
+  #     - stack-tests
+  #   image: node:16-alpine
+  #   commands:
+  #     - npm install
+  #     - npm run build
+  #     - npm run -w=@sw-internal/e2e-realtime-api dev
+  #   environment:
+  #     SW_TEST_CONFIG:
+  #       from_secret: STAGING_E2E_REALTIME_SW_TEST_CONFIG
+
+  # - name: prod-e2e-realtime-api
+  #   depends_on:
+  #     - stack-tests
+  #   image: node:16-alpine
+  #   commands:
+  #     - npm install
+  #     - npm run build
+  #     - npm run -w=@sw-internal/e2e-realtime-api dev
+  #   environment:
+  #     SW_TEST_CONFIG:
+  #       from_secret: PRODUCTION_E2E_REALTIME_SW_TEST_CONFIG
+
+  - name: stage-e2e-js
+    # depends_on:
+    #   - stack-tests
+    image: mcr.microsoft.com/playwright:v1.29.2-focal
+    commands:
+      - npm install
+      - npm run build
+      - npm run -w=@sw-internal/e2e-js dev
+    environment:
+      SW_TEST_CONFIG:
+        from_secret: STAGING_E2E_JS_SW_TEST_CONFIG
+
+  # - name: prod-e2e-js
+  #   depends_on:
+  #     - stack-tests
+  #   image: mcr.microsoft.com/playwright:v1.29.2-focal
+  #   commands:
+  #     - npm install
+  #     - npm run build
+  #     - npm run -w=@sw-internal/e2e-js dev
+  #   environment:
+  #     SW_TEST_CONFIG:
+  #       from_secret: PRODUCTION_E2E_JS_SW_TEST_CONFIG
+
+trigger:
+  event: push

--- a/internal/e2e-js/fixtures.ts
+++ b/internal/e2e-js/fixtures.ts
@@ -12,21 +12,22 @@ type CustomFixture = {
 
 const test = baseTest.extend<CustomFixture>({
   createCustomPage: async ({ context }, use) => {
-    const maker = async (options: { name: string }) => {
+    const maker = async (options: { name: string }): Promise<CustomPage> => {
       const page = await context.newPage()
       enablePageLogs(page, options.name)
 
-      return {
-        ...page,
-        swNetworkDown: () => {
-          console.log('Simulate network down..')
-          return context.setOffline(true)
-        },
-        swNetworkUp: () => {
-          console.log('Simulate network up..')
-          return context.setOffline(false)
-        },
+      // @ts-expect-error
+      page.swNetworkDown = () => {
+        console.log('Simulate network down..')
+        return context.setOffline(true)
       }
+      // @ts-expect-error
+      page.swNetworkUp = () => {
+        console.log('Simulate network up..')
+        return context.setOffline(false)
+      }
+      // @ts-expect-error
+      return page
     }
     await use(maker)
 

--- a/internal/e2e-js/fixtures.ts
+++ b/internal/e2e-js/fixtures.ts
@@ -2,8 +2,12 @@ import type { Video } from '@signalwire/js'
 import { test as baseTest, expect, type Page } from '@playwright/test'
 import { enablePageLogs } from './utils'
 
+type CustomPage = Page & {
+  swNetworkDown: () => Promise<void>
+  swNetworkUp: () => Promise<void>
+}
 type CustomFixture = {
-  createCustomPage(options: { name: string }): Promise<Page>
+  createCustomPage(options: { name: string }): Promise<CustomPage>
 }
 
 const test = baseTest.extend<CustomFixture>({
@@ -12,7 +16,17 @@ const test = baseTest.extend<CustomFixture>({
       const page = await context.newPage()
       enablePageLogs(page, options.name)
 
-      return page
+      return {
+        ...page,
+        swNetworkDown: () => {
+          console.log('Simulate network down..')
+          return context.setOffline(true)
+        },
+        swNetworkUp: () => {
+          console.log('Simulate network up..')
+          return context.setOffline(false)
+        },
+      }
     }
     await use(maker)
 

--- a/internal/e2e-js/playwright.config.ts
+++ b/internal/e2e-js/playwright.config.ts
@@ -2,7 +2,7 @@ require('dotenv').config()
 
 import { PlaywrightTestConfig, devices } from '@playwright/test'
 
-// const testMatch = process.argv.slice(3)
+const testMatch = process.argv.slice(3)
 
 const config: PlaywrightTestConfig = {
   testDir: 'tests',

--- a/internal/e2e-js/playwright.config.ts
+++ b/internal/e2e-js/playwright.config.ts
@@ -2,7 +2,7 @@ require('dotenv').config()
 
 import { PlaywrightTestConfig, devices } from '@playwright/test'
 
-const testMatch = process.argv.slice(3)
+// const testMatch = process.argv.slice(3)
 
 const config: PlaywrightTestConfig = {
   testDir: 'tests',

--- a/internal/e2e-js/tests/roomSessionBadNetwork.spec.ts
+++ b/internal/e2e-js/tests/roomSessionBadNetwork.spec.ts
@@ -8,6 +8,7 @@ import {
   expectMCUVisible,
   expectMCUVisibleForAudience,
   expectPageReceiveMedia,
+  expectMediaEvent,
 } from '../utils'
 
 type Test = {
@@ -50,6 +51,11 @@ test.describe('roomSessionBadNetwork', () => {
       }
       await createTestRoomSession(page, connectionSettings)
 
+      const firstMediaConnectedPromise = expectMediaEvent(
+        page,
+        'media.connected'
+      )
+
       // --------------- Joining the room ---------------
       const joinParams: any = await expectRoomJoined(page)
 
@@ -75,8 +81,14 @@ test.describe('roomSessionBadNetwork', () => {
       })
       expect(roomPermissions).toStrictEqual(permissions)
 
+      await firstMediaConnectedPromise
+
       await expectPageReceiveMedia(page)
 
+      const secondMediaConnectedPromise = expectMediaEvent(
+        page,
+        'media.connected'
+      )
       // --------------- Simulate Network Down and Up in 15s ---------------
       await page.swNetworkDown()
       await page.waitForTimeout(15_000)
@@ -87,6 +99,8 @@ test.describe('roomSessionBadNetwork', () => {
       await page.waitForTimeout(10_000)
 
       await expectPageReceiveMedia(page)
+
+      await secondMediaConnectedPromise
 
       // Make sure we still receive events from the room
       const makeMemberTalkingPromise = () =>

--- a/internal/e2e-js/tests/roomSessionBadNetwork.spec.ts
+++ b/internal/e2e-js/tests/roomSessionBadNetwork.spec.ts
@@ -26,7 +26,7 @@ test.describe('roomSessionBadNetwork', () => {
   ]
 
   tests.forEach((row) => {
-    test(`should allow survive to a WS blip for ${row.join_as}`, async ({
+    test(`should survive to a network switch for ${row.join_as}`, async ({
       createCustomPage,
     }) => {
       const page = await createCustomPage({
@@ -93,6 +93,8 @@ test.describe('roomSessionBadNetwork', () => {
       await page.swNetworkDown()
       await page.waitForTimeout(15_000)
       await page.swNetworkUp()
+
+      await page.waitForTimeout(5_000)
 
       await expectPageReceiveMedia(page)
 

--- a/internal/e2e-js/tests/roomSessionBadNetwork.spec.ts
+++ b/internal/e2e-js/tests/roomSessionBadNetwork.spec.ts
@@ -7,6 +7,7 @@ import {
   expectRoomJoined,
   expectMCUVisible,
   expectMCUVisibleForAudience,
+  getStats,
 } from '../utils'
 
 type Test = {
@@ -74,10 +75,20 @@ test.describe('roomSessionBadNetwork', () => {
       })
       expect(roomPermissions).toStrictEqual(permissions)
 
+      console.log('First')
+      await getStats(page)
+
       // --------------- Simulate Network Down and Up ---------------
       await page.swNetworkDown()
-      await page.waitForTimeout(5_000)
+      await page.waitForTimeout(15_000)
+      console.log('Second')
+      await getStats(page)
+
       await page.swNetworkUp()
+
+      await page.waitForTimeout(15_000)
+      console.log('Third')
+      await getStats(page)
     })
   })
 })

--- a/internal/e2e-js/tests/roomSessionBadNetwork.spec.ts
+++ b/internal/e2e-js/tests/roomSessionBadNetwork.spec.ts
@@ -1,0 +1,83 @@
+import { test, expect } from '../fixtures'
+import type { Video } from '@signalwire/js'
+import {
+  SERVER_URL,
+  createTestRoomSession,
+  randomizeRoomName,
+  expectRoomJoined,
+  expectMCUVisible,
+  expectMCUVisibleForAudience,
+} from '../utils'
+
+type Test = {
+  join_as: 'member' | 'audience'
+  expectMCU: typeof expectMCUVisible | typeof expectMCUVisibleForAudience
+}
+
+test.describe('roomSessionBadNetwork', () => {
+  /**
+   * Test both member and audience
+   */
+  const tests: Test[] = [
+    { join_as: 'member', expectMCU: expectMCUVisible },
+    // { join_as: 'audience', expectMCU: expectMCUVisibleForAudience },
+  ]
+
+  tests.forEach((row) => {
+    test(`should allow survive to a WS blip for ${row.join_as}`, async ({
+      createCustomPage,
+    }) => {
+      const page = await createCustomPage({
+        name: `[bad-network-${row.join_as}]`,
+      })
+      await page.goto(SERVER_URL)
+
+      const roomName = randomizeRoomName()
+      const permissions: any = []
+      const connectionSettings = {
+        vrt: {
+          room_name: roomName,
+          user_name: `e2e_bad_network_${row.join_as}`,
+          join_as: row.join_as,
+          auto_create_room: true,
+          permissions,
+        },
+        initialEvents: [],
+        roomSessionOptions: {
+          reattach: true, // FIXME: to remove
+        },
+      }
+      await createTestRoomSession(page, connectionSettings)
+
+      // --------------- Joining the room ---------------
+      const joinParams: any = await expectRoomJoined(page)
+
+      expect(joinParams.room).toBeDefined()
+      expect(joinParams.room_session).toBeDefined()
+      if (row.join_as === 'member') {
+        expect(
+          joinParams.room.members.some(
+            (member: any) => member.id === joinParams.member_id
+          )
+        ).toBeTruthy()
+      }
+      expect(joinParams.room_session.name).toBe(roomName)
+      expect(joinParams.room.name).toBe(roomName)
+
+      // Checks that the video is visible
+      await row.expectMCU(page)
+
+      const roomPermissions: any = await page.evaluate(() => {
+        // @ts-expect-error
+        const roomObj: Video.RoomSession = window._roomObj
+        return roomObj.permissions
+      })
+      expect(roomPermissions).toStrictEqual(permissions)
+
+      // --------------- Simulate Network Down and Up ---------------
+      await page.swNetworkDown()
+      await page.waitForTimeout(5_000)
+      await page.swNetworkUp()
+    })
+  })
+})

--- a/internal/e2e-js/tests/roomSessionBadNetwork.spec.ts
+++ b/internal/e2e-js/tests/roomSessionBadNetwork.spec.ts
@@ -89,6 +89,8 @@ test.describe('roomSessionBadNetwork', () => {
       await page.waitForTimeout(15_000)
       console.log('Third')
       await getStats(page)
+
+      await page.waitForTimeout(30_000)
     })
   })
 })

--- a/internal/e2e-js/tests/roomSessionBadNetwork.spec.ts
+++ b/internal/e2e-js/tests/roomSessionBadNetwork.spec.ts
@@ -125,7 +125,7 @@ test.describe('roomSessionBadNetwork', () => {
 
       const memberMuted: any = await promise1
       console.log('WWW', memberMuted)
-      expect(memberMuted.member.audio_mute).toBe(true)
+      expect(memberMuted.member.audio_muted).toBe(true)
 
       const promise2 = makeMemberUpdatedPromise()
 
@@ -138,7 +138,7 @@ test.describe('roomSessionBadNetwork', () => {
 
       const memberUnmuted: any = await promise2
       console.log('WWW', memberUnmuted)
-      expect(memberUnmuted.member.audio_mute).toBe(false)
+      expect(memberUnmuted.member.audio_muted).toBe(false)
     })
   })
 })

--- a/internal/e2e-js/utils.ts
+++ b/internal/e2e-js/utils.ts
@@ -588,3 +588,16 @@ export const getStats = async (page: Page) => {
 
   return stats
 }
+
+export const expectPageReceiveMedia = async (page: Page, delay = 5_000) => {
+  const first = await getStats(page)
+  await page.waitForTimeout(delay)
+  const last = await getStats(page)
+
+  expect(last.inboundRTP.video.packetsReceived).toBeGreaterThan(
+    first.inboundRTP.video.packetsReceived
+  )
+  expect(last.inboundRTP.audio.packetsReceived).toBeGreaterThan(
+    first.inboundRTP.audio.packetsReceived
+  )
+}

--- a/internal/e2e-js/utils.ts
+++ b/internal/e2e-js/utils.ts
@@ -611,7 +611,7 @@ export const expectPageReceiveMedia = async (page: Page, delay = 5_000) => {
 
   const seconds = delay / 1000
   const minAudioPacketsExpected = 40 * seconds
-  const minVideoPacketsExpected = 40 * seconds
+  const minVideoPacketsExpected = 25 * seconds
 
   expect(last.inboundRTP.video.packetsReceived).toBeGreaterThan(
     first.inboundRTP.video.packetsReceived + minVideoPacketsExpected

--- a/internal/e2e-js/utils.ts
+++ b/internal/e2e-js/utils.ts
@@ -1,4 +1,5 @@
 import type { Video } from '@signalwire/js'
+import type { MediaEvent } from '@signalwire/webrtc'
 import { createServer } from 'vite'
 import path from 'path'
 import { Page, expect } from '@playwright/test'
@@ -343,6 +344,19 @@ export const expectMemberTalkingEvent = (page: Page) => {
       roomObj.on('member.talking', resolve)
     })
   })
+}
+
+export const expectMediaEvent = (page: Page, event: MediaEvent) => {
+  return page.evaluate(
+    ({ event }) => {
+      return new Promise<void>((resolve) => {
+        // @ts-expect-error
+        const roomObj: Video.RoomSession = window._roomObj
+        roomObj.on(event, resolve)
+      })
+    },
+    { event }
+  )
 }
 
 export const expectTotalAudioEnergyToBeGreaterThan = async (

--- a/internal/e2e-js/utils.ts
+++ b/internal/e2e-js/utils.ts
@@ -546,6 +546,7 @@ export const getStats = async (page: Page) => {
     const inboundRTPHandler = (report: any) => {
       const media = report.mediaType as 'video' | 'audio'
       const trackId = rtcPeer._getReceiverByKind(media).track.id
+      console.log(`getStats trackId "${trackId}" for media ${media}`)
       if (report.trackIdentifier !== trackId) {
         console.log(
           `trackIdentifier "${report.trackIdentifier}" and trackId "${trackId}" are different`

--- a/internal/e2e-js/utils.ts
+++ b/internal/e2e-js/utils.ts
@@ -611,7 +611,7 @@ export const expectPageReceiveMedia = async (page: Page, delay = 5_000) => {
 
   const seconds = delay / 1000
   const minAudioPacketsExpected = 40 * seconds
-  const minVideoPacketsExpected = 80 * seconds
+  const minVideoPacketsExpected = 60 * seconds
 
   expect(last.inboundRTP.video.packetsReceived).toBeGreaterThan(
     first.inboundRTP.video.packetsReceived + minVideoPacketsExpected

--- a/internal/e2e-js/utils.ts
+++ b/internal/e2e-js/utils.ts
@@ -609,10 +609,14 @@ export const expectPageReceiveMedia = async (page: Page, delay = 5_000) => {
   await page.waitForTimeout(delay)
   const last = await getStats(page)
 
+  const seconds = delay / 1000
+  const minAudioPacketsExpected = 40 * seconds
+  const minVideoPacketsExpected = 80 * seconds
+
   expect(last.inboundRTP.video.packetsReceived).toBeGreaterThan(
-    first.inboundRTP.video.packetsReceived
+    first.inboundRTP.video.packetsReceived + minVideoPacketsExpected
   )
   expect(last.inboundRTP.audio.packetsReceived).toBeGreaterThan(
-    first.inboundRTP.audio.packetsReceived
+    first.inboundRTP.audio.packetsReceived + minAudioPacketsExpected
   )
 }

--- a/internal/e2e-js/utils.ts
+++ b/internal/e2e-js/utils.ts
@@ -611,7 +611,7 @@ export const expectPageReceiveMedia = async (page: Page, delay = 5_000) => {
 
   const seconds = delay / 1000
   const minAudioPacketsExpected = 40 * seconds
-  const minVideoPacketsExpected = 60 * seconds
+  const minVideoPacketsExpected = 40 * seconds
 
   expect(last.inboundRTP.video.packetsReceived).toBeGreaterThan(
     first.inboundRTP.video.packetsReceived + minVideoPacketsExpected

--- a/internal/e2e-realtime-api/src/chat.test.ts
+++ b/internal/e2e-realtime-api/src/chat.test.ts
@@ -4,7 +4,7 @@
  * The `handler` method grab a CRT and connects a JS ChatClient and a RealtimeAPI ChatClient
  * and the consume all the methods asserting both SDKs receive the proper events.
  */
-import { timeoutPromise } from '@signalwire/core'
+import { timeoutPromise, CloseEvent } from '@signalwire/core'
 import { Chat as RealtimeAPIChat } from '@signalwire/realtime-api'
 import { Chat as JSChat } from '@signalwire/js'
 import { WebSocket } from 'ws'
@@ -12,6 +12,8 @@ import { createTestRunner, createCRT, sessionStorageMock } from './utils'
 
 // @ts-ignore
 global.WebSocket = WebSocket
+// @ts-ignore
+global.CloseEvent = CloseEvent
 // @ts-ignore
 global.window = { sessionStorage: sessionStorageMock() }
 

--- a/internal/e2e-realtime-api/src/pubSub.test.ts
+++ b/internal/e2e-realtime-api/src/pubSub.test.ts
@@ -6,7 +6,7 @@
  * and the consume all the methods asserting both SDKs
  * receive the proper events.
  */
-import { timeoutPromise } from '@signalwire/core'
+import { timeoutPromise, CloseEvent } from '@signalwire/core'
 import { PubSub as RealtimeAPIPubSub } from '@signalwire/realtime-api'
 import { PubSub as JSPubSub } from '@signalwire/js'
 import { WebSocket } from 'ws'
@@ -14,6 +14,8 @@ import { createTestRunner, createCRT, sessionStorageMock } from './utils'
 
 // @ts-ignore
 global.WebSocket = WebSocket
+// @ts-ignore
+global.CloseEvent = CloseEvent
 // @ts-ignore
 global.window = { sessionStorage: sessionStorageMock() }
 

--- a/internal/playground-js/src/heroku/index.js
+++ b/internal/playground-js/src/heroku/index.js
@@ -232,6 +232,16 @@ window.connect = () => {
 
   console.debug('Video SDK roomObj', roomObj)
 
+  roomObj.on('media.connected', () => {
+    console.debug('>> media.connected')
+  })
+  roomObj.on('media.reconnecting', () => {
+    console.debug('>> media.reconnecting')
+  })
+  roomObj.on('media.disconnected', () => {
+    console.debug('>> media.disconnected')
+  })
+
   roomObj.on('room.started', (params) =>
     console.debug('>> room.started', params)
   )

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "jest": "^28.1.0",
         "jest-environment-jsdom": "^28.1.0",
         "prettier": "^2.6.2",
+        "sdp": "^3.0.3",
         "typedoc": "^0.22.10",
         "typescript": "^4.5.4"
       },
@@ -11554,6 +11555,11 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/scmp/-/scmp-2.1.0.tgz",
       "integrity": "sha512-o/mRQGk9Rcer/jEEw/yw4mwo3EU/NvYvp577/Btqrym9Qy5/MdWGBqipbALgd2lrdWTJ5/gqDusxfnQBxOxT2Q=="
+    },
+    "node_modules/sdp": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/sdp/-/sdp-3.0.3.tgz",
+      "integrity": "sha512-8EkfckS+XZQaPLyChu4ey7PghrdcraCVNpJe2Gfdi2ON1ylQ7OasuKX+b37R9slnRChwIAiQgt+oj8xXGD8x+A=="
     },
     "node_modules/semver": {
       "version": "6.3.0",
@@ -24213,6 +24219,11 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/scmp/-/scmp-2.1.0.tgz",
       "integrity": "sha512-o/mRQGk9Rcer/jEEw/yw4mwo3EU/NvYvp577/Btqrym9Qy5/MdWGBqipbALgd2lrdWTJ5/gqDusxfnQBxOxT2Q=="
+    },
+    "sdp": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/sdp/-/sdp-3.0.3.tgz",
+      "integrity": "sha512-8EkfckS+XZQaPLyChu4ey7PghrdcraCVNpJe2Gfdi2ON1ylQ7OasuKX+b37R9slnRChwIAiQgt+oj8xXGD8x+A=="
     },
     "semver": {
       "version": "6.3.0",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "jest": "^28.1.0",
     "jest-environment-jsdom": "^28.1.0",
     "prettier": "^2.6.2",
+    "sdp": "^3.0.3",
     "typedoc": "^0.22.10",
     "typescript": "^4.5.4"
   },

--- a/packages/core/src/BaseComponent.ts
+++ b/packages/core/src/BaseComponent.ts
@@ -969,7 +969,7 @@ export class BaseComponent<
       this._setWorker(name, def)
     }
 
-    this._attachWorker(name, def)
+    return this._attachWorker(name, def)
   }
 
   private _setWorker<Hooks extends SDKWorkerHooks = SDKWorkerHooks>(
@@ -995,6 +995,7 @@ export class BaseComponent<
      * queue.
      */
     this._workers.delete(name)
+    return task
   }
 
   private detachWorkers() {

--- a/packages/core/src/BaseJWTSession.test.ts
+++ b/packages/core/src/BaseJWTSession.test.ts
@@ -1,9 +1,11 @@
 import WS from 'jest-websocket-mock'
 import { BaseJWTSession } from './BaseJWTSession'
 import { RPCConnect } from './RPCMessages'
+import { CloseEvent } from './utils'
 
 class JWTSession extends BaseJWTSession {
   public WebSocketConstructor = WebSocket
+  public CloseEventConstructor = CloseEvent
 }
 
 jest.mock('uuid', () => {

--- a/packages/core/src/BaseJWTSession.ts
+++ b/packages/core/src/BaseJWTSession.ts
@@ -88,10 +88,7 @@ export class BaseJWTSession extends BaseSession {
       await this.persistRelayProtocol()
       this._checkTokenExpiration()
     } catch (error) {
-      if (error === this._swConnectError) {
-        this.logger.debug('Invalid connect response?')
-        return
-      }
+      this.logger.debug('BaseJWTSession authenticate error', error)
       throw error
     }
   }

--- a/packages/core/src/BaseSession.test.ts
+++ b/packages/core/src/BaseSession.test.ts
@@ -1,5 +1,4 @@
 import WS from 'jest-websocket-mock'
-
 import { BaseSession } from './BaseSession'
 import { socketMessageAction } from './redux/actions'
 import {
@@ -8,6 +7,7 @@ import {
   RPCPingResponse,
   RPCDisconnectResponse,
 } from './RPCMessages'
+import { CloseEvent } from './utils'
 import { wait } from './testUtils'
 
 jest.mock('uuid', () => {
@@ -37,6 +37,7 @@ describe('BaseSession', () => {
       token,
     })
     session.WebSocketConstructor = WebSocket
+    session.CloseEventConstructor = CloseEvent
     session.dispatch = jest.fn()
   })
   afterEach(() => {

--- a/packages/core/src/BaseSession.ts
+++ b/packages/core/src/BaseSession.ts
@@ -334,6 +334,10 @@ export class BaseSession {
     this.dispatch(authErrorAction({ error }))
   }
 
+  forceClose() {
+    return this._closeConnection('reconnecting')
+  }
+
   protected async _onSocketOpen(event: Event) {
     this.logger.debug('_onSocketOpen', event.type)
     try {
@@ -502,5 +506,15 @@ export class BaseSession {
       )
     )
     this.destroySocket()
+
+    if (this._status === 'reconnecting') {
+      /**
+       * Since the real `close` event can be delayed by OS/Browser,
+       * trigger it manually to start the reconnect process if required.
+       */
+      this.wsCloseHandler(
+        new CloseEvent('close', { reason: 'Client-side closed' })
+      )
+    }
   }
 }

--- a/packages/core/src/BaseSession.ts
+++ b/packages/core/src/BaseSession.ts
@@ -53,6 +53,7 @@ export class BaseSession {
 
   public uuid = uuid()
   public WebSocketConstructor: NodeSocketAdapter | WebSocketAdapter
+  public CloseEventConstructor: typeof CloseEvent
   public agent: string
   public connectVersion = DEFAULT_CONNECT_VERSION
   public reauthenticate?(): Promise<void>
@@ -178,6 +179,9 @@ export class BaseSession {
   connect(): void {
     if (!this?.WebSocketConstructor) {
       throw new Error('Missing WebSocketConstructor')
+    }
+    if (!this?.CloseEventConstructor) {
+      throw new Error('Missing CloseEventConstructor')
     }
     this._clearTimers()
     /**
@@ -528,7 +532,9 @@ export class BaseSession {
        * trigger it manually to start the reconnect process if required.
        */
       this.wsCloseHandler(
-        new CloseEvent('close', { reason: 'Client-side closed' })
+        new this.CloseEventConstructor('close', {
+          reason: 'Client-side closed',
+        })
       )
     }
   }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -14,6 +14,7 @@ import {
   serializeableProxy,
   timeoutPromise,
   debounce,
+  CloseEvent,
 } from './utils'
 import { BaseSession } from './BaseSession'
 import { BaseJWTSession } from './BaseJWTSession'
@@ -59,6 +60,7 @@ export {
   findNamespaceInPayload,
   timeoutPromise,
   debounce,
+  CloseEvent,
 }
 
 export * from './redux/features/component/componentSlice'

--- a/packages/core/src/redux/actions.ts
+++ b/packages/core/src/redux/actions.ts
@@ -1,8 +1,9 @@
 import { createAction, Action } from './toolkit'
-import {
+import type {
   JSONRPCRequest,
   SessionAuthError,
   SessionEvents,
+  SessionActions,
   CompoundEvents,
 } from '../utils/interfaces'
 import { ExecuteActionParams } from './interfaces'
@@ -47,6 +48,9 @@ export const sessionAuthErrorAction = createAction<Error, SessionEvents>(
 )
 export const sessionExpiringAction = createAction<void, SessionEvents>(
   'session.expiring'
+)
+export const sessionForceCloseAction = createAction<void, SessionActions>(
+  'session.forceClose'
 )
 const formatCustomSagaAction = (id: string, action: Action) => {
   return `${action.type}/${id}`

--- a/packages/core/src/redux/rootSaga.test.ts
+++ b/packages/core/src/redux/rootSaga.test.ts
@@ -20,6 +20,7 @@ import {
   sessionReconnectingAction,
   sessionAuthErrorAction,
   sessionExpiringAction,
+  sessionForceCloseAction,
   authSuccessAction,
   authErrorAction,
   authExpiringAction,
@@ -38,6 +39,7 @@ describe('sessionStatusWatcher', () => {
     reauthAction.type,
     sessionReconnectingAction.type,
     sessionDisconnectedAction.type,
+    sessionForceCloseAction.type,
   ]
   const session = {
     closed: true,

--- a/packages/core/src/redux/rootSaga.ts
+++ b/packages/core/src/redux/rootSaga.ts
@@ -23,6 +23,7 @@ import {
   sessionAuthErrorAction,
   sessionExpiringAction,
   reauthAction,
+  sessionForceCloseAction,
 } from './actions'
 import { sessionActions } from './features'
 import {
@@ -173,6 +174,7 @@ export function* sessionStatusWatcher(options: StartSagaOptions): SagaIterator {
         reauthAction.type,
         sessionReconnectingAction.type,
         sessionDisconnectedAction.type,
+        sessionForceCloseAction.type,
       ])
 
       getLogger().debug('sessionStatusWatcher', action.type, action.payload)
@@ -209,6 +211,10 @@ export function* sessionStatusWatcher(options: StartSagaOptions): SagaIterator {
         case sessionDisconnectedAction.type: {
           yield put(options.pubSubChannel, sessionDisconnectedAction())
           yield put(destroyAction())
+          break
+        }
+        case sessionForceCloseAction.type: {
+          options.session.forceClose()
           break
         }
       }

--- a/packages/core/src/utils/CloseEvent.ts
+++ b/packages/core/src/utils/CloseEvent.ts
@@ -1,0 +1,21 @@
+/**
+ * Class representing a close event.
+ * The `ws` package does not expose it so we can easily create one in here.
+ *
+ * @extends Event
+ */
+export class CloseEvent extends Event {
+  public code: number
+  public reason: string
+  public wasClean: boolean
+  constructor(
+    type: string,
+    options: { code?: number; reason?: string; wasClean?: boolean } = {}
+  ) {
+    super(type)
+
+    this.code = options.code === undefined ? 0 : options.code
+    this.reason = options.reason === undefined ? '' : options.reason
+    this.wasClean = options.wasClean === undefined ? false : options.wasClean
+  }
+}

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -19,6 +19,7 @@ export * from './extendComponent'
 export * from './eventTransformUtils'
 export * from './proxyUtils'
 export * from './debounce'
+export * from './CloseEvent'
 
 export const mutateStorageKey = (key: string) => `${STORAGE_PREFIX}${key}`
 

--- a/packages/core/src/utils/interfaces.ts
+++ b/packages/core/src/utils/interfaces.ts
@@ -234,6 +234,8 @@ export type SessionStatus =
 
 export type SessionEvents = `session.${SessionStatus}`
 
+export type SessionActions = 'session.forceClose'
+
 export type CompoundEvents = 'compound_event:attach'
 
 /**

--- a/packages/js/src/JWTSession.test.ts
+++ b/packages/js/src/JWTSession.test.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 import { JWTSession } from './JWTSession'
 
 describe('JWTSession', () => {

--- a/packages/js/src/JWTSession.ts
+++ b/packages/js/src/JWTSession.ts
@@ -9,6 +9,7 @@ import { getStorage, CALL_ID } from './utils/storage'
 
 export class JWTSession extends BaseJWTSession {
   public WebSocketConstructor = WebSocket
+  public CloseEventConstructor = CloseEvent
   public agent = process.env.SDK_PKG_AGENT!
 
   constructor(public options: SessionOptions) {

--- a/packages/js/src/RoomSessionDevice.ts
+++ b/packages/js/src/RoomSessionDevice.ts
@@ -5,14 +5,15 @@ import {
   BaseConnectionState,
   RoomLeft,
 } from '@signalwire/core'
-import { BaseConnection } from '@signalwire/webrtc'
+import { BaseConnection, MediaEvent } from '@signalwire/webrtc'
 import { RoomSessionDeviceMethods } from './utils/interfaces'
 
 type RoomSessionDeviceEventsHandlerMap = Record<
   BaseConnectionState,
   (params: RoomSessionDevice) => void
 > &
-  Record<RoomLeft, (params: void) => void>
+  Record<RoomLeft, (params: void) => void> &
+  Record<MediaEvent, () => void>
 
 export type RoomSessionDeviceEvents = {
   [k in keyof RoomSessionDeviceEventsHandlerMap]: RoomSessionDeviceEventsHandlerMap[k]

--- a/packages/js/src/RoomSessionScreenShare.ts
+++ b/packages/js/src/RoomSessionScreenShare.ts
@@ -5,14 +5,15 @@ import {
   BaseConnectionState,
   RoomLeft,
 } from '@signalwire/core'
-import { BaseConnection } from '@signalwire/webrtc'
+import { BaseConnection, MediaEvent } from '@signalwire/webrtc'
 import { RoomScreenShareMethods } from './utils/interfaces'
 
 type RoomSessionScreenShareEventsHandlerMap = Record<
   BaseConnectionState,
   (params: RoomSessionScreenShare) => void
 > &
-  Record<RoomLeft, (params: void) => void>
+  Record<RoomLeft, (params: void) => void> &
+  Record<MediaEvent, () => void>
 
 export type RoomSessionScreenShareEvents = {
   [k in keyof RoomSessionScreenShareEventsHandlerMap]: RoomSessionScreenShareEventsHandlerMap[k]

--- a/packages/js/src/utils/interfaces.ts
+++ b/packages/js/src/utils/interfaces.ts
@@ -33,6 +33,7 @@ import type {
   VideoAuthorization,
 } from '@signalwire/core'
 import { INTERNAL_MEMBER_UPDATABLE_PROPS } from '@signalwire/core'
+import type { MediaEvent } from '@signalwire/webrtc'
 import type { RoomSession } from '../RoomSession'
 import type { RoomSessionDevice } from '../RoomSessionDevice'
 import type { RoomSessionScreenShare } from '../RoomSessionScreenShare'
@@ -62,7 +63,7 @@ const INTERNAL_MEMBER_UPDATED_EVENTS = Object.keys(
 })
 /** @deprecated */
 export type DeprecatedMemberUpdatableProps =
-  typeof INTERNAL_MEMBER_UPDATED_EVENTS[number]
+  (typeof INTERNAL_MEMBER_UPDATED_EVENTS)[number]
 /** @deprecated */
 export type DeprecatedVideoMemberHandlerParams = {
   member: InternalVideoMemberEntity
@@ -121,6 +122,7 @@ export type RoomSessionObjectEventsHandlerMap = Record<
     (params: VideoRoomSubscribedEventParams) => void
   > &
   Record<RoomLeft, (params: void) => void> &
+  Record<MediaEvent, () => void> &
   Record<
     RoomAudienceCount,
     (params: VideoRoomAudienceCountEventParams) => void

--- a/packages/realtime-api/src/Session.ts
+++ b/packages/realtime-api/src/Session.ts
@@ -1,7 +1,8 @@
-import { BaseSession } from '@signalwire/core'
+import { BaseSession, CloseEvent } from '@signalwire/core'
 import WebSocket from 'ws'
 
 export class Session extends BaseSession {
   public WebSocketConstructor = WebSocket
+  public CloseEventConstructor = CloseEvent
   public agent = process.env.SDK_PKG_AGENT!
 }

--- a/packages/webrtc/src/BaseConnection.ts
+++ b/packages/webrtc/src/BaseConnection.ts
@@ -68,7 +68,6 @@ const DEFAULT_CALL_OPTIONS: ConnectionOptions = {
   maxConnectionStateTimeout: 3 * 1000,
   watchMediaPackets: true,
   watchMediaPacketsTimeout: 2 * 1000,
-  watchMediaPacketsInitialDelay: 10 * 1000,
 }
 
 type EventsHandlerMapping = Record<BaseConnectionState, (params: any) => void>

--- a/packages/webrtc/src/BaseConnection.ts
+++ b/packages/webrtc/src/BaseConnection.ts
@@ -697,18 +697,6 @@ export class BaseConnection<EventTypes extends EventEmitter.ValidEventTypes>
         subscribe,
       })
       this.logger.debug('Invite response', response)
-
-      /**
-       * With `response.sdp` it means the call has been reattached
-       * to a previous session so we can set the remote SDP right away
-       * to establish the connection
-       */
-      if (response?.sdp) {
-        if (!this.peer) {
-          return this.logger.warn('Missing RTCPeer')
-        }
-        await this.peer.onRemoteSdp(response.sdp)
-      }
     } catch (error) {
       this.setState('hangup')
       throw error.jsonrpc

--- a/packages/webrtc/src/BaseConnection.ts
+++ b/packages/webrtc/src/BaseConnection.ts
@@ -613,6 +613,10 @@ export class BaseConnection<EventTypes extends EventEmitter.ValidEventTypes>
 
   /** @internal */
   _closeWSConnection() {
+    this.runWorker('sessionAuthWorker', {
+      worker: workers.sessionAuthWorker,
+    })
+
     this.store.dispatch(actions.sessionForceCloseAction())
   }
 

--- a/packages/webrtc/src/BaseConnection.ts
+++ b/packages/webrtc/src/BaseConnection.ts
@@ -70,10 +70,15 @@ const DEFAULT_CALL_OPTIONS: ConnectionOptions = {
   watchMediaPacketsTimeout: 2 * 1000,
 }
 
-type EventsHandlerMapping = Record<BaseConnectionState, (params: any) => void>
+export type MediaEvent =
+  | 'media.connected'
+  | 'media.reconnecting'
+  | 'media.disconnected'
+type EventsHandlerMapping = Record<BaseConnectionState, (params: any) => void> &
+  Record<MediaEvent, () => void>
 
 export type BaseConnectionStateEventTypes = {
-  [k in BaseConnectionState]: EventsHandlerMapping[k]
+  [k in keyof EventsHandlerMapping]: EventsHandlerMapping[k]
 }
 
 export type BaseConnectionOptions<

--- a/packages/webrtc/src/RTCPeer.ts
+++ b/packages/webrtc/src/RTCPeer.ts
@@ -363,7 +363,7 @@ export default class RTCPeer<EventTypes extends EventEmitter.ValidEventTypes> {
   }
 
   async startNegotiation(force = false) {
-    if (this._negotiating || this._restartingIce) {
+    if (this._negotiating) {
       return this.logger.warn('Skip twice onnegotiationneeded!')
     }
     this._negotiating = true

--- a/packages/webrtc/src/RTCPeer.ts
+++ b/packages/webrtc/src/RTCPeer.ts
@@ -809,6 +809,10 @@ export default class RTCPeer<EventTypes extends EventEmitter.ValidEventTypes> {
           // Chrome bug: https://bugs.chromium.org/p/chromium/issues/detail?id=740501
           this._negotiating = false
           this.resetNeedResume()
+
+          if (this.instance.connectionState === 'connected') {
+            this.emitMediaConnected()
+          }
           break
         case 'have-local-offer': {
           if (this.instance.iceGatheringState === 'complete') {
@@ -838,8 +842,7 @@ export default class RTCPeer<EventTypes extends EventEmitter.ValidEventTypes> {
           break
         case 'connected':
           this.clearConnectionStateTimer()
-          // @ts-expect-error
-          this.call.emit('media.connected')
+          this.emitMediaConnected()
           break
         // case 'closed':
         //   break
@@ -904,5 +907,10 @@ export default class RTCPeer<EventTypes extends EventEmitter.ValidEventTypes> {
 
   private clearWatchMediaPacketsTimer() {
     clearTimeout(this._watchMediaPacketsTimer)
+  }
+
+  private emitMediaConnected() {
+    // @ts-expect-error
+    this.call.emit('media.connected')
   }
 }

--- a/packages/webrtc/src/RTCPeer.ts
+++ b/packages/webrtc/src/RTCPeer.ts
@@ -811,6 +811,8 @@ export default class RTCPeer<EventTypes extends EventEmitter.ValidEventTypes> {
           this.resetNeedResume()
 
           if (this.instance.connectionState === 'connected') {
+            // An ice restart won't change the connectionState so we emit the same event in here
+            // since the signalingState is "stable" again.
             this.emitMediaConnected()
           }
           break

--- a/packages/webrtc/src/RTCPeer.ts
+++ b/packages/webrtc/src/RTCPeer.ts
@@ -107,6 +107,16 @@ export default class RTCPeer<EventTypes extends EventEmitter.ValidEventTypes> {
     return audioSender?.track || null
   }
 
+  get remoteVideoTrack() {
+    const videoReceiver = this._getReceiverByKind('video')
+    return videoReceiver?.track || null
+  }
+
+  get remoteAudioTrack() {
+    const audioReceiver = this._getReceiverByKind('audio')
+    return audioReceiver?.track || null
+  }
+
   get hasAudioSender() {
     return this._getSenderByKind('audio') ? true : false
   }

--- a/packages/webrtc/src/RTCPeer.ts
+++ b/packages/webrtc/src/RTCPeer.ts
@@ -277,7 +277,6 @@ export default class RTCPeer<EventTypes extends EventEmitter.ValidEventTypes> {
     this.logger.info('Probably half-open so force close from client')
     this.clearTimers()
     this.needResume = true
-    this.logger.warn('>> FORCE CLOSE WS CONNECTION')
     this.call._closeWSConnection()
   }
 

--- a/packages/webrtc/src/RTCPeer.ts
+++ b/packages/webrtc/src/RTCPeer.ts
@@ -280,19 +280,23 @@ export default class RTCPeer<EventTypes extends EventEmitter.ValidEventTypes> {
   }
 
   triggerResume() {
+    this.logger.info('Probably half-open so force close from client')
     if (this.needResume) {
       this.logger.info('[skipped] Already in "resume" state')
       return
     }
-    this.logger.info('Probably half-open so force close from client')
+    // @ts-expect-error
+    this.call.emit('media.disconnected')
+
+    // @ts-expect-error
+    this.call.emit('media.reconnecting')
     this.clearTimers()
     this.needResume = true
     this.call._closeWSConnection()
   }
 
-  resetNeedResume() {
+  private resetNeedResume() {
     this.needResume = false
-
     if (this.options.watchMediaPackets) {
       this.startWatchMediaPackets()
     }
@@ -834,7 +838,8 @@ export default class RTCPeer<EventTypes extends EventEmitter.ValidEventTypes> {
           break
         case 'connected':
           this.clearConnectionStateTimer()
-          // this.call.setState(State.Active)
+          // @ts-expect-error
+          this.call.emit('media.connected')
           break
         // case 'closed':
         //   break

--- a/packages/webrtc/src/index.ts
+++ b/packages/webrtc/src/index.ts
@@ -42,4 +42,5 @@ export {
   BaseConnection,
   BaseConnectionOptions,
   BaseConnectionStateEventTypes,
+  MediaEvent,
 } from './BaseConnection'

--- a/packages/webrtc/src/utils/interfaces.ts
+++ b/packages/webrtc/src/utils/interfaces.ts
@@ -76,6 +76,17 @@ export interface ConnectionOptions {
   /** @internal */
   iceGatheringTimeout?: number
   /** @internal */
+  maxIceGatheringTimeout?: number
+  /** @internal */
+  maxConnectionStateTimeout?: number
+  /** @internal */
+  watchMediaPackets?: boolean
+  /** @internal */
+  watchMediaPacketsTimeout?: number
+  /** @internal */
+  watchMediaPacketsInitialDelay?: number
+
+  /** @internal */
   pingSupported?: boolean
   /** @internal */
   prevCallId?: string

--- a/packages/webrtc/src/utils/interfaces.ts
+++ b/packages/webrtc/src/utils/interfaces.ts
@@ -83,8 +83,6 @@ export interface ConnectionOptions {
   watchMediaPackets?: boolean
   /** @internal */
   watchMediaPacketsTimeout?: number
-  /** @internal */
-  watchMediaPacketsInitialDelay?: number
 
   /** @internal */
   pingSupported?: boolean

--- a/packages/webrtc/src/utils/sdpHelpers.ts
+++ b/packages/webrtc/src/utils/sdpHelpers.ts
@@ -128,6 +128,7 @@ export const sdpBitrateHack = (
 
 /**
  * Check for srflx, prflx or relay candidates
+ * TODO: improve the logic check private/public IP for typ host
  *
  * @param sdp string
  * @returns boolean

--- a/packages/webrtc/src/utils/sdpHelpers.ts
+++ b/packages/webrtc/src/utils/sdpHelpers.ts
@@ -1,3 +1,6 @@
+import { getLogger } from '@signalwire/core'
+import SDPUtils from 'sdp'
+
 const _isAudioLine = (line: string) => /^m=audio/.test(line)
 const _isVideoLine = (line: string) => /^m=video/.test(line)
 const _getCodecPayloadType = (line: string) => {
@@ -122,3 +125,30 @@ export const sdpBitrateHack = (
 //   ]
 //   return sdpAudioRemoveRTPExtensions(sdp, extensionsToFilter)
 // }
+
+/**
+ * Check for srflx, prflx or relay candidates
+ *
+ * @param sdp string
+ * @returns boolean
+ */
+export const sdpHasValidCandidates = (sdp: string) => {
+  try {
+    const regex = /typ (?:srflx|prflx|relay)/
+    const sections = SDPUtils.getMediaSections(sdp)
+    for (const section of sections) {
+      const lines = SDPUtils.splitLines(section)
+      const valid = lines.some((line) => {
+        return line.indexOf('a=candidate') === 0 && regex.test(line)
+      })
+      if (!valid) {
+        return false
+      }
+    }
+
+    return true
+  } catch (error) {
+    getLogger().error('Error checking SDP', error)
+    return false
+  }
+}

--- a/packages/webrtc/src/utils/watchRTCPeerMediaPackets.ts
+++ b/packages/webrtc/src/utils/watchRTCPeerMediaPackets.ts
@@ -27,15 +27,26 @@ export const watchRTCPeerMediaPackets = <
     let videoPacketsReceived = 0
     try {
       const stats = await rtcPeer.instance.getStats(null)
+      const audioTrackId = rtcPeer.remoteAudioTrack?.id
+      const videoTrackId = rtcPeer.remoteVideoTrack?.id
+
       stats.forEach((report) => {
-        if (report.type === 'inbound-rtp' && report.kind === 'audio') {
-          getLogger().debug(
+        if (
+          report.type === 'inbound-rtp' &&
+          report.kind === 'audio' &&
+          report.trackIdentifier === audioTrackId
+        ) {
+          getLogger().trace(
             `audio inbound-rtp: packetsReceived: ${report.packetsReceived} (at ${report.lastPacketReceivedTimestamp})`
           )
           audioPacketsReceived = report.packetsReceived
         }
-        if (report.type === 'inbound-rtp' && report.kind === 'video') {
-          getLogger().debug(
+        if (
+          report.type === 'inbound-rtp' &&
+          report.kind === 'video' &&
+          report.trackIdentifier === videoTrackId
+        ) {
+          getLogger().trace(
             `video inbound-rtp: packetsReceived: ${report.packetsReceived} (at ${report.lastPacketReceivedTimestamp})`
           )
           videoPacketsReceived = report.packetsReceived

--- a/packages/webrtc/src/utils/watchRTCPeerMediaPackets.ts
+++ b/packages/webrtc/src/utils/watchRTCPeerMediaPackets.ts
@@ -1,0 +1,69 @@
+import { EventEmitter, getLogger } from '@signalwire/core'
+import type RTCPeer from '../RTCPeer'
+
+export const watchRTCPeerMediaPackets = <
+  T extends EventEmitter.ValidEventTypes
+>(
+  rtcPeer: RTCPeer<T>
+) => {
+  if (!rtcPeer.hasAudioReceiver && !rtcPeer.hasVideoReceiver) {
+    getLogger().warn(
+      `Missing receivers to inspect media for RTCPeer "${rtcPeer.uuid}"`
+    )
+    return
+  }
+  getLogger().debug(`Start watching media for RTCPeer "${rtcPeer.uuid}"`)
+  let previousAudioValue = 0
+  let previousVideoValue = 0
+
+  let timer: ReturnType<typeof setTimeout>
+  const clearTimer = () => {
+    clearTimeout(timer)
+  }
+
+  const meter = async () => {
+    let audioPacketsReceived = 0
+    let videoPacketsReceived = 0
+    try {
+      const stats = await rtcPeer.instance.getStats(null)
+      stats.forEach((report) => {
+        if (report.type === 'inbound-rtp' && report.kind === 'audio') {
+          getLogger().debug(
+            `audio inbound-rtp: packetsReceived: ${report.packetsReceived} (at ${report.lastPacketReceivedTimestamp})`
+          )
+          audioPacketsReceived = report.packetsReceived
+        }
+        if (report.type === 'inbound-rtp' && report.kind === 'video') {
+          getLogger().debug(
+            `video inbound-rtp: packetsReceived: ${report.packetsReceived} (at ${report.lastPacketReceivedTimestamp})`
+          )
+          videoPacketsReceived = report.packetsReceived
+        }
+      })
+    } catch (error) {
+      getLogger().warn('getStats error', error)
+    } finally {
+      const noAudioChanged =
+        audioPacketsReceived && audioPacketsReceived <= previousAudioValue
+      const noVideoChanged =
+        videoPacketsReceived && videoPacketsReceived <= previousVideoValue
+      if (noAudioChanged && noVideoChanged) {
+        getLogger().warn(
+          `audioPacketsReceived: ${audioPacketsReceived} - previousAudioValue: ${previousAudioValue}`
+        )
+        getLogger().warn(
+          `videoPacketsReceived: ${videoPacketsReceived} - previousVideoValue: ${previousVideoValue}`
+        )
+        rtcPeer.triggerResume()
+      } else {
+        previousAudioValue = audioPacketsReceived ?? previousAudioValue
+        previousVideoValue = videoPacketsReceived ?? previousVideoValue
+        clearTimer()
+        timer = setTimeout(() => meter(), rtcPeer.watchMediaPacketsTimeout)
+      }
+    }
+  }
+
+  clearTimer()
+  meter()
+}

--- a/packages/webrtc/src/utils/watchRTCPeerMediaPackets.ts
+++ b/packages/webrtc/src/utils/watchRTCPeerMediaPackets.ts
@@ -16,6 +16,7 @@ export const watchRTCPeerMediaPackets = <
   let previousAudioValue = 0
   let previousVideoValue = 0
 
+  let run = true
   let timer: ReturnType<typeof setTimeout>
   const clearTimer = () => {
     clearTimeout(timer)
@@ -59,11 +60,21 @@ export const watchRTCPeerMediaPackets = <
         previousAudioValue = audioPacketsReceived ?? previousAudioValue
         previousVideoValue = videoPacketsReceived ?? previousVideoValue
         clearTimer()
-        timer = setTimeout(() => meter(), rtcPeer.watchMediaPacketsTimeout)
+        if (run && rtcPeer.instance.connectionState !== 'closed') {
+          timer = setTimeout(() => meter(), rtcPeer.watchMediaPacketsTimeout)
+        }
       }
     }
   }
 
-  clearTimer()
-  meter()
+  return {
+    start: () => {
+      clearTimer()
+      meter()
+    },
+    stop: () => {
+      run = false
+      clearTimer()
+    },
+  }
 }

--- a/packages/webrtc/src/workers/index.ts
+++ b/packages/webrtc/src/workers/index.ts
@@ -1,3 +1,4 @@
 export * from './vertoEventWorker'
 export * from './roomSubscribedWorker'
 export * from './promoteDemoteWorker'
+export * from './sessionAuthWorker'

--- a/packages/webrtc/src/workers/sessionAuthWorker.ts
+++ b/packages/webrtc/src/workers/sessionAuthWorker.ts
@@ -32,10 +32,10 @@ export const sessionAuthWorker: SDKWorker<
 
   switch (action.type) {
     case actions.authSuccessAction.type:
-      yield sagaEffects.call(instance.resume)
+      yield sagaEffects.call([instance, instance.resume])
       break
     case actions.authErrorAction.type:
-      yield sagaEffects.call(instance.setState, 'hangup')
+      yield sagaEffects.call([instance, instance.setState], 'hangup')
       break
   }
 

--- a/packages/webrtc/src/workers/sessionAuthWorker.ts
+++ b/packages/webrtc/src/workers/sessionAuthWorker.ts
@@ -1,0 +1,43 @@
+import {
+  getLogger,
+  sagaEffects,
+  actions,
+  SagaIterator,
+  SDKWorker,
+  SDKWorkerHooks,
+} from '@signalwire/core'
+
+import { BaseConnection } from '../BaseConnection'
+
+type SessionAuthWorkerOnDone = (args: BaseConnection<any>) => void
+type SessionAuthWorkerOnFail = (args: { error: Error }) => void
+
+export type SessionAuthWorkerHooks = SDKWorkerHooks<
+  SessionAuthWorkerOnDone,
+  SessionAuthWorkerOnFail
+>
+
+type Action = typeof actions.authSuccessAction | typeof actions.authErrorAction
+
+export const sessionAuthWorker: SDKWorker<
+  BaseConnection<any>,
+  SessionAuthWorkerHooks
+> = function* (options): SagaIterator {
+  getLogger().debug('sessionAuthWorker started')
+  const { instance } = options
+  const action: Action = yield sagaEffects.take([
+    actions.authSuccessAction.type,
+    actions.authErrorAction.type,
+  ])
+
+  switch (action.type) {
+    case actions.authSuccessAction.type:
+      yield sagaEffects.call(instance.resume)
+      break
+    case actions.authErrorAction.type:
+      yield sagaEffects.call(instance.setState, 'hangup')
+      break
+  }
+
+  getLogger().debug('sessionAuthWorker ended')
+}


### PR DESCRIPTION
This PR includes improvements on how the SDK detects a network disconnect. 

- Force close the WS if we detect loss of media packets
- Use a manual `CloseEvent` to trigger the reconnect process on our Session so the SDK is more reactive.
- After the WS reconnect, try to resume the RTC connection using an ice restart
- Add e2e tests simulating network down & up expecting the WebRTC connection to survive to the network issues.


It also includes general optimizations about the WebRTC signaling process.