### PR TITLE
Handle voice playback failure

### DIFF
--- a/.changeset/seven-beers-occur.md
+++ b/.changeset/seven-beers-occur.md
@@ -4,3 +4,4 @@
 ---
 
 Emit playback.failed event on playback failure
+Resolve the playback `.ended()` promise in case of playback failure

--- a/.changeset/seven-beers-occur.md
+++ b/.changeset/seven-beers-occur.md
@@ -1,0 +1,6 @@
+---
+'@signalwire/realtime-api': minor
+'@signalwire/core': minor
+---
+
+Emit playback.failed event on playback failure

--- a/internal/e2e-realtime-api/src/voicePlayback.test.ts
+++ b/internal/e2e-realtime-api/src/voicePlayback.test.ts
@@ -1,0 +1,111 @@
+import tap from 'tap'
+import { Voice } from '@signalwire/realtime-api'
+import { createTestRunner } from './utils'
+
+const handler = () => {
+  return new Promise<number>(async (resolve, reject) => {
+    const client = new Voice.Client({
+      host: process.env.RELAY_HOST || 'relay.swire.io',
+      project: process.env.RELAY_PROJECT as string,
+      token: process.env.RELAY_TOKEN as string,
+      contexts: [process.env.VOICE_CONTEXT as string],
+    })
+
+    client.on('call.received', async (call) => {
+      console.log('Got call', call.id, call.from, call.to, call.direction)
+
+      try {
+        const resultAnswer = await call.answer()
+        tap.ok(resultAnswer.id, 'Inboud call answered')
+        tap.equal(
+          call.id,
+          resultAnswer.id,
+          'Call answered gets the same instance'
+        )
+
+        const handle = await call.playAudio({
+          url: 'https://cdn.fake.com/default-music/fake.mp3',
+        })
+
+        tap.equal(
+          call.id,
+          handle.callId,
+          'Inbound playback returns the same instance'
+        )
+
+        const waitForPlaybackFailed = new Promise(async (resolve) => {
+          call.on('playback.failed', (playback) => {
+            tap.equal(playback.state, 'error', 'Inbound playback has failed')
+            resolve(true)
+          })
+        })
+
+        await waitForPlaybackFailed
+
+        await call.hangup()
+      } catch (error) {
+        console.error('Error', error)
+        reject(4)
+      }
+    })
+
+    const call = await client.dialPhone({
+      to: process.env.VOICE_DIAL_TO_NUMBER as string,
+      from: process.env.VOICE_DIAL_FROM_NUMBER as string,
+      timeout: 30,
+    })
+    tap.ok(call.id, 'Call resolved')
+
+    const handle = await call.playAudio({
+      url: 'https://cdn.signalwire.com/default-music/welcome.mp3',
+    })
+
+    tap.equal(
+      call.id,
+      handle.callId,
+      'Outbound playback returns the same instance'
+    )
+
+    const waitForPlaybackStarted = new Promise(async (resolve) => {
+      call.on('playback.started', (playback) => {
+        tap.equal(playback.state, 'playing', 'Outbound playback has started')
+        resolve(true)
+      })
+    })
+    await waitForPlaybackStarted
+
+    const waitForPlaybackEnded = new Promise(async (resolve) => {
+      call.on('playback.ended', (playback) => {
+        tap.equal(playback.state, 'finished', 'Outbound playback has finished')
+        resolve(true)
+      })
+    })
+    await waitForPlaybackEnded
+
+    const waitForParams = ['ended', 'ending', ['ending', 'ended']] as const
+    const results = await Promise.all(
+      waitForParams.map((params) => call.waitFor(params as any))
+    )
+    waitForParams.forEach((value, i) => {
+      if (typeof value === 'string') {
+        tap.ok(results[i], `"${value}": completed successfully.`)
+      } else {
+        tap.ok(results[i], `${JSON.stringify(value)}: completed successfully.`)
+      }
+    })
+
+    resolve(0)
+  })
+}
+
+async function main() {
+  const runner = createTestRunner({
+    name: 'Voice Playback E2E',
+    testHandler: handler,
+    executionTime: 60_000,
+  })
+
+  await runner.run()
+}
+
+main()

--- a/internal/e2e-realtime-api/src/voicePlayback.test.ts
+++ b/internal/e2e-realtime-api/src/voicePlayback.test.ts
@@ -23,6 +23,7 @@ const handler = () => {
           'Call answered gets the same instance'
         )
 
+        // Play an invalid audio
         const handle = await call.playAudio({
           url: 'https://cdn.fake.com/default-music/fake.mp3',
         })
@@ -33,15 +34,16 @@ const handler = () => {
           'Inbound playback returns the same instance'
         )
 
-        const waitForPlaybackFailed = new Promise(async (resolve) => {
+        const waitForPlaybackFailed = new Promise((resolve) => {
           call.on('playback.failed', (playback) => {
             tap.equal(playback.state, 'error', 'Inbound playback has failed')
             resolve(true)
           })
         })
-
+        // Wait for the inbound audio to failed
         await waitForPlaybackFailed
 
+        // Callee hangs up a call
         await call.hangup()
       } catch (error) {
         console.error('Error', error)
@@ -56,6 +58,7 @@ const handler = () => {
     })
     tap.ok(call.id, 'Call resolved')
 
+    // Play an audio
     const handle = await call.playAudio({
       url: 'https://cdn.signalwire.com/default-music/welcome.mp3',
     })
@@ -66,20 +69,22 @@ const handler = () => {
       'Outbound playback returns the same instance'
     )
 
-    const waitForPlaybackStarted = new Promise(async (resolve) => {
+    const waitForPlaybackStarted = new Promise((resolve) => {
       call.on('playback.started', (playback) => {
         tap.equal(playback.state, 'playing', 'Outbound playback has started')
         resolve(true)
       })
     })
+    // Wait for the outbound audio to start
     await waitForPlaybackStarted
 
-    const waitForPlaybackEnded = new Promise(async (resolve) => {
+    const waitForPlaybackEnded = new Promise((resolve) => {
       call.on('playback.ended', (playback) => {
         tap.equal(playback.state, 'finished', 'Outbound playback has finished')
         resolve(true)
       })
     })
+    // Wait for the outbound audio to end (callee hung up the call or audio ended)
     await waitForPlaybackEnded
 
     const waitForParams = ['ended', 'ending', ['ending', 'ended']] as const

--- a/packages/core/src/types/voiceCall.ts
+++ b/packages/core/src/types/voiceCall.ts
@@ -72,6 +72,7 @@ export type CallReceived = 'call.received'
 export type CallPlaybackStarted = 'playback.started'
 export type CallPlaybackUpdated = 'playback.updated'
 export type CallPlaybackEnded = 'playback.ended'
+export type CallPlaybackFailed = 'playback.failed'
 export type CallRecordingStarted = 'recording.started'
 export type CallRecordingUpdated = 'recording.updated'
 export type CallRecordingEnded = 'recording.ended'
@@ -106,6 +107,7 @@ export type VoiceCallEventNames =
   | CallPlaybackStarted
   | CallPlaybackUpdated
   | CallPlaybackEnded
+  | CallPlaybackFailed
   | CallRecordingStarted
   | CallRecordingUpdated
   | CallRecordingEnded
@@ -1148,6 +1150,14 @@ export interface CallPlaybackEndedEvent extends SwEvent {
   params: CallingCallPlayEventParams & { tag: string }
 }
 /**
+ * 'calling.playback.failed'
+ */
+export interface CallPlaybackFailedEvent extends SwEvent {
+  event_type: ToInternalVoiceEvent<CallPlaybackFailed>
+  params: CallingCallPlayEventParams & { tag: string }
+}
+
+/**
  * 'calling.call.received'
  */
 export interface CallReceivedEvent extends SwEvent {
@@ -1367,6 +1377,7 @@ export type VoiceCallEvent =
   | CallPlaybackStartedEvent
   | CallPlaybackUpdatedEvent
   | CallPlaybackEndedEvent
+  | CallPlaybackFailedEvent
   | CallRecordingStartedEvent
   | CallRecordingUpdatedEvent
   | CallRecordingEndedEvent
@@ -1408,6 +1419,7 @@ export type VoiceCallEventParams =
   | CallPlaybackStartedEvent['params']
   | CallPlaybackUpdatedEvent['params']
   | CallPlaybackEndedEvent['params']
+  | CallPlaybackFailedEvent['params']
   | CallRecordingStartedEvent['params']
   | CallRecordingUpdatedEvent['params']
   | CallRecordingEndedEvent['params']

--- a/packages/realtime-api/src/types/voice.ts
+++ b/packages/realtime-api/src/types/voice.ts
@@ -4,6 +4,7 @@ import type {
   CallPlaybackStarted,
   CallPlaybackUpdated,
   CallPlaybackEnded,
+  CallPlaybackFailed,
   CallRecordingStarted,
   CallRecordingUpdated,
   CallRecordingEnded,
@@ -33,7 +34,10 @@ export type RealTimeCallApiEventsHandlerMapping = Record<
 > &
   Record<CallState, (call: Call) => void> &
   Record<
-    CallPlaybackStarted | CallPlaybackUpdated | CallPlaybackEnded,
+    | CallPlaybackStarted
+    | CallPlaybackUpdated
+    | CallPlaybackEnded
+    | CallPlaybackFailed,
     (playback: CallPlayback) => void
   > &
   Record<

--- a/packages/realtime-api/src/voice/Call.ts
+++ b/packages/realtime-api/src/voice/Call.ts
@@ -74,6 +74,7 @@ type EmitterTransformsEvents =
   | 'calling.playback.started'
   | 'calling.playback.updated'
   | 'calling.playback.ended'
+  | 'calling.playback.failed'
   | 'calling.recording.started'
   | 'calling.recording.updated'
   | 'calling.recording.ended'
@@ -247,6 +248,7 @@ export class CallConsumer extends AutoApplyTransformsConsumer<RealTimeCallApiEve
           'calling.playback.started',
           'calling.playback.updated',
           'calling.playback.ended',
+          'calling.playback.failed',
         ],
         {
           type: 'voiceCallPlayback',

--- a/packages/realtime-api/src/voice/CallPlayback.ts
+++ b/packages/realtime-api/src/voice/CallPlayback.ts
@@ -104,7 +104,8 @@ export class CallPlaybackAPI
   }
 
   ended() {
-    if (['finished', 'error'].includes(this.state)) {
+    const ENDED_STATES = ['finished', 'error']
+    if (ENDED_STATES.includes(this.state)) {
       return Promise.resolve(this)
     }
 

--- a/packages/realtime-api/src/voice/CallPlayback.ts
+++ b/packages/realtime-api/src/voice/CallPlayback.ts
@@ -23,6 +23,8 @@ export type CallPlaybackEventsHandlerMapping = {}
 export interface CallPlaybackOptions
   extends BaseComponentOptions<CallPlaybackEventsHandlerMapping> {}
 
+const ENDED_STATES: string[] = ['finished', 'error']
+
 export class CallPlaybackAPI
   extends BaseComponent<CallPlaybackEventsHandlerMapping>
   implements VoiceCallPlaybackContract
@@ -104,7 +106,6 @@ export class CallPlaybackAPI
   }
 
   ended() {
-    const ENDED_STATES = ['finished', 'error']
     if (ENDED_STATES.includes(this.state)) {
       return Promise.resolve(this)
     }

--- a/packages/realtime-api/src/voice/CallPlayback.ts
+++ b/packages/realtime-api/src/voice/CallPlayback.ts
@@ -104,6 +104,10 @@ export class CallPlaybackAPI
   }
 
   ended() {
+    if (['finished', 'error'].includes(this.state)) {
+      return Promise.resolve(this)
+    }
+
     return new Promise<this>((resolve) => {
       this._attachListeners(this.controlId)
 

--- a/packages/realtime-api/src/voice/workers/voiceCallPlayWorker.ts
+++ b/packages/realtime-api/src/voice/workers/voiceCallPlayWorker.ts
@@ -44,7 +44,7 @@ export const voiceCallPlayWorker: SDKWorker<Call> = function* (
      * Update the original CallPlayback object using the
      * transform pipeline
      */
-     yield sagaEffects.put(pubSubChannel, {
+    yield sagaEffects.put(pubSubChannel, {
       // @ts-ignore
       type: callingPlaybackTriggerEvent,
       // @ts-ignore
@@ -73,9 +73,27 @@ export const voiceCallPlayWorker: SDKWorker<Call> = function* (
         })
         break
       }
-      case 'error':
-        // TODO: dispatch calling.playback.error ?
+      case 'error': {
+        yield sagaEffects.put(pubSubChannel, {
+          type: 'calling.playback.failed',
+          payload: payloadWithTag,
+        })
+
+        /**
+         * Dispatch an event to resolve `ended()` in CallPlayback
+         * when ended
+         */
+        yield sagaEffects.put(pubSubChannel, {
+          type: 'calling.playback.ended',
+          payload: {
+            tag: controlId,
+            ...action.payload,
+          },
+        })
+
+        done()
         break
+      }
       case 'finished': {
         yield sagaEffects.put(pubSubChannel, {
           type: 'calling.playback.ended',


### PR DESCRIPTION
On playback failure

- Emit `playback.failed` event to the end-user,
- Resolve the playback promise

This PR also includes an e2e test case for the playback function.