### PR TITLE
Resolve the `.ended()` promise in case of call failure

### DIFF
--- a/.changeset/seven-beers-occur.md
+++ b/.changeset/seven-beers-occur.md
@@ -3,5 +3,10 @@
 '@signalwire/core': minor
 ---
 
-Emit playback.failed event on playback failure
-Resolve the playback `.ended()` promise in case of playback failure
+Emit `playback.failed` event on playback failure
+Resolve the playback `.ended()` promise in case of Playback failure
+Resolve the playback `.ended()` promise in case of Prompt failure
+Resolve the playback `.ended()` promise in case of Recording failure
+Resolve the playback `.ended()` promise in case of Detect failure
+Resolve the playback `.ended()` promise in case of Collect failure
+Resolve the playback `.ended()` promise in case of Tap failure

--- a/.changeset/seven-beers-occur.md
+++ b/.changeset/seven-beers-occur.md
@@ -4,3 +4,4 @@
 ---
 
 Emit playback.failed event on playback failure
+Resolve the playback `.ended()` promise in case of playback failure

--- a/.changeset/seven-beers-occur.md
+++ b/.changeset/seven-beers-occur.md
@@ -1,0 +1,6 @@
+---
+'@signalwire/realtime-api': minor
+'@signalwire/core': minor
+---
+
+Emit playback.failed event on playback failure

--- a/internal/e2e-realtime-api/src/utils.ts
+++ b/internal/e2e-realtime-api/src/utils.ts
@@ -121,3 +121,9 @@ export const sessionStorageMock = () => {
     },
   }
 }
+
+export const sleep = (ms = 3000) => {
+  return new Promise((r) => {
+    setTimeout(r, ms)
+  })
+}

--- a/internal/e2e-realtime-api/src/voice.test.ts
+++ b/internal/e2e-realtime-api/src/voice.test.ts
@@ -1,12 +1,6 @@
 import tap from 'tap'
 import { Voice } from '@signalwire/realtime-api'
-import { createTestRunner } from './utils'
-
-const sleep = (ms = 3000) => {
-  return new Promise((r) => {
-    setTimeout(r, ms)
-  })
-}
+import { createTestRunner, sleep } from './utils'
 
 const handler = () => {
   return new Promise<number>(async (resolve, reject) => {

--- a/internal/e2e-realtime-api/src/voiceCollect.test.ts
+++ b/internal/e2e-realtime-api/src/voiceCollect.test.ts
@@ -1,12 +1,6 @@
 import tap from 'tap'
 import { Voice } from '@signalwire/realtime-api'
-import { createTestRunner } from './utils'
-
-const sleep = (ms = 3000) => {
-  return new Promise((r) => {
-    setTimeout(r, ms)
-  })
-}
+import { createTestRunner, sleep } from './utils'
 
 const handler = () => {
   return new Promise<number>(async (resolve, reject) => {

--- a/internal/e2e-realtime-api/src/voiceDetect.test.ts
+++ b/internal/e2e-realtime-api/src/voiceDetect.test.ts
@@ -1,0 +1,87 @@
+import tap from 'tap'
+import { Voice } from '@signalwire/realtime-api'
+import { createTestRunner } from './utils'
+
+const sleep = (ms = 3000) => {
+  return new Promise((r) => {
+    setTimeout(r, ms)
+  })
+}
+const handler = () => {
+  return new Promise<number>(async (resolve, reject) => {
+    const client = new Voice.Client({
+      host: process.env.RELAY_HOST || 'relay.swire.io',
+      project: process.env.RELAY_PROJECT as string,
+      token: process.env.RELAY_TOKEN as string,
+      contexts: [process.env.VOICE_CONTEXT as string],
+    })
+
+    client.on('call.received', async (call) => {
+      console.log(
+        'Inbound - Got call',
+        call.id,
+        call.from,
+        call.to,
+        call.direction
+      )
+
+      try {
+        const resultAnswer = await call.answer()
+        tap.ok(resultAnswer.id, 'Inbound - Call answered')
+        tap.equal(
+          call.id,
+          resultAnswer.id,
+          'Inbound - Call answered gets the same instance'
+        )
+
+        // Send digits 1234 to the caller
+        const sendDigitResult = await call.sendDigits('1w2w3w4w#')
+        tap.equal(
+          call.id,
+          sendDigitResult.id,
+          'Inbound - sendDigit returns the same instance'
+        )
+
+        // Callee hangs up a call
+        await call.hangup()
+      } catch (error) {
+        console.error('Inbound - Error', error)
+        reject(4)
+      }
+    })
+
+    const call = await client.dialPhone({
+      to: process.env.VOICE_DIAL_TO_NUMBER as string,
+      from: process.env.VOICE_DIAL_FROM_NUMBER as string,
+      timeout: 30,
+    })
+    tap.ok(call.id, 'Outbound - Call resolved')
+
+    // Start a detect
+    const detect = await call.detectDigit({ digits: '1234' })
+
+    tap.equal(
+      call.id,
+      detect.callId,
+      'Outbound - Detect returns the same instance'
+    )
+
+    const { type } = await detect.ended()
+
+    tap.equal(type, 'digit', 'Outbound - Received the digit')
+
+    resolve(0)
+  })
+}
+
+async function main() {
+  const runner = createTestRunner({
+    name: 'Voice Detect E2E',
+    testHandler: handler,
+    executionTime: 60_000,
+  })
+
+  await runner.run()
+}
+
+main()

--- a/internal/e2e-realtime-api/src/voiceDetect.test.ts
+++ b/internal/e2e-realtime-api/src/voiceDetect.test.ts
@@ -2,11 +2,6 @@ import tap from 'tap'
 import { Voice } from '@signalwire/realtime-api'
 import { createTestRunner } from './utils'
 
-const sleep = (ms = 3000) => {
-  return new Promise((r) => {
-    setTimeout(r, ms)
-  })
-}
 const handler = () => {
   return new Promise<number>(async (resolve, reject) => {
     const client = new Voice.Client({

--- a/internal/e2e-realtime-api/src/voicePlayback.test.ts
+++ b/internal/e2e-realtime-api/src/voicePlayback.test.ts
@@ -1,0 +1,111 @@
+import tap from 'tap'
+import { Voice } from '@signalwire/realtime-api'
+import { createTestRunner } from './utils'
+
+const handler = () => {
+  return new Promise<number>(async (resolve, reject) => {
+    const client = new Voice.Client({
+      host: process.env.RELAY_HOST || 'relay.swire.io',
+      project: process.env.RELAY_PROJECT as string,
+      token: process.env.RELAY_TOKEN as string,
+      contexts: [process.env.VOICE_CONTEXT as string],
+    })
+
+    client.on('call.received', async (call) => {
+      console.log('Got call', call.id, call.from, call.to, call.direction)
+
+      try {
+        const resultAnswer = await call.answer()
+        tap.ok(resultAnswer.id, 'Inboud call answered')
+        tap.equal(
+          call.id,
+          resultAnswer.id,
+          'Call answered gets the same instance'
+        )
+
+        const handle = await call.playAudio({
+          url: 'https://cdn.fake.com/default-music/fake.mp3',
+        })
+
+        tap.equal(
+          call.id,
+          handle.callId,
+          'Inbound playback returns the same instance'
+        )
+
+        const waitForPlaybackFailed = new Promise(async (resolve) => {
+          call.on('playback.failed', (playback) => {
+            tap.equal(playback.state, 'error', 'Inbound playback has failed')
+            resolve(true)
+          })
+        })
+
+        await waitForPlaybackFailed
+
+        await call.hangup()
+      } catch (error) {
+        console.error('Error', error)
+        reject(4)
+      }
+    })
+
+    const call = await client.dialPhone({
+      to: process.env.VOICE_DIAL_TO_NUMBER as string,
+      from: process.env.VOICE_DIAL_FROM_NUMBER as string,
+      timeout: 30,
+    })
+    tap.ok(call.id, 'Call resolved')
+
+    const handle = await call.playAudio({
+      url: 'https://cdn.signalwire.com/default-music/welcome.mp3',
+    })
+
+    tap.equal(
+      call.id,
+      handle.callId,
+      'Outbound playback returns the same instance'
+    )
+
+    const waitForPlaybackStarted = new Promise(async (resolve) => {
+      call.on('playback.started', (playback) => {
+        tap.equal(playback.state, 'playing', 'Outbound playback has started')
+        resolve(true)
+      })
+    })
+    await waitForPlaybackStarted
+
+    const waitForPlaybackEnded = new Promise(async (resolve) => {
+      call.on('playback.ended', (playback) => {
+        tap.equal(playback.state, 'finished', 'Outbound playback has finished')
+        resolve(true)
+      })
+    })
+    await waitForPlaybackEnded
+
+    const waitForParams = ['ended', 'ending', ['ending', 'ended']] as const
+    const results = await Promise.all(
+      waitForParams.map((params) => call.waitFor(params as any))
+    )
+    waitForParams.forEach((value, i) => {
+      if (typeof value === 'string') {
+        tap.ok(results[i], `"${value}": completed successfully.`)
+      } else {
+        tap.ok(results[i], `${JSON.stringify(value)}: completed successfully.`)
+      }
+    })
+
+    resolve(0)
+  })
+}
+
+async function main() {
+  const runner = createTestRunner({
+    name: 'Voice Playback E2E',
+    testHandler: handler,
+    executionTime: 60_000,
+  })
+
+  await runner.run()
+}
+
+main()

--- a/internal/e2e-realtime-api/src/voicePlayback.test.ts
+++ b/internal/e2e-realtime-api/src/voicePlayback.test.ts
@@ -23,6 +23,7 @@ const handler = () => {
           'Call answered gets the same instance'
         )
 
+        // Play an invalid audio
         const handle = await call.playAudio({
           url: 'https://cdn.fake.com/default-music/fake.mp3',
         })
@@ -33,15 +34,16 @@ const handler = () => {
           'Inbound playback returns the same instance'
         )
 
-        const waitForPlaybackFailed = new Promise(async (resolve) => {
+        const waitForPlaybackFailed = new Promise((resolve) => {
           call.on('playback.failed', (playback) => {
             tap.equal(playback.state, 'error', 'Inbound playback has failed')
             resolve(true)
           })
         })
-
+        // Wait for the inbound audio to failed
         await waitForPlaybackFailed
 
+        // Callee hangs up a call
         await call.hangup()
       } catch (error) {
         console.error('Error', error)
@@ -56,6 +58,7 @@ const handler = () => {
     })
     tap.ok(call.id, 'Call resolved')
 
+    // Play an audio
     const handle = await call.playAudio({
       url: 'https://cdn.signalwire.com/default-music/welcome.mp3',
     })
@@ -66,20 +69,22 @@ const handler = () => {
       'Outbound playback returns the same instance'
     )
 
-    const waitForPlaybackStarted = new Promise(async (resolve) => {
+    const waitForPlaybackStarted = new Promise((resolve) => {
       call.on('playback.started', (playback) => {
         tap.equal(playback.state, 'playing', 'Outbound playback has started')
         resolve(true)
       })
     })
+    // Wait for the outbound audio to start
     await waitForPlaybackStarted
 
-    const waitForPlaybackEnded = new Promise(async (resolve) => {
+    const waitForPlaybackEnded = new Promise((resolve) => {
       call.on('playback.ended', (playback) => {
         tap.equal(playback.state, 'finished', 'Outbound playback has finished')
         resolve(true)
       })
     })
+    // Wait for the outbound audio to end (callee hung up the call or audio ended)
     await waitForPlaybackEnded
 
     const waitForParams = ['ended', 'ending', ['ending', 'ended']] as const

--- a/internal/e2e-realtime-api/src/voiceRecording.test.ts
+++ b/internal/e2e-realtime-api/src/voiceRecording.test.ts
@@ -1,0 +1,164 @@
+import tap from 'tap'
+import { Voice } from '@signalwire/realtime-api'
+import { createTestRunner } from './utils'
+
+const sleep = (ms = 3000) => {
+  return new Promise((r) => {
+    setTimeout(r, ms)
+  })
+}
+
+const handler = () => {
+  return new Promise<number>(async (resolve, reject) => {
+    const client = new Voice.Client({
+      host: process.env.RELAY_HOST || 'relay.swire.io',
+      project: process.env.RELAY_PROJECT as string,
+      token: process.env.RELAY_TOKEN as string,
+      contexts: [process.env.VOICE_CONTEXT as string],
+    })
+
+    client.on('call.received', async (call) => {
+      console.log(
+        'Inbound - Got call',
+        call.id,
+        call.from,
+        call.to,
+        call.direction
+      )
+
+      try {
+        const resultAnswer = await call.answer()
+        tap.ok(resultAnswer.id, 'Inbound - Call answered')
+        tap.equal(
+          call.id,
+          resultAnswer.id,
+          'Inbound - Call answered gets the same instance'
+        )
+
+        await sleep(10000)
+
+        // Send digit # to terminate the recording
+        const sendDigitResult = await call.sendDigits('#')
+        tap.equal(
+          call.id,
+          sendDigitResult.id,
+          'Inbound - sendDigit returns the same instance'
+        )
+
+        await sleep(5000)
+
+        // Start an inbound recording
+        const recording = await call.recordAudio({ direction: 'both' })
+        tap.equal(
+          call.id,
+          recording.callId,
+          'Inbound - Recording returns the same instance'
+        )
+
+        // Play an invalid audio to fail the recording
+        await call.playAudio({
+          url: 'https://cdn.fake.com/default-music/fake.mp3',
+        })
+
+        const waitForRecordingFailed = new Promise((resolve) => {
+          call.on('recording.failed', (recording) => {
+            tap.equal(
+              recording.state,
+              'no_input',
+              'Inbound - Recording has failed'
+            )
+            resolve(true)
+          })
+        })
+        // Wait for the outbound recording to start
+        await waitForRecordingFailed
+
+        // Callee hangs up a call
+        await call.hangup()
+      } catch (error) {
+        console.error('Inbound - Error', error)
+        reject(4)
+      }
+    })
+
+    const call = await client.dialPhone({
+      to: process.env.VOICE_DIAL_TO_NUMBER as string,
+      from: process.env.VOICE_DIAL_FROM_NUMBER as string,
+      timeout: 30,
+    })
+    tap.ok(call.id, 'Outbound - Call resolved')
+
+    // Start an outbound recording
+    const recording = await call.recordAudio({ direction: 'both' })
+
+    tap.equal(
+      call.id,
+      recording.callId,
+      'Outbound - Recording returns the same instance'
+    )
+
+    const waitForRecordingStarted = new Promise((resolve) => {
+      call.on('recording.started', (recording) => {
+        tap.equal(
+          recording.state,
+          'recording',
+          'Outbound - Recording has started'
+        )
+        resolve(true)
+      })
+    })
+    // Wait for the outbound recording to start
+    await waitForRecordingStarted
+
+    // Play a valid audio
+    const playlist = new Voice.Playlist({ volume: 2 })
+      .add(
+        Voice.Playlist.Audio({
+          url: 'https://freetestdata.com/wp-content/uploads/2021/09/Free_Test_Data_100KB_MP3.mp3',
+        })
+      )
+      .add(
+        Voice.Playlist.TTS({
+          text: 'Thank you, you are now disconnected from the peer',
+        })
+      )
+    const playback = await call.play(playlist)
+
+    await playback.ended()
+
+    const waitForRecordingEnded = new Promise((resolve) => {
+      call.on('recording.ended', (recording) => {
+        tap.equal(recording.state, 'finished', 'Outbound - Recording has ended')
+        resolve(true)
+      })
+    })
+    // Wait for the outbound recording to end
+    await waitForRecordingEnded
+
+    const waitForParams = ['ended', 'ending', ['ending', 'ended']] as const
+    const results = await Promise.all(
+      waitForParams.map((params) => call.waitFor(params as any))
+    )
+    waitForParams.forEach((value, i) => {
+      if (typeof value === 'string') {
+        tap.ok(results[i], `"${value}": completed successfully.`)
+      } else {
+        tap.ok(results[i], `${JSON.stringify(value)}: completed successfully.`)
+      }
+    })
+
+    resolve(0)
+  })
+}
+
+async function main() {
+  const runner = createTestRunner({
+    name: 'Voice Recording E2E',
+    testHandler: handler,
+    executionTime: 60_000,
+  })
+
+  await runner.run()
+}
+
+main()

--- a/internal/e2e-realtime-api/src/voiceRecording.test.ts
+++ b/internal/e2e-realtime-api/src/voiceRecording.test.ts
@@ -1,12 +1,6 @@
 import tap from 'tap'
 import { Voice } from '@signalwire/realtime-api'
-import { createTestRunner } from './utils'
-
-const sleep = (ms = 3000) => {
-  return new Promise((r) => {
-    setTimeout(r, ms)
-  })
-}
+import { createTestRunner, sleep } from './utils'
 
 const handler = () => {
   return new Promise<number>(async (resolve, reject) => {

--- a/internal/e2e-realtime-api/src/voiceTap.test.ts
+++ b/internal/e2e-realtime-api/src/voiceTap.test.ts
@@ -1,0 +1,85 @@
+import tap from 'tap'
+import { Voice } from '@signalwire/realtime-api'
+import { createTestRunner } from './utils'
+
+const sleep = (ms = 3000) => {
+  return new Promise((r) => {
+    setTimeout(r, ms)
+  })
+}
+const handler = () => {
+  return new Promise<number>(async (resolve, reject) => {
+    const client = new Voice.Client({
+      host: process.env.RELAY_HOST || 'relay.swire.io',
+      project: process.env.RELAY_PROJECT as string,
+      token: process.env.RELAY_TOKEN as string,
+      contexts: [process.env.VOICE_CONTEXT as string],
+    })
+
+    client.on('call.received', async (call) => {
+      console.log(
+        'Inbound - Got call',
+        call.id,
+        call.from,
+        call.to,
+        call.direction
+      )
+
+      try {
+        const resultAnswer = await call.answer()
+        tap.ok(resultAnswer.id, 'Inbound - Call answered')
+        tap.equal(
+          call.id,
+          resultAnswer.id,
+          'Inbound - Call answered gets the same instance'
+        )
+
+        await sleep(10000)
+
+        // Callee hangs up a call
+        await call.hangup()
+      } catch (error) {
+        console.error('Inbound - Error', error)
+        reject(4)
+      }
+    })
+
+    const call = await client.dialPhone({
+      to: process.env.VOICE_DIAL_TO_NUMBER as string,
+      from: process.env.VOICE_DIAL_FROM_NUMBER as string,
+      timeout: 30,
+    })
+    tap.ok(call.id, 'Outbound - Call resolved')
+
+    try {
+      // Start an audio tap
+      const tapAudio = await call.tapAudio({
+        direction: 'both',
+        device: {
+          type: 'ws',
+          uri: 'wss://example.domain.com/endpoint',
+        },
+      })
+
+      // Tap should fail due to wrong WSS
+      reject()
+    } catch (error) {
+      tap.ok(error, 'Outbound - Tap error')
+      resolve(0)
+    }
+
+    resolve(0)
+  })
+}
+
+async function main() {
+  const runner = createTestRunner({
+    name: 'Voice Tap E2E',
+    testHandler: handler,
+    executionTime: 60_000,
+  })
+
+  await runner.run()
+}
+
+main()

--- a/internal/e2e-realtime-api/src/voiceTap.test.ts
+++ b/internal/e2e-realtime-api/src/voiceTap.test.ts
@@ -1,12 +1,7 @@
 import tap from 'tap'
 import { Voice } from '@signalwire/realtime-api'
-import { createTestRunner } from './utils'
+import { createTestRunner, sleep } from './utils'
 
-const sleep = (ms = 3000) => {
-  return new Promise((r) => {
-    setTimeout(r, ms)
-  })
-}
 const handler = () => {
   return new Promise<number>(async (resolve, reject) => {
     const client = new Voice.Client({

--- a/packages/core/src/types/voiceCall.ts
+++ b/packages/core/src/types/voiceCall.ts
@@ -72,6 +72,7 @@ export type CallReceived = 'call.received'
 export type CallPlaybackStarted = 'playback.started'
 export type CallPlaybackUpdated = 'playback.updated'
 export type CallPlaybackEnded = 'playback.ended'
+export type CallPlaybackFailed = 'playback.failed'
 export type CallRecordingStarted = 'recording.started'
 export type CallRecordingUpdated = 'recording.updated'
 export type CallRecordingEnded = 'recording.ended'
@@ -106,6 +107,7 @@ export type VoiceCallEventNames =
   | CallPlaybackStarted
   | CallPlaybackUpdated
   | CallPlaybackEnded
+  | CallPlaybackFailed
   | CallRecordingStarted
   | CallRecordingUpdated
   | CallRecordingEnded
@@ -1148,6 +1150,14 @@ export interface CallPlaybackEndedEvent extends SwEvent {
   params: CallingCallPlayEventParams & { tag: string }
 }
 /**
+ * 'calling.playback.failed'
+ */
+export interface CallPlaybackFailedEvent extends SwEvent {
+  event_type: ToInternalVoiceEvent<CallPlaybackFailed>
+  params: CallingCallPlayEventParams & { tag: string }
+}
+
+/**
  * 'calling.call.received'
  */
 export interface CallReceivedEvent extends SwEvent {
@@ -1367,6 +1377,7 @@ export type VoiceCallEvent =
   | CallPlaybackStartedEvent
   | CallPlaybackUpdatedEvent
   | CallPlaybackEndedEvent
+  | CallPlaybackFailedEvent
   | CallRecordingStartedEvent
   | CallRecordingUpdatedEvent
   | CallRecordingEndedEvent
@@ -1408,6 +1419,7 @@ export type VoiceCallEventParams =
   | CallPlaybackStartedEvent['params']
   | CallPlaybackUpdatedEvent['params']
   | CallPlaybackEndedEvent['params']
+  | CallPlaybackFailedEvent['params']
   | CallRecordingStartedEvent['params']
   | CallRecordingUpdatedEvent['params']
   | CallRecordingEndedEvent['params']

--- a/packages/core/src/types/voiceCall.ts
+++ b/packages/core/src/types/voiceCall.ts
@@ -891,6 +891,12 @@ export interface CallingCallReceiveEvent extends SwEvent {
  * 'calling.call.play'
  */
 export type CallingCallPlayState = 'playing' | 'paused' | 'error' | 'finished'
+
+export type CallingCallPlayEndState = Exclude<
+  CallingCallPlayState,
+  'playing' | 'paused'
+>
+
 export interface CallingCallPlayEventParams {
   node_id: string
   call_id: string
@@ -907,6 +913,12 @@ export interface CallingCallPlayEvent extends SwEvent {
  * 'calling.call.record'
  */
 export type CallingCallRecordState = 'recording' | 'no_input' | 'finished'
+
+export type CallingCallRecordEndState = Exclude<
+  CallingCallRecordState,
+  'recording'
+>
+
 export interface CallingCallRecordEventParams {
   node_id: string
   call_id: string
@@ -960,6 +972,11 @@ export type CallingCallCollectResult =
   | CallingCallCollectResultDigit
   | CallingCallCollectResultSpeech
 
+export type CallingCallCollectEndState = Exclude<
+  CallingCallCollectResult['type'],
+  'start_of_input'
+>
+
 export interface CallingCallCollectEventParams {
   node_id: string
   call_id: string
@@ -977,6 +994,8 @@ export interface CallingCallCollectEvent extends SwEvent {
  * 'calling.call.tap'
  */
 export type CallingCallTapState = 'tapping' | 'finished'
+
+export type CallingCallTapEndState = Exclude<CallingCallTapState, 'tapping'>
 
 interface CallingCallTapDeviceRTP {
   type: 'rtp'
@@ -1066,6 +1085,7 @@ export interface CallingCallSendDigitsEvent extends SwEvent {
  * 'calling.call.detect'
  */
 type CallingCallDetectState = 'finished' | 'error'
+export type CallingCallDetectEndState = CallingCallDetectState
 interface CallingCallDetectFax {
   type: 'fax'
   params: {

--- a/packages/realtime-api/src/types/voice.ts
+++ b/packages/realtime-api/src/types/voice.ts
@@ -4,6 +4,7 @@ import type {
   CallPlaybackStarted,
   CallPlaybackUpdated,
   CallPlaybackEnded,
+  CallPlaybackFailed,
   CallRecordingStarted,
   CallRecordingUpdated,
   CallRecordingEnded,
@@ -33,7 +34,10 @@ export type RealTimeCallApiEventsHandlerMapping = Record<
 > &
   Record<CallState, (call: Call) => void> &
   Record<
-    CallPlaybackStarted | CallPlaybackUpdated | CallPlaybackEnded,
+    | CallPlaybackStarted
+    | CallPlaybackUpdated
+    | CallPlaybackEnded
+    | CallPlaybackFailed,
     (playback: CallPlayback) => void
   > &
   Record<

--- a/packages/realtime-api/src/voice/Call.ts
+++ b/packages/realtime-api/src/voice/Call.ts
@@ -74,6 +74,7 @@ type EmitterTransformsEvents =
   | 'calling.playback.started'
   | 'calling.playback.updated'
   | 'calling.playback.ended'
+  | 'calling.playback.failed'
   | 'calling.recording.started'
   | 'calling.recording.updated'
   | 'calling.recording.ended'
@@ -247,6 +248,7 @@ export class CallConsumer extends AutoApplyTransformsConsumer<RealTimeCallApiEve
           'calling.playback.started',
           'calling.playback.updated',
           'calling.playback.ended',
+          'calling.playback.failed',
         ],
         {
           type: 'voiceCallPlayback',

--- a/packages/realtime-api/src/voice/CallCollect.ts
+++ b/packages/realtime-api/src/voice/CallCollect.ts
@@ -3,6 +3,7 @@ import {
   BaseComponentOptions,
   VoiceCallCollectContract,
   CallingCallCollectResult,
+  CallingCallCollectEndState,
   BaseComponent,
   CallCollectEndedEvent,
 } from '@signalwire/core'
@@ -20,7 +21,7 @@ export type CallCollectEventsHandlerMapping = {}
 export interface CallCollectOptions
   extends BaseComponentOptions<CallCollectEventsHandlerMapping> {}
 
-const ENDED_STATES: string[] = [
+const ENDED_STATES: CallingCallCollectEndState[] = [
   'error',
   'no_input',
   'no_match',
@@ -119,7 +120,9 @@ export class CallCollectAPI
 
   ended() {
     // Resolve the promise if the collect has already ended
-    if (ENDED_STATES.includes(this.result?.type as string)) {
+    if (
+      ENDED_STATES.includes(this.result?.type as CallingCallCollectEndState)
+    ) {
       return Promise.resolve(this)
     }
 

--- a/packages/realtime-api/src/voice/CallCollect.ts
+++ b/packages/realtime-api/src/voice/CallCollect.ts
@@ -20,6 +20,14 @@ export type CallCollectEventsHandlerMapping = {}
 export interface CallCollectOptions
   extends BaseComponentOptions<CallCollectEventsHandlerMapping> {}
 
+const ENDED_STATES: string[] = [
+  'error',
+  'no_input',
+  'no_match',
+  'digit',
+  'speech',
+]
+
 export class CallCollectAPI
   extends BaseComponent<CallCollectEventsHandlerMapping>
   implements VoiceCallCollectContract
@@ -110,6 +118,11 @@ export class CallCollectAPI
   }
 
   ended() {
+    // Resolve the promise if the collect has already ended
+    if (ENDED_STATES.includes(this.result?.type as string)) {
+      return Promise.resolve(this)
+    }
+
     return new Promise<this>((resolve) => {
       this._attachListeners(this.controlId)
       const handler = (_callCollect: CallCollectEndedEvent['params']) => {

--- a/packages/realtime-api/src/voice/CallDetect.ts
+++ b/packages/realtime-api/src/voice/CallDetect.ts
@@ -4,6 +4,7 @@ import {
   BaseComponentOptions,
   VoiceCallDetectContract,
   Detector,
+  CallingCallDetectEndState,
 } from '@signalwire/core'
 
 /**
@@ -19,7 +20,7 @@ export type CallDetectEventsHandlerMapping = {}
 export interface CallDetectOptions
   extends BaseComponentOptions<CallDetectEventsHandlerMapping> {}
 
-const ENDED_STATES: string[] = ['finished', 'error']
+const ENDED_STATES: CallingCallDetectEndState[] = ['finished', 'error']
 
 export class CallDetectAPI
   extends BaseComponent<CallDetectEventsHandlerMapping>
@@ -62,7 +63,11 @@ export class CallDetectAPI
 
   ended() {
     // Resolve the promise if the detect has already ended
-    if (ENDED_STATES.includes(this.detect?.params?.event as string)) {
+    if (
+      ENDED_STATES.includes(
+        this.detect?.params?.event as CallingCallDetectEndState
+      )
+    ) {
       return Promise.resolve(this)
     }
 

--- a/packages/realtime-api/src/voice/CallDetect.ts
+++ b/packages/realtime-api/src/voice/CallDetect.ts
@@ -19,6 +19,8 @@ export type CallDetectEventsHandlerMapping = {}
 export interface CallDetectOptions
   extends BaseComponentOptions<CallDetectEventsHandlerMapping> {}
 
+const ENDED_STATES: string[] = ['finished', 'error']
+
 export class CallDetectAPI
   extends BaseComponent<CallDetectEventsHandlerMapping>
   implements VoiceCallDetectContract
@@ -59,6 +61,11 @@ export class CallDetectAPI
   }
 
   ended() {
+    // Resolve the promise if the detect has already ended
+    if (ENDED_STATES.includes(this.detect?.params?.event as string)) {
+      return Promise.resolve(this)
+    }
+
     return new Promise<this>((resolve) => {
       this._attachListeners(this.controlId)
 

--- a/packages/realtime-api/src/voice/CallPlayback.ts
+++ b/packages/realtime-api/src/voice/CallPlayback.ts
@@ -4,6 +4,7 @@ import {
   BaseComponentOptions,
   VoiceCallPlaybackContract,
   CallingCallPlayState,
+  CallingCallPlayEndState,
 } from '@signalwire/core'
 
 /**
@@ -23,7 +24,7 @@ export type CallPlaybackEventsHandlerMapping = {}
 export interface CallPlaybackOptions
   extends BaseComponentOptions<CallPlaybackEventsHandlerMapping> {}
 
-const ENDED_STATES: string[] = ['finished', 'error']
+const ENDED_STATES: CallingCallPlayEndState[] = ['finished', 'error']
 
 export class CallPlaybackAPI
   extends BaseComponent<CallPlaybackEventsHandlerMapping>
@@ -107,7 +108,7 @@ export class CallPlaybackAPI
 
   ended() {
     // Resolve the promise if the playback has already ended
-    if (ENDED_STATES.includes(this.state)) {
+    if (ENDED_STATES.includes(this.state as CallingCallPlayEndState)) {
       return Promise.resolve(this)
     }
 

--- a/packages/realtime-api/src/voice/CallPlayback.ts
+++ b/packages/realtime-api/src/voice/CallPlayback.ts
@@ -106,6 +106,7 @@ export class CallPlaybackAPI
   }
 
   ended() {
+    // Resolve the promise if the playback has already ended
     if (ENDED_STATES.includes(this.state)) {
       return Promise.resolve(this)
     }

--- a/packages/realtime-api/src/voice/CallPlayback.ts
+++ b/packages/realtime-api/src/voice/CallPlayback.ts
@@ -104,7 +104,8 @@ export class CallPlaybackAPI
   }
 
   ended() {
-    if (['finished', 'error'].includes(this.state)) {
+    const ENDED_STATES = ['finished', 'error']
+    if (ENDED_STATES.includes(this.state)) {
       return Promise.resolve(this)
     }
 

--- a/packages/realtime-api/src/voice/CallPlayback.ts
+++ b/packages/realtime-api/src/voice/CallPlayback.ts
@@ -23,6 +23,8 @@ export type CallPlaybackEventsHandlerMapping = {}
 export interface CallPlaybackOptions
   extends BaseComponentOptions<CallPlaybackEventsHandlerMapping> {}
 
+const ENDED_STATES: string[] = ['finished', 'error']
+
 export class CallPlaybackAPI
   extends BaseComponent<CallPlaybackEventsHandlerMapping>
   implements VoiceCallPlaybackContract
@@ -104,7 +106,6 @@ export class CallPlaybackAPI
   }
 
   ended() {
-    const ENDED_STATES = ['finished', 'error']
     if (ENDED_STATES.includes(this.state)) {
       return Promise.resolve(this)
     }

--- a/packages/realtime-api/src/voice/CallPlayback.ts
+++ b/packages/realtime-api/src/voice/CallPlayback.ts
@@ -104,6 +104,10 @@ export class CallPlaybackAPI
   }
 
   ended() {
+    if (['finished', 'error'].includes(this.state)) {
+      return Promise.resolve(this)
+    }
+
     return new Promise<this>((resolve) => {
       this._attachListeners(this.controlId)
 

--- a/packages/realtime-api/src/voice/CallPrompt.ts
+++ b/packages/realtime-api/src/voice/CallPrompt.ts
@@ -124,6 +124,7 @@ export class CallPromptAPI
   }
 
   ended() {
+    // Resolve the promise if the prompt has already ended
     if (ENDED_STATES.includes(this.result?.type as string)) {
       return Promise.resolve(this)
     }

--- a/packages/realtime-api/src/voice/CallPrompt.ts
+++ b/packages/realtime-api/src/voice/CallPrompt.ts
@@ -20,6 +20,14 @@ export type CallPromptEventsHandlerMapping = {}
 export interface CallPromptOptions
   extends BaseComponentOptions<CallPromptEventsHandlerMapping> {}
 
+const ENDED_STATES: string[] = [
+  'no_input',
+  'error',
+  'no_match',
+  'digit',
+  'speech',
+]
+
 export class CallPromptAPI
   extends BaseComponent<CallPromptEventsHandlerMapping>
   implements VoiceCallPromptContract
@@ -116,6 +124,10 @@ export class CallPromptAPI
   }
 
   ended() {
+    if (ENDED_STATES.includes(this.result?.type as string)) {
+      return Promise.resolve(this)
+    }
+
     return new Promise<this>((resolve) => {
       this._attachListeners(this.controlId)
       const handler = (_callPrompt: CallPromptEndedEvent['params']) => {

--- a/packages/realtime-api/src/voice/CallPrompt.ts
+++ b/packages/realtime-api/src/voice/CallPrompt.ts
@@ -3,6 +3,7 @@ import {
   BaseComponentOptions,
   VoiceCallPromptContract,
   CallingCallCollectResult,
+  CallingCallCollectEndState,
   BaseComponent,
   CallPromptEndedEvent,
 } from '@signalwire/core'
@@ -20,7 +21,7 @@ export type CallPromptEventsHandlerMapping = {}
 export interface CallPromptOptions
   extends BaseComponentOptions<CallPromptEventsHandlerMapping> {}
 
-const ENDED_STATES: string[] = [
+const ENDED_STATES: CallingCallCollectEndState[] = [
   'no_input',
   'error',
   'no_match',
@@ -125,7 +126,9 @@ export class CallPromptAPI
 
   ended() {
     // Resolve the promise if the prompt has already ended
-    if (ENDED_STATES.includes(this.result?.type as string)) {
+    if (
+      ENDED_STATES.includes(this.result?.type as CallingCallCollectEndState)
+    ) {
       return Promise.resolve(this)
     }
 

--- a/packages/realtime-api/src/voice/CallRecording.ts
+++ b/packages/realtime-api/src/voice/CallRecording.ts
@@ -4,6 +4,7 @@ import {
   BaseComponentOptions,
   VoiceCallRecordingContract,
   CallingCallRecordState,
+  CallingCallRecordEndState,
 } from '@signalwire/core'
 
 /**
@@ -19,7 +20,7 @@ export type CallRecordingEventsHandlerMapping = {}
 export interface CallRecordingOptions
   extends BaseComponentOptions<CallRecordingEventsHandlerMapping> {}
 
-const ENDED_STATES: string[] = ['finished', 'no_input']
+const ENDED_STATES: CallingCallRecordEndState[] = ['finished', 'no_input']
 
 export class CallRecordingAPI
   extends BaseComponent<CallRecordingEventsHandlerMapping>
@@ -56,7 +57,7 @@ export class CallRecordingAPI
 
   ended() {
     // Resolve the promise if the recording has already ended
-    if (ENDED_STATES.includes(this.state)) {
+    if (ENDED_STATES.includes(this.state as CallingCallRecordEndState)) {
       return Promise.resolve(this)
     }
 

--- a/packages/realtime-api/src/voice/CallRecording.ts
+++ b/packages/realtime-api/src/voice/CallRecording.ts
@@ -19,6 +19,8 @@ export type CallRecordingEventsHandlerMapping = {}
 export interface CallRecordingOptions
   extends BaseComponentOptions<CallRecordingEventsHandlerMapping> {}
 
+const ENDED_STATES: string[] = ['finished', 'no_input']
+
 export class CallRecordingAPI
   extends BaseComponent<CallRecordingEventsHandlerMapping>
   implements VoiceCallRecordingContract
@@ -53,6 +55,11 @@ export class CallRecordingAPI
   }
 
   ended() {
+    // Resolve the promise if the recording has already ended
+    if (ENDED_STATES.includes(this.state)) {
+      return Promise.resolve(this)
+    }
+
     return new Promise<this>((resolve) => {
       this._attachListeners(this.controlId)
       const handler = () => {

--- a/packages/realtime-api/src/voice/CallTap.ts
+++ b/packages/realtime-api/src/voice/CallTap.ts
@@ -4,6 +4,7 @@ import {
   BaseComponentOptions,
   VoiceCallTapContract,
   CallingCallTapState,
+  CallingCallTapEndState,
 } from '@signalwire/core'
 
 /**
@@ -18,6 +19,8 @@ export type CallTapEventsHandlerMapping = {}
 
 export interface CallTapOptions
   extends BaseComponentOptions<CallTapEventsHandlerMapping> {}
+
+const ENDED_STATES: CallingCallTapEndState[] = ['finished']
 
 export class CallTapAPI
   extends BaseComponent<CallTapEventsHandlerMapping>
@@ -48,6 +51,11 @@ export class CallTapAPI
   }
 
   ended() {
+    // Resolve the promise if the tap has already ended
+    if (ENDED_STATES.includes(this.state as CallingCallTapEndState)) {
+      return Promise.resolve(this)
+    }
+
     return new Promise<this>((resolve) => {
       this._attachListeners(this.controlId)
 

--- a/packages/realtime-api/src/voice/workers/voiceCallPlayWorker.ts
+++ b/packages/realtime-api/src/voice/workers/voiceCallPlayWorker.ts
@@ -44,7 +44,7 @@ export const voiceCallPlayWorker: SDKWorker<Call> = function* (
      * Update the original CallPlayback object using the
      * transform pipeline
      */
-     yield sagaEffects.put(pubSubChannel, {
+    yield sagaEffects.put(pubSubChannel, {
       // @ts-ignore
       type: callingPlaybackTriggerEvent,
       // @ts-ignore
@@ -73,9 +73,27 @@ export const voiceCallPlayWorker: SDKWorker<Call> = function* (
         })
         break
       }
-      case 'error':
-        // TODO: dispatch calling.playback.error ?
+      case 'error': {
+        yield sagaEffects.put(pubSubChannel, {
+          type: 'calling.playback.failed',
+          payload: payloadWithTag,
+        })
+
+        /**
+         * Dispatch an event to resolve `ended()` in CallPlayback
+         * when ended
+         */
+        yield sagaEffects.put(pubSubChannel, {
+          type: 'calling.playback.ended',
+          payload: {
+            tag: controlId,
+            ...action.payload,
+          },
+        })
+
+        done()
         break
+      }
       case 'finished': {
         yield sagaEffects.put(pubSubChannel, {
           type: 'calling.playback.ended',


### PR DESCRIPTION
Based on this [issue](https://github.com/signalwire/cloud-product/issues/5710).

- Handle the `.ended()` promise for **Playback** function
- Handle the `.ended()` promise for **Prompt** function
- Handle the `.ended()` promise for **Recording** function
- Handle the `.ended()` promise for **Detect** function
- Handle the `.ended()` promise for **Collect** function
- Handle the `.ended()` promise for **Tap** function

- e2e test cases for **Playback** function
- e2e test cases for **Prompt** function
- e2e test cases for **Detect** function
- e2e test cases for **Tap** function
- e2e test cases for **Recording** function