### PR TITLE
Decouple `executeAction` requests from Redux store

### DIFF
--- a/.changeset/tidy-wasps-rule.md
+++ b/.changeset/tidy-wasps-rule.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/core': patch
+---
+
+Introduce a new worker to decouple `executeAction` requests from Redux store

--- a/packages/core/src/BaseComponent.ts
+++ b/packages/core/src/BaseComponent.ts
@@ -709,8 +709,8 @@ export class BaseComponent<
 
       this.runWorker('executeActionWorker', {
         worker: executeActionWorker,
-        onDone: resolve,
-        onFail: reject,
+        onDone: (data) => resolve(transformResolve(data)),
+        onFail: (error) => resolve(transformReject(error)),
         payload: {
           requestId,
           componentId: this.__uuid,

--- a/packages/core/src/BaseComponent.ts
+++ b/packages/core/src/BaseComponent.ts
@@ -8,7 +8,7 @@ import {
   getLogger,
   isSessionEvent,
 } from './utils'
-import { executeAction, Action } from './redux'
+import { Action } from './redux'
 import {
   ExecuteParams,
   ExecuteTransform,
@@ -39,6 +39,7 @@ import {
 import { compoundEventAttachAction } from './redux/actions'
 import { AuthError } from './CustomErrors'
 import { proxyFactory } from './utils/proxyUtils'
+import { executeActionWorker } from './workers'
 
 type EventRegisterHandlers<EventTypes extends EventEmitter.ValidEventTypes> =
   | {
@@ -706,14 +707,17 @@ export class BaseComponent<
         transformReject,
       })
 
-      this.store.dispatch(
-        executeAction({
+      this.runWorker('executeActionWorker', {
+        worker: executeActionWorker,
+        onDone: resolve,
+        onFail: reject,
+        payload: {
           requestId,
           componentId: this.__uuid,
           method,
           params: transformParams(params as ParamsType),
-        })
-      )
+        },
+      })
     })
   }
 

--- a/packages/core/src/workers/executeActionWorker.ts
+++ b/packages/core/src/workers/executeActionWorker.ts
@@ -1,0 +1,39 @@
+import { call } from '@redux-saga/core/effects'
+import { SagaIterator } from '@redux-saga/core'
+import { getLogger } from '../utils/logger'
+import { RPCExecute } from '../RPCMessages/RPCExecute'
+import type { SDKWorker } from '../utils/interfaces'
+import type { ExecuteActionParams } from '../redux/interfaces'
+
+/**
+ * Send a JSONRPC over the wire using session.execute and resolve/reject the promise
+ */
+export const executeActionWorker: SDKWorker<ExecuteActionParams> = function* (
+  options
+): SagaIterator {
+  const { payload, onDone, onFail, getSession } = options
+
+  const { requestId, method, params } = payload
+
+  const session = getSession()
+
+  if (!session) {
+    const error = new Error('Session does not exist!')
+    getLogger().error(error)
+    onFail?.(error)
+    return
+  }
+
+  try {
+    const message = RPCExecute({
+      id: requestId,
+      method,
+      params,
+    })
+    const response = yield call(session.execute, message)
+    onDone?.(response)
+  } catch (error) {
+    getLogger().warn('Execute error: ', error)
+    onFail?.(error)
+  }
+}

--- a/packages/core/src/workers/index.ts
+++ b/packages/core/src/workers/index.ts
@@ -1,0 +1,1 @@
+export * from './executeActionWorker'


### PR DESCRIPTION
The initialization of a new saga worker to handle execute action requests.