### PR TITLE
Split E2E Tests in different projects

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -99,7 +99,8 @@ jobs:
     strategy:
       matrix:
         node-version: [18.x]
-        project: [default, streaming, slow]
+        # project: [default, streaming, slow]
+        project: [default, slow]
 
     steps:
       - uses: actions/checkout@v3
@@ -123,7 +124,8 @@ jobs:
     strategy:
       matrix:
         node-version: [18.x]
-        project: [default, streaming, slow]
+        # project: [default, streaming, slow]
+        project: [default, slow]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -96,6 +96,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: stack-tests
 
+    strategy:
+      matrix:
+        node-version: [18.x]
+        project: [default, streaming, slow]
+
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -106,7 +111,7 @@ jobs:
       - name: Install Playwright
         run: npx playwright@^1.28.1 install --with-deps
       - run: npm run build
-      - run: npm run -w=@sw-internal/e2e-js dev
+      - run: npm run -w=@sw-internal/e2e-js dev -- --project ${{ matrix.project }}
         env:
           SW_TEST_CONFIG: ${{ secrets.STAGING_E2E_JS_SW_TEST_CONFIG }}
 
@@ -115,6 +120,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: stack-tests
 
+    strategy:
+      matrix:
+        node-version: [18.x]
+        project: [default, streaming, slow]
+
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -125,6 +135,6 @@ jobs:
       - name: Install Playwright
         run: npx playwright@^1.28.1 install --with-deps
       - run: npm run build
-      - run: npm run -w=@sw-internal/e2e-js dev
+      - run: npm run -w=@sw-internal/e2e-js dev -- --project ${{ matrix.project }}
         env:
           SW_TEST_CONFIG: ${{ secrets.PRODUCTION_E2E_JS_SW_TEST_CONFIG }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,6 +31,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: unit-test
 
+    strategy:
+      matrix:
+        node-version: [18.x]
+
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -50,6 +54,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: stack-tests
 
+    strategy:
+      matrix:
+        node-version: [18.x]
+
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -66,6 +74,10 @@ jobs:
     name: E2E tests Realtime API - Production
     runs-on: ubuntu-latest
     needs: stack-tests
+
+    strategy:
+      matrix:
+        node-version: [18.x]
 
     steps:
       - uses: actions/checkout@v3

--- a/internal/e2e-js/package.json
+++ b/internal/e2e-js/package.json
@@ -5,7 +5,6 @@
   "main": "index.js",
   "scripts": {
     "dev": "sw-test --mode=playwright",
-    "dev:new": "playwright test",
     "test": ""
   },
   "dependencies": {

--- a/internal/e2e-js/playwright.config.ts
+++ b/internal/e2e-js/playwright.config.ts
@@ -2,15 +2,32 @@ require('dotenv').config()
 
 import { PlaywrightTestConfig, devices } from '@playwright/test'
 
-const testMatch = process.argv.slice(3)
+const streamingTests = [
+  'roomSessionStreamingAPI.spec.ts',
+  'roomSessionStreaming.spec.ts',
+]
+const slowTests = [
+  'roomSessionAudienceCount.spec.ts',
+  'roomSessionBadNetwork.spec.ts',
+]
+
+const useDesktopChrome = {
+  ...devices['Desktop Chrome'],
+  launchOptions: {
+    // devtools: true,
+    // headless: false,
+    args: [
+      '--use-fake-ui-for-media-stream',
+      '--use-fake-device-for-media-stream',
+    ],
+  },
+}
 
 const config: PlaywrightTestConfig = {
   testDir: 'tests',
   globalSetup: require.resolve('./global-setup'),
-  testMatch: testMatch.length ? testMatch : undefined,
-  testIgnore: [
-    'roomSessionStreamingAPI.spec.ts',
-  ],
+  testMatch: undefined,
+  testIgnore: undefined,
   timeout: 120_000,
   expect: {
     // Default is 5000
@@ -21,18 +38,19 @@ const config: PlaywrightTestConfig = {
   workers: 1,
   projects: [
     {
-      name: 'chromium',
-      use: {
-        ...devices['Desktop Chrome'],
-        launchOptions: {
-          // devtools: true,
-          // headless: false,
-          args: [
-            '--use-fake-ui-for-media-stream',
-            '--use-fake-device-for-media-stream',
-          ],
-        },
-      },
+      name: 'default',
+      use: useDesktopChrome,
+      testIgnore: [...slowTests, ...streamingTests],
+    },
+    {
+      name: 'streaming',
+      use: useDesktopChrome,
+      testMatch: streamingTests,
+    },
+    {
+      name: 'slow',
+      use: useDesktopChrome,
+      testMatch: slowTests,
     },
   ],
 }


### PR DESCRIPTION
Using different [Playwright Projects](https://playwright.dev/docs/test-advanced#projects) to target specific tests.
For now i used: `default`, `streaming` and `slow` so we can easily ignore some run and/or tests.