### PR TITLE
Introduce a new saga channel for BaseSession

### DIFF
--- a/.changeset/funny-pumpkins-hammer.md
+++ b/.changeset/funny-pumpkins-hammer.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/core': patch
+---
+
+Session channel introduced for BaseSession

--- a/packages/core/src/BaseComponent.ts
+++ b/packages/core/src/BaseComponent.ts
@@ -710,7 +710,7 @@ export class BaseComponent<
       this.runWorker('executeActionWorker', {
         worker: executeActionWorker,
         onDone: (data) => resolve(transformResolve(data)),
-        onFail: (error) => resolve(transformReject(error)),
+        onFail: (error) => reject(transformReject(error)),
         initialState: {
           requestId,
           componentId: this.__uuid,

--- a/packages/core/src/BaseSession.ts
+++ b/packages/core/src/BaseSession.ts
@@ -7,7 +7,6 @@ import {
   safeParseJson,
   isJSONRPCResponse,
 } from './utils'
-import { PayloadAction } from './redux'
 import { DEFAULT_HOST, WebSocketState } from './utils/constants'
 import {
   RPCConnect,
@@ -37,7 +36,7 @@ import {
 } from './redux/actions'
 import { sessionActions } from './redux/features/session/sessionSlice'
 import { SwAuthorizationState } from '.'
-import { SessionChannel } from './redux/interfaces'
+import { SessionChannel, SessionChannelAction } from './redux/interfaces'
 
 export const SW_SYMBOL = Symbol('BaseSession')
 
@@ -81,13 +80,13 @@ export class BaseSession {
   private wsErrorHandler: (event: Event) => void
 
   constructor(public options: SessionOptions) {
-    const { host, logLevel = 'info', channel } = options
+    const { host, logLevel = 'info', sessionChannel } = options
     if (host) {
       this._host = checkWebSocketHost(host)
     }
 
-    if (channel) {
-      this._sessionChannel = channel
+    if (sessionChannel) {
+      this._sessionChannel = sessionChannel
     }
 
     if (logLevel) {
@@ -173,16 +172,8 @@ export class BaseSession {
     return !Boolean(this.idle || !this.connected)
   }
 
-  get sessionChannel() {
-    return this._sessionChannel
-  }
-
   set token(token: string) {
     this.options.token = token
-  }
-
-  set sessionChannel(channel) {
-    this._sessionChannel = channel
   }
 
   /**
@@ -457,15 +448,11 @@ export class BaseSession {
     }
   }
 
-  public dispatch(_payload: PayloadAction<any>) {
-    if (!this.sessionChannel) {
+  public dispatch(_payload: SessionChannelAction) {
+    if (!this._sessionChannel) {
       throw new Error('Session channel does not exist')
     }
-    this.sessionChannel.put(_payload)
-  }
-
-  public setChannel(channel: SessionChannel) {
-    this._sessionChannel = channel
+    this._sessionChannel.put(_payload)
   }
 
   /**

--- a/packages/core/src/redux/features/session/sessionSaga.ts
+++ b/packages/core/src/redux/features/session/sessionSaga.ts
@@ -1,4 +1,4 @@
-import { SagaIterator, eventChannel, EventChannel } from '@redux-saga/core'
+import { SagaIterator, eventChannel } from '@redux-saga/core'
 import { call, put, take, fork, cancelled } from '@redux-saga/core/effects'
 import type { PayloadAction } from '../../toolkit'
 import { BaseSession } from '../../../BaseSession'
@@ -13,6 +13,7 @@ import type {
 import type {
   ExecuteActionParams,
   PubSubChannel,
+  SessionChannel,
   SwEventChannel,
 } from '../../interfaces'
 import { createCatchableSaga } from '../../utils/sagaHelpers'
@@ -23,7 +24,7 @@ import { getLogger, toInternalAction } from '../../../utils'
 
 type SessionSagaParams = {
   session: BaseSession
-  sessionChannel: EventChannel<any>
+  sessionChannel: SessionChannel
   pubSubChannel: PubSubChannel
   swEventChannel: SwEventChannel
 }

--- a/packages/core/src/redux/index.ts
+++ b/packages/core/src/redux/index.ts
@@ -1,5 +1,6 @@
 import { Store } from 'redux'
 import createSagaMiddleware, {
+  channel,
   multicastChannel,
   Saga,
   Task,
@@ -7,7 +8,12 @@ import createSagaMiddleware, {
 import { configureStore as rtConfigureStore } from './toolkit'
 import { rootReducer } from './rootReducer'
 import rootSaga from './rootSaga'
-import { PubSubChannel, SDKState, SwEventChannel } from './interfaces'
+import {
+  PubSubChannel,
+  SDKState,
+  SessionChannel,
+  SwEventChannel,
+} from './interfaces'
 import { connect } from './connect'
 import {
   InternalUserOptions,
@@ -40,6 +46,7 @@ const configureStore = (options: ConfigureStoreOptions) => {
   const sagaMiddleware = createSagaMiddleware()
   const pubSubChannel: PubSubChannel = multicastChannel()
   const swEventChannel: SwEventChannel = multicastChannel()
+  const sessionChannel: SessionChannel = channel()
   /**
    * List of channels that are gonna be shared across all
    * sagas.
@@ -47,6 +54,7 @@ const configureStore = (options: ConfigureStoreOptions) => {
   const channels: InternalChannels = {
     pubSubChannel,
     swEventChannel,
+    sessionChannel,
   }
   const store = rtConfigureStore({
     devTools: userOptions?.devTools ?? true,
@@ -63,7 +71,10 @@ const configureStore = (options: ConfigureStoreOptions) => {
 
   let session: BaseSession
   const initSession = () => {
-    session = new SessionConstructor(userOptions)
+    session = new SessionConstructor({
+      ...userOptions,
+      channel: sessionChannel,
+    })
     return session
   }
 

--- a/packages/core/src/redux/index.ts
+++ b/packages/core/src/redux/index.ts
@@ -73,7 +73,7 @@ const configureStore = (options: ConfigureStoreOptions) => {
   const initSession = () => {
     session = new SessionConstructor({
       ...userOptions,
-      channel: sessionChannel,
+      sessionChannel,
     })
     return session
   }

--- a/packages/core/src/redux/interfaces.ts
+++ b/packages/core/src/redux/interfaces.ts
@@ -3,6 +3,7 @@ import { END, MulticastChannel } from '@redux-saga/core'
 import type { PayloadAction } from './toolkit'
 import {
   JSONRPCResponse,
+  JSONRPCRequest,
   SessionAuthError,
   SessionAuthStatus,
   SessionEvents,
@@ -118,8 +119,16 @@ export type PubSubAction =
   | MessagingAction
   | VoiceCallAction
 
+export type SessionChannelAction =
+  | PayloadAction<void, SessionEvents>
+  | PayloadAction<JSONRPCRequest>
+  | PayloadAction<void, 'auth/success'>
+  | PayloadAction<void, 'auth/expiring'>
+  | PayloadAction<{ error: SessionAuthError }>
+  | PayloadAction<SessionAuthStatus>
+
 export type PubSubChannel = MulticastChannel<PubSubAction>
 export type SwEventChannel = MulticastChannel<MapToPubSubShape<SwEventParams>>
-export type SessionChannel = Channel<PayloadAction>
+export type SessionChannel = Channel<SessionChannelAction>
 
 export type SDKActions = MapToPubSubShape<SwEventParams> | END

--- a/packages/core/src/redux/interfaces.ts
+++ b/packages/core/src/redux/interfaces.ts
@@ -1,4 +1,5 @@
-import type { SagaIterator } from '@redux-saga/types'
+import type { Channel, SagaIterator } from '@redux-saga/types'
+import { END, MulticastChannel } from '@redux-saga/core'
 import type { PayloadAction } from './toolkit'
 import {
   JSONRPCResponse,
@@ -20,7 +21,6 @@ import type {
   PubSubEventAction,
 } from '../types'
 import { SDKRunSaga } from '.'
-import { END, MulticastChannel } from '@redux-saga/core'
 
 interface SWComponent {
   id: string
@@ -120,5 +120,6 @@ export type PubSubAction =
 
 export type PubSubChannel = MulticastChannel<PubSubAction>
 export type SwEventChannel = MulticastChannel<MapToPubSubShape<SwEventParams>>
+export type SessionChannel = Channel<PayloadAction>
 
 export type SDKActions = MapToPubSubShape<SwEventParams> | END

--- a/packages/core/src/redux/rootSaga.test.ts
+++ b/packages/core/src/redux/rootSaga.test.ts
@@ -141,6 +141,7 @@ describe('sessionStatusWatcher', () => {
 describe('initSessionSaga', () => {
   const session = {
     connect: jest.fn(),
+    disconnect: jest.fn(),
   } as any
   const initSession = jest.fn().mockImplementation(() => session)
   const pubSubChannel = createPubSubChannel()
@@ -196,8 +197,8 @@ describe('initSessionSaga', () => {
     expect(sessionStatusTask.cancel).toHaveBeenCalledTimes(1)
     expect(pubSubChannel.close).not.toHaveBeenCalled()
     expect(swEventChannel.close).not.toHaveBeenCalled()
-    expect(sessionChannel.close).not.toHaveBeenCalled()
     expect(session.connect).toHaveBeenCalledTimes(1)
+    expect(session.disconnect).toHaveBeenCalledTimes(1)
   })
 })
 

--- a/packages/core/src/redux/rootSaga.ts
+++ b/packages/core/src/redux/rootSaga.ts
@@ -130,6 +130,8 @@ export function* initSessionSaga({
    * // swEventChannel.close()
    * // sessionChannel.close()
    */
+
+  session.disconnect()
 }
 
 export function* reauthenticateWorker({

--- a/packages/core/src/redux/rootSaga.ts
+++ b/packages/core/src/redux/rootSaga.ts
@@ -1,5 +1,4 @@
 import type { Task, SagaIterator } from '@redux-saga/types'
-import { EventChannel } from '@redux-saga/core'
 import { fork, call, take, put, all, cancelled } from '@redux-saga/core/effects'
 import { InternalUserOptions, InternalChannels } from '../utils/interfaces'
 import { getLogger, setDebugOptions, setLogger } from '../utils'
@@ -7,7 +6,6 @@ import { BaseSession } from '../BaseSession'
 import {
   executeActionWatcher,
   sessionChannelWatcher,
-  createSessionChannel,
 } from './features/session/sessionSaga'
 import { pubSubSaga } from './features/pubSub/pubSubSaga'
 import {
@@ -28,13 +26,13 @@ import {
   authExpiringAction,
 } from './actions'
 import { AuthError } from '../CustomErrors'
-import { PubSubChannel } from './interfaces'
+import { PubSubChannel, SessionChannel } from './interfaces'
 import { createRestartableSaga } from './utils/sagaHelpers'
 // import { componentCleanupSaga } from './features/component/componentSaga'
 
 interface StartSagaOptions {
   session: BaseSession
-  sessionChannel: EventChannel<any>
+  sessionChannel: SessionChannel
   pubSubChannel: PubSubChannel
   userOptions: InternalUserOptions
 }
@@ -50,11 +48,6 @@ export function* initSessionSaga({
 }): SagaIterator {
   const session = initSession()
 
-  const sessionChannel: EventChannel<any> = yield call(
-    createSessionChannel,
-    session
-  )
-
   /**
    * Channel to communicate between sagas and emit events to
    * the public
@@ -64,6 +57,10 @@ export function* initSessionSaga({
    * Channel to broadcast all the events sent by the server
    */
   const swEventChannel = channels.swEventChannel
+  /**
+   * Channel to communicate with base session
+   */
+  const sessionChannel = channels.sessionChannel
 
   /**
    * Start all the custom workers on startup
@@ -125,13 +122,13 @@ export function* initSessionSaga({
   pubSubTask.cancel()
   sessionStatusTask.cancel()
   executeActionTask.cancel()
-  sessionChannel.close()
   customTasks.forEach((task) => task.cancel())
   /**
-   * Do not close pubSubChannel and swEventChannel
+   * Do not close pubSubChannel, swEventChannel, and sessionChannel
    * since we may need them again in case of reauth/reconnect
    * // pubSubChannel.close()
    * // swEventChannel.close()
+   * // sessionChannel.close()
    */
 }
 

--- a/packages/core/src/testUtils.ts
+++ b/packages/core/src/testUtils.ts
@@ -1,6 +1,10 @@
-import { multicastChannel } from '@redux-saga/core'
+import { channel, multicastChannel } from '@redux-saga/core'
 import { configureStore, ConfigureStoreOptions, SDKStore } from './redux'
-import { PubSubChannel, SwEventChannel } from './redux/interfaces'
+import {
+  PubSubChannel,
+  SwEventChannel,
+  SessionChannel,
+} from './redux/interfaces'
 import { BaseSession } from './BaseSession'
 import { RPCConnectResult, InternalSDKLogger } from './utils/interfaces'
 import { EventEmitter } from './utils/EventEmitter'
@@ -123,3 +127,4 @@ export const rpcConnectResultVRT: RPCConnectResult = {
 
 export const createPubSubChannel = (): PubSubChannel => multicastChannel()
 export const createSwEventChannel = (): SwEventChannel => multicastChannel()
+export const createSessionChannel = (): SessionChannel => channel()

--- a/packages/core/src/utils/interfaces.ts
+++ b/packages/core/src/utils/interfaces.ts
@@ -10,6 +10,7 @@ import {
 import type {
   CustomSaga,
   PubSubChannel,
+  SessionChannel,
   SwEventChannel,
 } from '../redux/interfaces'
 import type { URL as NodeURL } from 'node:url'
@@ -110,6 +111,7 @@ export interface SessionOptions {
    * @internal
    * */
   _onRefreshToken?(): void
+  channel?: SessionChannel
 }
 export interface UserOptions extends SessionOptions {
   /** @internal */
@@ -512,6 +514,7 @@ export type BaseEventHandler = (...args: any[]) => void
 export type InternalChannels = {
   pubSubChannel: PubSubChannel
   swEventChannel: SwEventChannel
+  sessionChannel: SessionChannel
 }
 
 export type SDKWorkerHooks<

--- a/packages/core/src/utils/interfaces.ts
+++ b/packages/core/src/utils/interfaces.ts
@@ -111,7 +111,7 @@ export interface SessionOptions {
    * @internal
    * */
   _onRefreshToken?(): void
-  channel?: SessionChannel
+  sessionChannel?: SessionChannel
 }
 export interface UserOptions extends SessionOptions {
   /** @internal */


### PR DESCRIPTION
Move logic from BaseSession `_onSocketMessage()` into the new saga channel to not use the chain of Promises.