### PR TITLE
Fix webrtc "sdp" package dependency

### DIFF
--- a/.changeset/soft-windows-love.md
+++ b/.changeset/soft-windows-love.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/webrtc': patch
+---
+
+Add missing `sdp` dependency.

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,6 @@
         "jest": "^28.1.0",
         "jest-environment-jsdom": "^28.1.0",
         "prettier": "^2.6.2",
-        "sdp": "^3.0.3",
         "typedoc": "^0.22.10",
         "typescript": "^4.5.4"
       },
@@ -15560,7 +15559,8 @@
       "version": "3.6.1",
       "license": "MIT",
       "dependencies": {
-        "@signalwire/core": "3.14.0"
+        "@signalwire/core": "3.14.0",
+        "sdp": "^3.2.0"
       },
       "engines": {
         "node": ">=10"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "jest": "^28.1.0",
     "jest-environment-jsdom": "^28.1.0",
     "prettier": "^2.6.2",
-    "sdp": "^3.0.3",
     "typedoc": "^0.22.10",
     "typescript": "^4.5.4"
   },

--- a/packages/webrtc/package.json
+++ b/packages/webrtc/package.json
@@ -39,7 +39,8 @@
     "docs:watch": "npm run docs -- --watch"
   },
   "dependencies": {
-    "@signalwire/core": "3.14.0"
+    "@signalwire/core": "3.14.0",
+    "sdp": "^3.2.0"
   },
   "types": "dist/cjs/webrtc/src/index.d.ts"
 }


### PR DESCRIPTION
The `sdp` package was installed at the root level instead of under `packages/webrtc`. This PR moves the dependency under the correct `webrtc` package.