### PR TITLE
Improve Session Disconnect Logic

### DIFF
--- a/.changeset/great-squids-hug.md
+++ b/.changeset/great-squids-hug.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/core': patch
+---
+
+Wait for the pending requests before closing the WebSocket connection.

--- a/.changeset/nervous-pants-look.md
+++ b/.changeset/nervous-pants-look.md
@@ -1,0 +1,6 @@
+---
+'@signalwire/webrtc': patch
+'@signalwire/js': patch
+---
+
+[internal] Destroy the object when the session disconnects.

--- a/internal/e2e-js/tests/roomSessionRemoveAllMembers.spec.ts
+++ b/internal/e2e-js/tests/roomSessionRemoveAllMembers.spec.ts
@@ -6,11 +6,13 @@ import {
   expectRoomJoined,
   expectMCUVisible,
   expectPageReceiveAudio,
-  randomizeRoomName
+  randomizeRoomName,
 } from '../utils'
 
 test.describe('RoomSession removeAllMembers method', () => {
-  test('should remove all members from a room', async ({ createCustomPage }) => {
+  test('should remove all members from a room', async ({
+    createCustomPage,
+  }) => {
     const allPages = await Promise.all([
       createCustomPage({ name: '[page1]' }),
       createCustomPage({ name: '[page2]' }),
@@ -65,22 +67,22 @@ test.describe('RoomSession removeAllMembers method', () => {
       })
     })
 
-    await pageOne.evaluate(
-      async () => {
-        // @ts-expect-error
-        const roomObj: Video.RoomSession = window._roomObj
+    await pageOne.evaluate(async () => {
+      // @ts-expect-error
+      const roomObj: Video.RoomSession = window._roomObj
 
-        const promiseWaitForMember1Left = new Promise((resolve) => {
-          roomObj.on('room.left', () => {
-            resolve(true)
-          })
+      const promiseWaitForMember1Left = new Promise((resolve) => {
+        roomObj.on('room.left', () => {
+          resolve(true)
         })
+      })
 
-        await roomObj.removeAllMembers()
-        return await promiseWaitForMember1Left
-      }
-    )
+      await roomObj.removeAllMembers()
+      return promiseWaitForMember1Left
+    })
 
     await Promise.all([promiseWaitForMember2Left, promiseWaitForMember3Left])
+
+    await pageOne.waitForTimeout(5_000)
   })
 })

--- a/packages/core/src/BaseJWTSession.test.ts
+++ b/packages/core/src/BaseJWTSession.test.ts
@@ -27,6 +27,19 @@ describe('JWTSession', () => {
   let session: JWTSession
   beforeEach(() => {
     ws = new WS(host)
+    // Respond to RPCs
+    ws.on('connection', (socket: any) => {
+      socket.on('message', (data: any) => {
+        const parsedData = JSON.parse(data)
+        socket.send(
+          JSON.stringify({
+            jsonrpc: '2.0',
+            id: parsedData.id,
+            result: {},
+          })
+        )
+      })
+    })
     session = new JWTSession({
       host,
       token,
@@ -42,6 +55,8 @@ describe('JWTSession', () => {
     await ws.connected
 
     expect(session.connected).toBe(true)
+
+    await expect(ws).toReceiveMessage(JSON.stringify(rpcConnect))
 
     session.disconnect()
 

--- a/packages/core/src/BaseSession.test.ts
+++ b/packages/core/src/BaseSession.test.ts
@@ -31,6 +31,20 @@ describe('BaseSession', () => {
   let session: BaseSession
   beforeEach(() => {
     ws = new WS(host)
+    // Respond to RPCs
+    ws.on('connection', (socket: any) => {
+      socket.on('message', (data: any) => {
+        const parsedData = JSON.parse(data)
+        socket.send(
+          JSON.stringify({
+            jsonrpc: '2.0',
+            id: parsedData.id,
+            result: {},
+          })
+        )
+      })
+    })
+
     session = new BaseSession({
       host,
       project,
@@ -49,6 +63,8 @@ describe('BaseSession', () => {
     await ws.connected
 
     expect(session.connected).toBe(true)
+
+    await expect(ws).toReceiveMessage(JSON.stringify(rpcConnect))
 
     session.disconnect()
 

--- a/packages/core/src/BaseSession.ts
+++ b/packages/core/src/BaseSession.ts
@@ -265,12 +265,8 @@ export class BaseSession {
       return
     }
 
-    this._clearCheckPingTimer()
-    this._requests.clear()
-    this._closeConnection('disconnected')
-
-    /** sessionDisconnectedAction() will destroy the rootSaga too */
-    this.dispatch(sessionDisconnectedAction())
+    this._status = 'disconnecting'
+    this._checkCurrentStatus()
   }
 
   /**
@@ -278,6 +274,16 @@ export class BaseSession {
    * @return Promise that will resolve/reject depending on the server response
    */
   execute(msg: JSONRPCRequest | JSONRPCResponse): Promise<any> {
+    if (this._status === 'disconnecting') {
+      this.logger.warn(
+        'Reject request because the session is disconnecting',
+        msg
+      )
+      return Promise.reject({
+        code: '400',
+        message: 'The SDK session is disconnecting',
+      })
+    }
     // In case of a response don't wait for a result
     let promise: Promise<unknown> = Promise.resolve()
     if ('params' in msg) {
@@ -426,6 +432,9 @@ export class BaseSession {
           response: payload,
           request: rpcRequest,
         })
+
+        this._checkCurrentStatus()
+
         return error ? reject(error) : resolve(result)
       }
 
@@ -536,6 +545,37 @@ export class BaseSession {
     await this.execute(RPCPingResponse(payload.id, payload?.params?.timestamp))
   }
 
+  /**
+   * Do something based on the current `this._status`
+   */
+  private _checkCurrentStatus() {
+    switch (this._status) {
+      // Only close the WS connection if there are no pending requests
+      case 'disconnecting':
+        if (this._requests.size > 0) {
+          return
+        }
+        this._requests.clear()
+        this._closeConnection('disconnected')
+        break
+      case 'disconnected':
+        // Will destroy the rootSaga too
+        this.dispatch(sessionDisconnectedAction())
+        break
+      case 'reconnecting':
+        /**
+         * Since the real `close` event can be delayed by OS/Browser,
+         * trigger it manually to start the reconnect process if required.
+         */
+        this.wsCloseHandler(
+          new this.CloseEventConstructor('close', {
+            reason: 'Client-side closed',
+          })
+        )
+        break
+    }
+  }
+
   private _closeConnection(
     status: Extract<SessionStatus, 'reconnecting' | 'disconnected'>
   ) {
@@ -548,17 +588,6 @@ export class BaseSession {
       )
     )
     this.destroySocket()
-
-    if (this._status === 'reconnecting') {
-      /**
-       * Since the real `close` event can be delayed by OS/Browser,
-       * trigger it manually to start the reconnect process if required.
-       */
-      this.wsCloseHandler(
-        new this.CloseEventConstructor('close', {
-          reason: 'Client-side closed',
-        })
-      )
-    }
+    this._checkCurrentStatus()
   }
 }

--- a/packages/core/src/BaseSession.ts
+++ b/packages/core/src/BaseSession.ts
@@ -580,7 +580,7 @@ export class BaseSession {
     status: Extract<SessionStatus, 'reconnecting' | 'disconnected'>
   ) {
     this._clearCheckPingTimer()
-    this.logger.debug('Close Connection')
+    this.logger.debug('Close Connection:', status)
     this._status = status
     this.dispatch(
       sessionActions.authStatus(

--- a/packages/core/src/BaseSession.ts
+++ b/packages/core/src/BaseSession.ts
@@ -313,6 +313,7 @@ export class BaseSession {
         if ('method' in msg && msg.method === 'signalwire.connect') {
           throw this._swConnectError
         }
+        this._checkCurrentStatus()
         this.logger.error('Request Timeout', msg)
         if (this.status === 'disconnected') {
           return this.logger.debug(

--- a/packages/core/src/redux/rootSaga.ts
+++ b/packages/core/src/redux/rootSaga.ts
@@ -105,6 +105,11 @@ export function* initSessionSaga({
 
   yield take(destroyAction.type)
 
+  session.disconnect()
+
+  yield take(sessionDisconnectedAction.type)
+  yield put(pubSubChannel, sessionDisconnectedAction())
+
   /**
    * We have to manually cancel the fork because it is not
    * being automatically cleaned up when the session is
@@ -121,8 +126,6 @@ export function* initSessionSaga({
    * // swEventChannel.close()
    * // sessionChannel.close()
    */
-
-  session.disconnect()
 }
 
 export function* reauthenticateWorker({
@@ -159,7 +162,6 @@ export function* sessionStatusWatcher(options: StartSagaOptions): SagaIterator {
         authExpiringAction.type,
         reauthAction.type,
         sessionReconnectingAction.type,
-        sessionDisconnectedAction.type,
         sessionForceCloseAction.type,
       ])
 
@@ -192,11 +194,6 @@ export function* sessionStatusWatcher(options: StartSagaOptions): SagaIterator {
         }
         case sessionReconnectingAction.type: {
           yield put(options.pubSubChannel, sessionReconnectingAction())
-          break
-        }
-        case sessionDisconnectedAction.type: {
-          yield put(options.pubSubChannel, sessionDisconnectedAction())
-          yield put(destroyAction())
           break
         }
         case sessionForceCloseAction.type: {

--- a/packages/core/src/utils/interfaces.ts
+++ b/packages/core/src/utils/interfaces.ts
@@ -249,6 +249,7 @@ export type SessionStatus =
   | 'idle'
   | 'reconnecting'
   | 'connected'
+  | 'disconnecting'
   | 'disconnected'
   | 'auth_error'
   | 'expiring'

--- a/packages/js/src/RoomSession.ts
+++ b/packages/js/src/RoomSession.ts
@@ -159,6 +159,10 @@ export const RoomSession = function (roomOptions: RoomSessionOptions) {
     client.disconnect()
   })
 
+  client.once('session.disconnected', () => {
+    room.destroy()
+  })
+
   const join = (params?: BaseRoomSessionJoinParams) => {
     return new Promise(async (resolve, reject) => {
       try {

--- a/packages/webrtc/src/BaseConnection.ts
+++ b/packages/webrtc/src/BaseConnection.ts
@@ -925,7 +925,5 @@ export class BaseConnection<EventTypes extends EventEmitter.ValidEventTypes>
       rtcPeer.stop()
     })
     this.rtcPeerMap.clear()
-
-    this.destroy()
   }
 }


### PR DESCRIPTION
This PR improve the internal logic where a server-side event informs the SDK to close the WebSocket connection.
Now the SDK will wait for the pending requests to get a response to resolve/reject the pending RPC promises.