### PR TITLE
Include machineWordsThreshold to Create a Call function

### DIFF
--- a/.changeset/early-cups-jog.md
+++ b/.changeset/early-cups-jog.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/compatibility-api': patch
+---
+
+Include machineWordsThreshold parameter to calls.create function

--- a/packages/compatibility-api/compatibility-api.d.ts
+++ b/packages/compatibility-api/compatibility-api.d.ts
@@ -2,12 +2,33 @@ import type { Twilio, TwimlInterface, JwtInterface } from 'twilio'
 import * as webhookTools from 'twilio/lib/webhooks/webhooks'
 import TwilioClient from 'twilio/lib/rest/Twilio'
 import type { CompatibilityAPIRestClientOptions } from './src/types'
+import {
+  CallListInstance,
+  CallInstance,
+  CallListInstanceCreateOptions,
+} from 'twilio/lib/rest/api/v2010/account/call'
 
 declare function RestClient(
   username: string,
   token: string,
   opts?: CompatibilityAPIRestClientOptions
-): Twilio
+): CompatibilityApi
+
+interface CompatibilityApiCallListInstanceCreateOptions
+  extends CallListInstanceCreateOptions {
+  machineWordsThreshold?: number
+}
+
+interface CompatibilityApiCallListInstance extends CallListInstance {
+  create(
+    opts: CompatibilityApiCallListInstanceCreateOptions,
+    callback?: (error: Error | null, item: CallInstance) => any
+  ): Promise<CallInstance>
+}
+
+declare class CompatibilityApi extends Twilio {
+  calls: CompatibilityApiCallListInstance
+}
 
 declare class FaxResponse {
   constructor()

--- a/packages/compatibility-api/src/index.ts
+++ b/packages/compatibility-api/src/index.ts
@@ -16,7 +16,7 @@ const RestClient = function (
   username: string,
   token: string,
   opts?: CompatibilityAPIRestClientOptions
-): Twilio {
+) {
   const host = getHost(opts)
   // "AC" prefix because twilio-node requires it
   const client = twilio('AC' + username, token, opts)


### PR DESCRIPTION
As mentioned [here](https://github.com/signalwire/cloud-product/issues/5848#issuecomment-1484242672), allow user to pass an optional parameter `machineWordsThreshold` to call.create function of Compatibility API.