### PR TITLE
Exclude client-side events from the initial invite request

### DIFF
--- a/.changeset/sixty-boxes-rest.md
+++ b/.changeset/sixty-boxes-rest.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/core': patch
+---
+
+Exclude internal events into the initial subscribe request.

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -126,6 +126,9 @@ const CLIENT_SIDE_EVENT_NAMES = [
   'video.requesting',
   'video.ringing',
   'video.trying',
+  'video.media.connected',
+  'video.media.reconnecting',
+  'video.media.disconnected',
 ]
 /**
  * Check and filter the events the user attached returning only the valid ones


### PR DESCRIPTION
The invite request includes a list of `events` the client wants to subscribe to. Exclude the `video.media.xx` events from that list. 