### PR TITLE
Remove instance when action ended

### DIFF
--- a/packages/realtime-api/src/video/workers/videoRoomWorker.ts
+++ b/packages/realtime-api/src/video/workers/videoRoomWorker.ts
@@ -67,8 +67,6 @@ export const videoRoomWorker = function* (
     )
   }
 
-  // console.log('videoRoomWorker', type)
-
   switch (type) {
     case 'video.room.started':
     case 'video.room.updated': {

--- a/packages/realtime-api/src/voice/workers/voiceCallCollectWorker.ts
+++ b/packages/realtime-api/src/voice/workers/voiceCallCollectWorker.ts
@@ -14,7 +14,7 @@ export const voiceCallCollectWorker = function* (
   getLogger().trace('voiceCallCollectWorker started')
   const {
     payload,
-    instanceMap: { get, set },
+    instanceMap: { get, set, remove },
   } = options
 
   const callInstance = get<Call>(payload.call_id)
@@ -59,6 +59,8 @@ export const voiceCallCollectWorker = function* (
             `${eventPrefix}.failed`,
             actionInstance
           )
+
+          remove<CallCollect>(payload.control_id)
           break
         }
         case 'speech':
@@ -70,6 +72,8 @@ export const voiceCallCollectWorker = function* (
             `${eventPrefix}.ended`,
             actionInstance
           )
+
+          remove<CallCollect>(payload.control_id)
           break
         }
         default:

--- a/packages/realtime-api/src/voice/workers/voiceCallDetectWorker.ts
+++ b/packages/realtime-api/src/voice/workers/voiceCallDetectWorker.ts
@@ -13,7 +13,7 @@ export const voiceCallDetectWorker = function* (
   getLogger().trace('voiceCallDetectWorker started')
   const {
     payload,
-    instanceMap: { get, set },
+    instanceMap: { get, set, remove },
   } = options
 
   const callInstance = get<Call>(payload.call_id)
@@ -49,6 +49,8 @@ export const voiceCallDetectWorker = function* (
 
       // To resolve the ended() promise in CallDetect
       detectInstance.baseEmitter.emit('detect.ended', detectInstance)
+
+      remove<CallDetect>(payload.control_id)
       return
     }
     default:

--- a/packages/realtime-api/src/voice/workers/voiceCallDialWorker.ts
+++ b/packages/realtime-api/src/voice/workers/voiceCallDialWorker.ts
@@ -22,7 +22,6 @@ export const voiceCallDialWorker = function* (
 
   switch (payload.dial_state) {
     case 'failed': {
-      // TODO: same in the failed  case?
       // @ts-expect-error
       client.baseEmitter.emit('dial.failed', payload)
       break

--- a/packages/realtime-api/src/voice/workers/voiceCallPlayWorker.ts
+++ b/packages/realtime-api/src/voice/workers/voiceCallPlayWorker.ts
@@ -13,7 +13,7 @@ export const voiceCallPlayWorker = function* (
   getLogger().trace('voiceCallPlayWorker started')
   const {
     payload,
-    instanceMap: { get, set },
+    instanceMap: { get, set, remove },
   } = options
 
   const callInstance = get<Call>(payload.call_id)
@@ -60,6 +60,8 @@ export const voiceCallPlayWorker = function* (
 
       // To resolve the ended() promise in CallPlayback
       playbackInstance.baseEmitter.emit('playback.failed', playbackInstance)
+
+      remove<CallPlayback>(controlId)
       break
     }
     case 'finished': {
@@ -67,6 +69,8 @@ export const voiceCallPlayWorker = function* (
 
       // To resolve the ended() promise in CallPlayback
       playbackInstance.baseEmitter.emit('playback.ended', playbackInstance)
+
+      remove<CallPlayback>(controlId)
       break
     }
     default:

--- a/packages/realtime-api/src/voice/workers/voiceCallRecordWorker.ts
+++ b/packages/realtime-api/src/voice/workers/voiceCallRecordWorker.ts
@@ -13,7 +13,7 @@ export const voiceCallRecordWorker = function* (
   getLogger().trace('voiceCallRecordWorker started')
   const {
     payload,
-    instanceMap: { get, set },
+    instanceMap: { get, set, remove },
   } = options
 
   const callInstance = get<Call>(payload.call_id)
@@ -47,6 +47,8 @@ export const voiceCallRecordWorker = function* (
 
       // To resolve the ended() promise in CallRecording
       recordingInstance.baseEmitter.emit(type, recordingInstance)
+
+      remove<CallRecording>(payload.control_id)
       break
     }
     default:

--- a/packages/realtime-api/src/voice/workers/voiceCallTapWorker.ts
+++ b/packages/realtime-api/src/voice/workers/voiceCallTapWorker.ts
@@ -13,7 +13,7 @@ export const voiceCallTapWorker = function* (
   getLogger().trace('voiceCallTapWorker started')
   const {
     payload,
-    instanceMap: { get, set },
+    instanceMap: { get, set, remove },
   } = options
 
   const callInstance = get(payload.call_id) as Call
@@ -43,6 +43,8 @@ export const voiceCallTapWorker = function* (
 
       // To resolve the ended() promise in CallTap
       tapInstance.baseEmitter.emit('tap.ended', tapInstance)
+
+      remove<CallTap>(payload.control_id)
       break
     default:
       getLogger().warn(`Unknown tap state: "${payload.state}"`)


### PR DESCRIPTION
Based on [6421](https://github.com/signalwire/cloud-product/issues/6421)

- [x] Remove instances from `instanceMap` on ended events