### PR TITLE
Return RoomSessionMember object instead of plain Member object in realtime-api

### DIFF
--- a/.changeset/tidy-files-reflect.md
+++ b/.changeset/tidy-files-reflect.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/realtime-api': patch
+---
+
+Return RoomSessionMember object instead of plain Member object

--- a/packages/core/src/types/videoRoomSession.ts
+++ b/packages/core/src/types/videoRoomSession.ts
@@ -273,15 +273,6 @@ export interface VideoRoomSessionContract {
     params: MemberCommandWithValueParams
   ): Rooms.SetInputSensitivityMember
   /**
-   * Returns a list of members currently in the room.
-   *
-   * @example
-   * ```typescript
-   * await room.getMembers()
-   * ```
-   */
-  getMembers(): Rooms.GetMembers
-  /**
    * Mutes the incoming audio. The affected participant will not hear audio
    * from the other participants anymore. You can use this method to make deaf
    * either yourself or another participant in the room.

--- a/packages/core/src/types/videoRoomSession.ts
+++ b/packages/core/src/types/videoRoomSession.ts
@@ -273,6 +273,15 @@ export interface VideoRoomSessionContract {
     params: MemberCommandWithValueParams
   ): Rooms.SetInputSensitivityMember
   /**
+   * Returns a list of members currently in the room.
+   *
+   * @example
+   * ```typescript
+   * await room.getMembers()
+   * ```
+   */
+  getMembers(): Rooms.GetMembers
+  /**
    * Mutes the incoming audio. The affected participant will not hear audio
    * from the other participants anymore. You can use this method to make deaf
    * either yourself or another participant in the room.

--- a/packages/realtime-api/src/video/RoomSession.ts
+++ b/packages/realtime-api/src/video/RoomSession.ts
@@ -22,7 +22,11 @@ import {
   Optional,
 } from '@signalwire/core'
 import { RealTimeRoomApiEvents } from '../types'
-import { RoomSessionMember } from './RoomSessionMember'
+import {
+  RoomSessionMember,
+  RoomSessionMemberEventParams,
+  createRoomSessionMemberObject,
+} from './RoomSessionMember'
 
 type EmitterTransformsEvents =
   | InternalVideoRoomSessionEventNames
@@ -41,6 +45,15 @@ export interface RoomSession
     ConsumerContract<RealTimeRoomApiEvents, RoomSessionFullState> {
   baseEmitter: EventEmitter
   setPayload(payload: Optional<VideoRoomEventParams, 'room'>): void
+  /**
+   * Returns a list of members currently in the room.
+   *
+   * @example
+   * ```typescript
+   * await room.getMembers()
+   * ```
+   */
+  getMembers(): Rooms.GetMembers
 }
 
 export type RoomSessionUpdated = EntityUpdated<RoomSession>
@@ -199,6 +212,50 @@ export class RoomSessionConsumer extends BaseConsumer<RealTimeRoomApiEvents> {
   protected setPayload(payload: Optional<VideoRoomEventParams, 'room'>) {
     this._payload = payload
   }
+
+  getMembers() {
+    return new Promise(async (resolve, reject) => {
+      try {
+        const { members } = await this.execute<
+          void,
+          { members: RoomSessionMemberEventParams['member'][] }
+        >({
+          method: 'video.members.get',
+          params: {
+            room_session_id: this.roomSessionId,
+          },
+        })
+
+        const memberInstances: RoomSessionMember[] = []
+        members.forEach((member) => {
+          let memberInstance = this.instanceMap.get<RoomSessionMember>(
+            member.id
+          )
+          if (!memberInstance) {
+            memberInstance = createRoomSessionMemberObject({
+              store: this.store,
+              // @ts-expect-error
+              emitter: this.emitter,
+              payload: { member },
+            })
+          } else {
+            memberInstance.setPayload({
+              member,
+            } as RoomSessionMemberEventParams)
+          }
+          memberInstances.push(memberInstance)
+          this.instanceMap.set<RoomSessionMember>(
+            memberInstance.id,
+            memberInstance
+          )
+        })
+
+        resolve({ members: memberInstances })
+      } catch (error) {
+        reject(error)
+      }
+    })
+  }
 }
 
 export const RoomSessionAPI = extendComponent<
@@ -207,7 +264,6 @@ export const RoomSessionAPI = extendComponent<
 >(RoomSessionConsumer, {
   videoMute: Rooms.videoMuteMember,
   videoUnmute: Rooms.videoUnmuteMember,
-  getMembers: Rooms.getMembers,
   audioMute: Rooms.audioMuteMember,
   audioUnmute: Rooms.audioUnmuteMember,
   deaf: Rooms.deafMember,

--- a/packages/realtime-api/src/video/RoomSession.ts
+++ b/packages/realtime-api/src/video/RoomSession.ts
@@ -53,7 +53,7 @@ export interface RoomSession
    * await room.getMembers()
    * ```
    */
-  getMembers(): Rooms.GetMembers
+  getMembers(): Promise<{ members: RoomSessionMember[] }>
 }
 
 export type RoomSessionUpdated = EntityUpdated<RoomSession>
@@ -260,7 +260,7 @@ export class RoomSessionConsumer extends BaseConsumer<RealTimeRoomApiEvents> {
 
 export const RoomSessionAPI = extendComponent<
   RoomSessionConsumer,
-  VideoRoomSessionMethods
+  Omit<VideoRoomSessionMethods, 'getMembers'>
 >(RoomSessionConsumer, {
   videoMute: Rooms.videoMuteMember,
   videoUnmute: Rooms.videoUnmuteMember,


### PR DESCRIPTION
Based on [6421](https://github.com/signalwire/cloud-product/issues/6421)

- [x] Return video member instance instead of plain object (this is a bug in our current SDK with realtime-api)