### PR TITLE
Publish playground to GH Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -30,22 +30,22 @@ jobs:
           # Upload entire repository
           path: './public'
 
-  deploy:
-    runs-on: ubuntu-latest
-    # Add a dependency to the build job
-    needs: build
+  # deploy:
+  #   runs-on: ubuntu-latest
+  #   # Add a dependency to the build job
+  #   needs: build
 
-    # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
-    permissions:
-      pages: write # to deploy to Pages
-      id-token: write # to verify the deployment originates from an appropriate source
+  #   # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
+  #   permissions:
+  #     pages: write # to deploy to Pages
+  #     id-token: write # to verify the deployment originates from an appropriate source
 
-    # Deploy to the github-pages environment
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+  #   # Deploy to the github-pages environment
+  #   environment:
+  #     name: github-pages
+  #     url: ${{ steps.deployment.outputs.page_url }}
 
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v2
+  #   steps:
+  #     - name: Deploy to GitHub Pages
+  #       id: deployment
+  #       uses: actions/deploy-pages@v2

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -24,11 +24,11 @@ jobs:
       - name: Build static assets for each branch
         run: |
           ./prepare_public_folder.sh
-      # - name: Upload artifact
-      #   uses: actions/upload-pages-artifact@v1
-      #   with:
-      #     # Upload entire repository
-      #     path: './public'
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          # Upload entire repository
+          path: './public'
 
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -30,22 +30,22 @@ jobs:
           # Upload entire repository
           path: './public'
 
-  # deploy:
-  #   runs-on: ubuntu-latest
-  #   # Add a dependency to the build job
-  #   needs: build
+  deploy:
+    runs-on: ubuntu-latest
+    # Add a dependency to the build job
+    needs: build
 
-  #   # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
-  #   permissions:
-  #     pages: write # to deploy to Pages
-  #     id-token: write # to verify the deployment originates from an appropriate source
+    # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
+    permissions:
+      pages: write # to deploy to Pages
+      id-token: write # to verify the deployment originates from an appropriate source
 
-  #   # Deploy to the github-pages environment
-  #   environment:
-  #     name: github-pages
-  #     url: ${{ steps.deployment.outputs.page_url }}
+    # Deploy to the github-pages environment
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
 
-  #   steps:
-  #     - name: Deploy to GitHub Pages
-  #       id: deployment
-  #       uses: actions/deploy-pages@v2
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -18,6 +18,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - uses: actions/setup-node@v3
         with:
           node-version: 18.x

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,51 @@
+name: Publish to Pages
+
+on:
+  push:
+    branches: ['eg/gh-workflow-to-pages']
+  # pull_request:
+  #   branches: ['*']
+  workflow_dispatch:
+
+# Only one workflow allowed at a time for ALL branches
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18.x
+      - name: Build static assets for each branch
+        run: |
+          ./prepare_public_folder.sh
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          # Upload entire repository
+          path: './public'
+
+  # deploy:
+  #   runs-on: ubuntu-latest
+  #   # Add a dependency to the build job
+  #   needs: build
+
+  #   # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
+  #   permissions:
+  #     pages: write # to deploy to Pages
+  #     id-token: write # to verify the deployment originates from an appropriate source
+
+  #   # Deploy to the github-pages environment
+  #   environment:
+  #     name: github-pages
+  #     url: ${{ steps.deployment.outputs.page_url }}
+
+  #   steps:
+  #     - name: Deploy to GitHub Pages
+  #       id: deployment
+  #       uses: actions/deploy-pages@v2

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -24,28 +24,28 @@ jobs:
       - name: Build static assets for each branch
         run: |
           ./prepare_public_folder.sh
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
-        with:
-          # Upload entire repository
-          path: './public'
+      # - name: Upload artifact
+      #   uses: actions/upload-pages-artifact@v1
+      #   with:
+      #     # Upload entire repository
+      #     path: './public'
 
-  deploy:
-    runs-on: ubuntu-latest
-    # Add a dependency to the build job
-    needs: build
+  # deploy:
+  #   runs-on: ubuntu-latest
+  #   # Add a dependency to the build job
+  #   needs: build
 
-    # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
-    permissions:
-      pages: write # to deploy to Pages
-      id-token: write # to verify the deployment originates from an appropriate source
+  #   # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
+  #   permissions:
+  #     pages: write # to deploy to Pages
+  #     id-token: write # to verify the deployment originates from an appropriate source
 
-    # Deploy to the github-pages environment
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+  #   # Deploy to the github-pages environment
+  #   environment:
+  #     name: github-pages
+  #     url: ${{ steps.deployment.outputs.page_url }}
 
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v2
+  #   steps:
+  #     - name: Deploy to GitHub Pages
+  #       id: deployment
+  #       uses: actions/deploy-pages@v2

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -30,22 +30,22 @@ jobs:
       #     # Upload entire repository
       #     path: './public'
 
-  # deploy:
-  #   runs-on: ubuntu-latest
-  #   # Add a dependency to the build job
-  #   needs: build
+  deploy:
+    runs-on: ubuntu-latest
+    # Add a dependency to the build job
+    needs: build
 
-  #   # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
-  #   permissions:
-  #     pages: write # to deploy to Pages
-  #     id-token: write # to verify the deployment originates from an appropriate source
+    # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
+    permissions:
+      pages: write # to deploy to Pages
+      id-token: write # to verify the deployment originates from an appropriate source
 
-  #   # Deploy to the github-pages environment
-  #   environment:
-  #     name: github-pages
-  #     url: ${{ steps.deployment.outputs.page_url }}
+    # Deploy to the github-pages environment
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
 
-  #   steps:
-  #     - name: Deploy to GitHub Pages
-  #       id: deployment
-  #       uses: actions/deploy-pages@v2
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -18,8 +18,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
       - uses: actions/setup-node@v3
         with:
           node-version: 18.x

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -2,9 +2,7 @@ name: Publish to Pages
 
 on:
   push:
-    branches: ['eg/gh-workflow-to-pages']
-  # pull_request:
-  #   branches: ['*']
+    branches: ['*']
   workflow_dispatch:
 
 # Only one workflow allowed at a time for ALL branches

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ yarn-debug.log*
 yarn-error.log*
 
 coverage/
+public/

--- a/internal/playground-js/index.html
+++ b/internal/playground-js/index.html
@@ -1,0 +1,1 @@
+<h1>JS SDK Playground</h1>

--- a/internal/playground-js/vite.config.ts
+++ b/internal/playground-js/vite.config.ts
@@ -75,4 +75,17 @@ function listPlugin() {
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [listPlugin()],
+  base: process.env.VITE_BASE ?? '/',
+  build: {
+    rollupOptions: {
+      input: {
+        main: path.resolve(__dirname, 'index.html'),
+        heroku: path.resolve(__dirname, 'src/heroku/index.html'),
+        chat: path.resolve(__dirname, 'src/chat/index.html'),
+        fabric: path.resolve(__dirname, 'src/fabric/index.html'),
+        pubSub: path.resolve(__dirname, 'src/pubSub/index.html'),
+        videoManager: path.resolve(__dirname, 'src/videoManager/index.html'),
+      },
+    },
+  },
 })

--- a/prepare_public_folder.sh
+++ b/prepare_public_folder.sh
@@ -17,7 +17,7 @@ for branch in $(git for-each-ref --format='%(refname:short)' refs/remotes/origin
   
   echo "NPM install and Build SDK for this branch"
   # TODO: Build only JS/required sdks 
-  # npm i && npm run build
+  npm i && npm run build
   
   echo "Build playgrounds"
   {

--- a/prepare_public_folder.sh
+++ b/prepare_public_folder.sh
@@ -2,10 +2,10 @@
 
 set -e
 mkdir -p public
+echo "<h1>JS SDK Playground</h1>" > public/index.html
 
-branch="eg/gh-workflow-to-pages"
 # ref: https://stackoverflow.com/a/57748047
-# for branch in $(git for-each-ref --format='%(refname:short)' refs/heads); do
+for branch in $(git for-each-ref --format='%(refname:short)' refs/heads); do
   folder="public/$branch"
   echo "\nCreate folder $folder"
   mkdir -p $folder
@@ -22,4 +22,4 @@ branch="eg/gh-workflow-to-pages"
   echo "Move static assets to 'public'"
   cp -R ./internal/playground-js/dist/* $folder
   echo "\n"
-# done
+done

--- a/prepare_public_folder.sh
+++ b/prepare_public_folder.sh
@@ -34,7 +34,7 @@ for branch_name in $(git for-each-ref --format='%(refname:short)' refs/remotes/o
   echo "Build playgrounds"
   {
     # VITE_BASE used in internal/playground-js/vite.config.ts
-    VITE_BASE="/$branch/" npm run -w=@sw-internal/playground-js build
+    VITE_BASE="/signalwire-js/$branch/" npm run -w=@sw-internal/playground-js build
     echo "Move static assets to 'public'"
     cp -R ./internal/playground-js/dist/* $folder
   } || { 

--- a/prepare_public_folder.sh
+++ b/prepare_public_folder.sh
@@ -18,7 +18,7 @@ for branch in $(git for-each-ref --format='%(refname:short)' refs/remotes/origin
   echo "\nCreate folder $folder"
   mkdir -p $folder
   echo "Checkout $branch"
-  git git switch -f "$branch"
+  git switch -f "$branch"
   
   echo "NPM install and Build SDK for this branch"
   # TODO: Build only JS/required sdks 

--- a/prepare_public_folder.sh
+++ b/prepare_public_folder.sh
@@ -4,32 +4,25 @@ set -e
 mkdir -p public
 echo "<h1>JS SDK Playground</h1>" > public/index.html
 
+# Fetch origin to list the branches below
 git fetch origin
 
-echo "===="
-echo $(git for-each-ref --format='%(refname:short)' refs/heads)
-echo "===="
-echo $(git for-each-ref --format='%(refname:short)' refs/remotes/origin/)
-echo "===="
-echo $(git for-each-ref --format='%(refname:short)')
-echo "===="
-
 # ref: https://stackoverflow.com/a/57748047
-# for branch in $(git for-each-ref --format='%(refname:short)' refs/heads); do
-#   folder="public/$branch"
-#   echo "\nCreate folder $folder"
-#   mkdir -p $folder
-#   echo "Checkout $branch"
-#   git checkout "$branch"
+for branch in $(git for-each-ref --format='%(refname:short)' refs/remotes/origin/); do
+  folder="public/$branch"
+  echo "\nCreate folder $folder"
+  mkdir -p $folder
+  echo "Checkout $branch"
+  git checkout "$branch"
   
-#   echo "NPM install and Build SDK for this branch"
-#   # TODO: Build only JS/required sdks 
-#   npm i && npm run build
+  echo "NPM install and Build SDK for this branch"
+  # TODO: Build only JS/required sdks 
+  npm i && npm run build
   
-#   echo "Build playgrounds"
-#   VITE_BASE="/$branch/" npm run -w=@sw-internal/playground-js build
+  echo "Build playgrounds"
+  VITE_BASE="/$branch/" npm run -w=@sw-internal/playground-js build
 
-#   echo "Move static assets to 'public'"
-#   cp -R ./internal/playground-js/dist/* $folder
-#   echo "\n"
-# done
+  echo "Move static assets to 'public'"
+  cp -R ./internal/playground-js/dist/* $folder
+  echo "\n"
+done

--- a/prepare_public_folder.sh
+++ b/prepare_public_folder.sh
@@ -9,7 +9,7 @@ git fetch origin
 
 # ref: https://stackoverflow.com/a/57748047
 for branch in $(git for-each-ref --format='%(refname:short)' refs/remotes/origin/); do
-  if [ "$branch" == "origin/canary" ]; then
+  if [[ $branch == "origin/canary" ]]; then
     echo "Skip canary branch"
     continue
   fi

--- a/prepare_public_folder.sh
+++ b/prepare_public_folder.sh
@@ -21,19 +21,19 @@ for branch_name in $(git for-each-ref --format='%(refname:short)' refs/remotes/o
   echo "Checkout $branch"
   git switch -f "$branch"
   
-  # echo "NPM install and Build SDK for this branch"
-  # TODO: Build only JS/required sdks 
-  # npm i && npm run build
+  echo "NPM install and Build SDK for this branch"
+  TODO: Build only JS/required sdks 
+  npm i && npm run build
   
-  # echo "Build playgrounds"
-  # {
-  #   # VITE_BASE used in internal/playground-js/vite.config.ts
-  #   VITE_BASE="/$branch/" npm run -w=@sw-internal/playground-js build
-  #   echo "Move static assets to 'public'"
-  #   cp -R ./internal/playground-js/dist/* $folder
-  # } || { 
-  #   echo "Error building $branch"
-  # }
+  echo "Build playgrounds"
+  {
+    # VITE_BASE used in internal/playground-js/vite.config.ts
+    VITE_BASE="/$branch/" npm run -w=@sw-internal/playground-js build
+    echo "Move static assets to 'public'"
+    cp -R ./internal/playground-js/dist/* $folder
+  } || { 
+    echo "Error building $branch"
+  }
 
   echo "\n"
 done

--- a/prepare_public_folder.sh
+++ b/prepare_public_folder.sh
@@ -4,22 +4,28 @@ set -e
 mkdir -p public
 echo "<h1>JS SDK Playground</h1>" > public/index.html
 
-# ref: https://stackoverflow.com/a/57748047
-for branch in $(git for-each-ref --format='%(refname:short)' refs/heads); do
-  folder="public/$branch"
-  echo "\nCreate folder $folder"
-  mkdir -p $folder
-  echo "Checkout $branch"
-  git checkout "$branch"
-  
-  echo "NPM install and Build SDK for this branch"
-  # TODO: Build only JS/required sdks 
-  npm i && npm run build
-  
-  echo "Build playgrounds"
-  VITE_BASE="/$branch/" npm run -w=@sw-internal/playground-js build
+echo $(git for-each-ref --format='%(refname:short)' refs/heads)
 
-  echo "Move static assets to 'public'"
-  cp -R ./internal/playground-js/dist/* $folder
-  echo "\n"
-done
+git fetch origin
+
+echo $(git for-each-ref --format='%(refname:short)' refs/heads)
+
+# ref: https://stackoverflow.com/a/57748047
+# for branch in $(git for-each-ref --format='%(refname:short)' refs/heads); do
+#   folder="public/$branch"
+#   echo "\nCreate folder $folder"
+#   mkdir -p $folder
+#   echo "Checkout $branch"
+#   git checkout "$branch"
+  
+#   echo "NPM install and Build SDK for this branch"
+#   # TODO: Build only JS/required sdks 
+#   npm i && npm run build
+  
+#   echo "Build playgrounds"
+#   VITE_BASE="/$branch/" npm run -w=@sw-internal/playground-js build
+
+#   echo "Move static assets to 'public'"
+#   cp -R ./internal/playground-js/dist/* $folder
+#   echo "\n"
+# done

--- a/prepare_public_folder.sh
+++ b/prepare_public_folder.sh
@@ -7,6 +7,8 @@ echo "<h1>JS SDK Playground</h1>" > public/index.html
 # Fetch origin to list the branches below
 git fetch --no-tags
 
+git for-each-ref --format='%(refname:short)'
+echo "==="
 git for-each-ref --format='%(refname:short)' refs/remotes/origin/
 echo "==="
 git for-each-ref --format='%(refname:short)' refs/heads

--- a/prepare_public_folder.sh
+++ b/prepare_public_folder.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env sh
+
+set -e
+mkdir -p public
+
+branch="eg/gh-workflow-to-pages"
+# ref: https://stackoverflow.com/a/57748047
+# for branch in $(git for-each-ref --format='%(refname:short)' refs/heads); do
+  folder="public/$branch"
+  echo "\nCreate folder $folder"
+  mkdir -p $folder
+  echo "Checkout $branch"
+  git checkout "$branch"
+  
+  echo "NPM install and Build SDK for this branch"
+  # TODO: Build only JS/required sdks 
+  npm i && npm run build
+  
+  echo "Build playgrounds"
+  VITE_BASE="/$branch/" npm run -w=@sw-internal/playground-js build
+
+  echo "Move static assets to 'public'"
+  cp -R ./internal/playground-js/dist/* $folder
+  echo "\n"
+# done

--- a/prepare_public_folder.sh
+++ b/prepare_public_folder.sh
@@ -9,11 +9,16 @@ git fetch origin
 
 # ref: https://stackoverflow.com/a/57748047
 for branch in $(git for-each-ref --format='%(refname:short)' refs/remotes/origin/); do
+  if [ "$branch" == "origin/canary" ]; then
+    echo "Skip canary branch"
+    continue
+  fi
+
   folder="public/$branch"
   echo "\nCreate folder $folder"
   mkdir -p $folder
   echo "Checkout $branch"
-  git checkout "$branch"
+  git git switch -f "$branch"
   
   echo "NPM install and Build SDK for this branch"
   # TODO: Build only JS/required sdks 

--- a/prepare_public_folder.sh
+++ b/prepare_public_folder.sh
@@ -7,7 +7,7 @@ echo "<h1>JS SDK Playground</h1>" > public/index.html
 # Fetch origin to list the branches below
 git fetch --no-tags
 
-git for-each-ref --format='%(refname:short)'
+git for-each-ref
 echo "==="
 git for-each-ref --format='%(refname:short)' refs/remotes/origin/
 echo "==="

--- a/prepare_public_folder.sh
+++ b/prepare_public_folder.sh
@@ -9,6 +9,8 @@ git fetch origin
 echo "===="
 echo $(git for-each-ref --format='%(refname:short)' refs/heads)
 echo "===="
+echo $(git for-each-ref --format='%(refname:short)' refs/remotes/origin/)
+echo "===="
 echo $(git for-each-ref --format='%(refname:short)')
 echo "===="
 

--- a/prepare_public_folder.sh
+++ b/prepare_public_folder.sh
@@ -17,12 +17,17 @@ for branch in $(git for-each-ref --format='%(refname:short)' refs/remotes/origin
   
   echo "NPM install and Build SDK for this branch"
   # TODO: Build only JS/required sdks 
-  npm i && npm run build
+  # npm i && npm run build
   
   echo "Build playgrounds"
-  VITE_BASE="/$branch/" npm run -w=@sw-internal/playground-js build
+  {
+    # VITE_BASE used in internal/playground-js/vite.config.ts
+    VITE_BASE="/$branch/" npm run -w=@sw-internal/playground-js build
+    echo "Move static assets to 'public'"
+    cp -R ./internal/playground-js/dist/* $folder
+  } || { 
+    echo "Error building $branch"
+  }
 
-  echo "Move static assets to 'public'"
-  cp -R ./internal/playground-js/dist/* $folder
   echo "\n"
 done

--- a/prepare_public_folder.sh
+++ b/prepare_public_folder.sh
@@ -7,39 +7,33 @@ echo "<h1>JS SDK Playground</h1>" > public/index.html
 # Fetch origin to list the branches below
 git fetch --no-tags
 
-git for-each-ref
-echo "==="
-git for-each-ref --format='%(refname:short)' refs/remotes/origin/
-echo "==="
-git for-each-ref --format='%(refname:short)' refs/heads
-echo "==="
-
 # ref: https://stackoverflow.com/a/57748047
-# for branch in $(git for-each-ref --format='%(refname:short)' refs/remotes/origin/); do
-#   if [[ $branch == "origin/canary" ]]; then
-#     echo "Skip canary branch"
-#     continue
-#   fi
+for branch_name in $(git for-each-ref --format='%(refname:short)' refs/remotes/origin/); do
+  branch=${branch_name/origin\//}
+  if [[ $branch == "canary" ]]; then
+    echo "Skip canary branch"
+    continue
+  fi
 
-#   folder="public/$branch"
-#   echo "\nCreate folder $folder"
-#   mkdir -p $folder
-#   echo "Checkout $branch"
-#   git checkout -f "$branch"
+  folder="public/$branch"
+  echo "\nCreate folder $folder"
+  mkdir -p $folder
+  echo "Checkout $branch"
+  git switch -f "$branch"
   
-#   echo "NPM install and Build SDK for this branch"
-#   # TODO: Build only JS/required sdks 
-#   npm i && npm run build
+  # echo "NPM install and Build SDK for this branch"
+  # TODO: Build only JS/required sdks 
+  # npm i && npm run build
   
-#   echo "Build playgrounds"
-#   {
-#     # VITE_BASE used in internal/playground-js/vite.config.ts
-#     VITE_BASE="/$branch/" npm run -w=@sw-internal/playground-js build
-#     echo "Move static assets to 'public'"
-#     cp -R ./internal/playground-js/dist/* $folder
-#   } || { 
-#     echo "Error building $branch"
-#   }
+  # echo "Build playgrounds"
+  # {
+  #   # VITE_BASE used in internal/playground-js/vite.config.ts
+  #   VITE_BASE="/$branch/" npm run -w=@sw-internal/playground-js build
+  #   echo "Move static assets to 'public'"
+  #   cp -R ./internal/playground-js/dist/* $folder
+  # } || { 
+  #   echo "Error building $branch"
+  # }
 
-#   echo "\n"
-# done
+  echo "\n"
+done

--- a/prepare_public_folder.sh
+++ b/prepare_public_folder.sh
@@ -5,10 +5,12 @@ mkdir -p public
 echo "<h1>JS SDK Playground</h1>" > public/index.html
 
 echo $(git for-each-ref --format='%(refname:short)' refs/heads)
-
+echo "===="
+echo $(git for-each-ref --format='%(refname:short)' origin)
+echo "===="
 git fetch origin
-
-echo $(git for-each-ref --format='%(refname:short)' refs/heads)
+echo "===="
+echo $(git for-each-ref --format='%(refname:short)' origin)
 
 # ref: https://stackoverflow.com/a/57748047
 # for branch in $(git for-each-ref --format='%(refname:short)' refs/heads); do

--- a/prepare_public_folder.sh
+++ b/prepare_public_folder.sh
@@ -5,34 +5,39 @@ mkdir -p public
 echo "<h1>JS SDK Playground</h1>" > public/index.html
 
 # Fetch origin to list the branches below
-git fetch origin
+git fetch --no-tags
+
+git for-each-ref --format='%(refname:short)' refs/remotes/origin/
+echo "==="
+git for-each-ref --format='%(refname:short)' refs/heads
+echo "==="
 
 # ref: https://stackoverflow.com/a/57748047
-for branch in $(git for-each-ref --format='%(refname:short)' refs/remotes/origin/); do
-  if [[ $branch == "origin/canary" ]]; then
-    echo "Skip canary branch"
-    continue
-  fi
+# for branch in $(git for-each-ref --format='%(refname:short)' refs/remotes/origin/); do
+#   if [[ $branch == "origin/canary" ]]; then
+#     echo "Skip canary branch"
+#     continue
+#   fi
 
-  folder="public/$branch"
-  echo "\nCreate folder $folder"
-  mkdir -p $folder
-  echo "Checkout $branch"
-  git checkout -f "$branch"
+#   folder="public/$branch"
+#   echo "\nCreate folder $folder"
+#   mkdir -p $folder
+#   echo "Checkout $branch"
+#   git checkout -f "$branch"
   
-  echo "NPM install and Build SDK for this branch"
-  # TODO: Build only JS/required sdks 
-  npm i && npm run build
+#   echo "NPM install and Build SDK for this branch"
+#   # TODO: Build only JS/required sdks 
+#   npm i && npm run build
   
-  echo "Build playgrounds"
-  {
-    # VITE_BASE used in internal/playground-js/vite.config.ts
-    VITE_BASE="/$branch/" npm run -w=@sw-internal/playground-js build
-    echo "Move static assets to 'public'"
-    cp -R ./internal/playground-js/dist/* $folder
-  } || { 
-    echo "Error building $branch"
-  }
+#   echo "Build playgrounds"
+#   {
+#     # VITE_BASE used in internal/playground-js/vite.config.ts
+#     VITE_BASE="/$branch/" npm run -w=@sw-internal/playground-js build
+#     echo "Move static assets to 'public'"
+#     cp -R ./internal/playground-js/dist/* $folder
+#   } || { 
+#     echo "Error building $branch"
+#   }
 
-  echo "\n"
-done
+#   echo "\n"
+# done

--- a/prepare_public_folder.sh
+++ b/prepare_public_folder.sh
@@ -8,7 +8,7 @@ echo $(git for-each-ref --format='%(refname:short)' refs/heads)
 echo "===="
 echo $(git for-each-ref --format='%(refname:short)' origin)
 echo "===="
-git fetch origin
+# git fetch origin
 echo "===="
 echo $(git for-each-ref --format='%(refname:short)' origin)
 

--- a/prepare_public_folder.sh
+++ b/prepare_public_folder.sh
@@ -1,16 +1,22 @@
 #!/usr/bin/env bash
 
 set -e
+
+# Create the public folder to be published on Pages
 mkdir -p public
+# Set an entrypoint to avoid 404 on Pages
 echo "<h1>JS SDK Playground</h1>" > public/index.html
 
 # Fetch origin to list the branches below
 git fetch --no-tags
 
-# ref: https://stackoverflow.com/a/57748047
+# Loop all the branches and - for each - build the SDK, build the playground-js
+# and copy the `dist` folder in the global `public` folder.
 for branch_name in $(git for-each-ref --format='%(refname:short)' refs/remotes/origin/); do
+  # Remove `remote/` from refname
   branch=${branch_name/origin\//}
   if [[ $branch == "canary" ]]; then
+    # canary branch is too old!
     echo "Skip canary branch"
     continue
   fi

--- a/prepare_public_folder.sh
+++ b/prepare_public_folder.sh
@@ -9,7 +9,7 @@ git fetch origin
 echo "===="
 echo $(git for-each-ref --format='%(refname:short)' refs/heads)
 echo "===="
-echo $(git for-each-ref --format='%(refname:short)' origin)
+echo $(git for-each-ref --format='%(refname:short)')
 echo "===="
 
 # ref: https://stackoverflow.com/a/57748047

--- a/prepare_public_folder.sh
+++ b/prepare_public_folder.sh
@@ -22,7 +22,7 @@ for branch_name in $(git for-each-ref --format='%(refname:short)' refs/remotes/o
   git switch -f "$branch"
   
   echo "NPM install and Build SDK for this branch"
-  TODO: Build only JS/required sdks 
+  # TODO: Build only JS/required sdks 
   npm i && npm run build
   
   echo "Build playgrounds"

--- a/prepare_public_folder.sh
+++ b/prepare_public_folder.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 set -e
 mkdir -p public

--- a/prepare_public_folder.sh
+++ b/prepare_public_folder.sh
@@ -18,7 +18,7 @@ for branch in $(git for-each-ref --format='%(refname:short)' refs/remotes/origin
   echo "\nCreate folder $folder"
   mkdir -p $folder
   echo "Checkout $branch"
-  git switch -f "$branch"
+  git checkout -f "$branch"
   
   echo "NPM install and Build SDK for this branch"
   # TODO: Build only JS/required sdks 

--- a/prepare_public_folder.sh
+++ b/prepare_public_folder.sh
@@ -4,13 +4,13 @@ set -e
 mkdir -p public
 echo "<h1>JS SDK Playground</h1>" > public/index.html
 
+git fetch origin
+
+echo "===="
 echo $(git for-each-ref --format='%(refname:short)' refs/heads)
 echo "===="
 echo $(git for-each-ref --format='%(refname:short)' origin)
 echo "===="
-# git fetch origin
-echo "===="
-echo $(git for-each-ref --format='%(refname:short)' origin)
 
 # ref: https://stackoverflow.com/a/57748047
 # for branch in $(git for-each-ref --format='%(refname:short)' refs/heads); do


### PR DESCRIPTION
# Description

This PR includes a new GHA workflow to publish several folders to Pages. The logic is:

- On `push` on every branch
- Checkout the repo and loop through the branches
  - Build the SDK
  - Build the playground-js folders
- Publish on Pages to make the playground-js demo available to test

## Type of change

- [x] Internal refactoring
- [ ] Bug fix (bugfix - non-breaking)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Code snippets

Not required - just repo setup
