### PR TITLE
Improve support for React Native

### DIFF
--- a/.changeset/dull-bottles-crash.md
+++ b/.changeset/dull-bottles-crash.md
@@ -1,0 +1,7 @@
+---
+'@signalwire/webrtc': patch
+'@signalwire/core': patch
+'@signalwire/js': patch
+---
+
+Improve support for React Native.

--- a/packages/core/src/utils/CloseEvent.ts
+++ b/packages/core/src/utils/CloseEvent.ts
@@ -1,10 +1,22 @@
 /**
+ * Polyfill the Event class for React Native platform
+ */
+class SwEvent {
+  constructor(public type: string, public options?: EventInit) {}
+}
+
+// const EventClass =
+
+/**
  * Class representing a close event.
  * The `ws` package does not expose it so we can easily create one in here.
  *
  * @extends Event
  */
-export class CloseEvent extends Event {
+export class CloseEvent
+  extends (typeof Event === 'function' ? Event : SwEvent)
+  implements Event
+{
   public code: number
   public reason: string
   public wasClean: boolean
@@ -18,4 +30,42 @@ export class CloseEvent extends Event {
     this.reason = options.reason === undefined ? '' : options.reason
     this.wasClean = options.wasClean === undefined ? false : options.wasClean
   }
+
+  bubbles: boolean
+  cancelBubble: boolean
+  cancelable: boolean
+  composed: boolean
+  currentTarget: EventTarget | null
+  defaultPrevented: boolean
+  eventPhase: number
+  isTrusted: boolean
+  returnValue: boolean
+  srcElement: EventTarget | null
+  target: EventTarget | null
+  timeStamp: number
+  type: string
+  composedPath(): EventTarget[] {
+    console.warn('Method not implemented.')
+    return []
+  }
+  initEvent(
+    _type: string,
+    _bubbles?: boolean | undefined,
+    _cancelable?: boolean | undefined
+  ): void {
+    console.warn('Method not implemented.')
+  }
+  preventDefault(): void {
+    console.warn('Method not implemented.')
+  }
+  stopImmediatePropagation(): void {
+    console.warn('Method not implemented.')
+  }
+  stopPropagation(): void {
+    console.warn('Method not implemented.')
+  }
+  NONE: 0
+  CAPTURING_PHASE: 1
+  AT_TARGET: 2
+  BUBBLING_PHASE: 3
 }

--- a/packages/core/src/utils/CloseEvent.ts
+++ b/packages/core/src/utils/CloseEvent.ts
@@ -5,8 +5,6 @@ class SwEvent {
   constructor(public type: string, public options?: EventInit) {}
 }
 
-// const EventClass =
-
 /**
  * Class representing a close event.
  * The `ws` package does not expose it so we can easily create one in here.

--- a/packages/js/src/JWTSession.ts
+++ b/packages/js/src/JWTSession.ts
@@ -6,10 +6,11 @@ import {
   SwAuthorizationState,
 } from '@signalwire/core'
 import { getStorage, CALL_ID } from './utils/storage'
+import { SwCloseEvent } from './utils/CloseEvent'
 
 export class JWTSession extends BaseJWTSession {
   public WebSocketConstructor = WebSocket
-  public CloseEventConstructor = CloseEvent
+  public CloseEventConstructor = SwCloseEvent
   public agent = process.env.SDK_PKG_AGENT!
 
   constructor(public options: SessionOptions) {

--- a/packages/js/src/utils/CloseEvent.ts
+++ b/packages/js/src/utils/CloseEvent.ts
@@ -1,0 +1,6 @@
+import { CloseEvent as CoreCloseEvent } from '@signalwire/core'
+
+const SwCloseEvent =
+  typeof CloseEvent === 'function' ? CloseEvent : CoreCloseEvent
+
+export { SwCloseEvent }

--- a/packages/webrtc/src/RTCPeer.ts
+++ b/packages/webrtc/src/RTCPeer.ts
@@ -42,7 +42,7 @@ export default class RTCPeer<EventTypes extends EventEmitter.ValidEventTypes> {
 
   private _localStream?: MediaStream
   private _remoteStream?: MediaStream
-  private rtcConfigPolyfill: RTCConfiguration = {}
+  private rtcConfigPolyfill: RTCConfiguration
 
   private get logger() {
     return getLogger()
@@ -69,6 +69,8 @@ export default class RTCPeer<EventTypes extends EventEmitter.ValidEventTypes> {
     if (this.options.localStream && streamIsValid(this.options.localStream)) {
       this._localStream = this.options.localStream
     }
+
+    this.rtcConfigPolyfill = this.config
   }
 
   get watchMediaPacketsTimeout() {
@@ -951,6 +953,6 @@ export default class RTCPeer<EventTypes extends EventEmitter.ValidEventTypes> {
     ) {
       return this.instance.getConfiguration()
     }
-    return this.rtcConfigPolyfill
+    return this.rtcConfigPolyfill || this.config
   }
 }

--- a/packages/webrtc/src/RTCPeer.ts
+++ b/packages/webrtc/src/RTCPeer.ts
@@ -679,7 +679,7 @@ export default class RTCPeer<EventTypes extends EventEmitter.ValidEventTypes> {
       return sdpHasValidCandidates(this.localSdp)
     }
 
-    return false
+    return Boolean(this.localSdp)
   }
 
   private _forceNegotiation() {

--- a/scripts/sw-release/modes/development.js
+++ b/scripts/sw-release/modes/development.js
@@ -23,7 +23,7 @@ const getDevVersion = async () => {
 
   await new Promise((r) => setTimeout(r, 3000))
 
-  return `internal.${timestamp}.${sha}`
+  return `dev.${timestamp}.${sha}`
 }
 
 const getDevelopmentTasks = ({ flags, dryRun, executer }) => {
@@ -72,7 +72,7 @@ const getDevelopmentTasks = ({ flags, dryRun, executer }) => {
       },
     },
     ...publishTaskFactory({
-      npmOptions: ['--tag', 'internal'],
+      npmOptions: ['--tag', 'dev'],
       executer,
       dryRun,
     }),

--- a/scripts/sw-release/modes/development.js
+++ b/scripts/sw-release/modes/development.js
@@ -23,7 +23,7 @@ const getDevVersion = async () => {
 
   await new Promise((r) => setTimeout(r, 3000))
 
-  return `dev.${timestamp}.${sha}`
+  return `internal.${timestamp}.${sha}`
 }
 
 const getDevelopmentTasks = ({ flags, dryRun, executer }) => {
@@ -72,7 +72,7 @@ const getDevelopmentTasks = ({ flags, dryRun, executer }) => {
       },
     },
     ...publishTaskFactory({
-      npmOptions: ['--tag', 'dev'],
+      npmOptions: ['--tag', 'internal'],
       executer,
       dryRun,
     }),


### PR DESCRIPTION
# Description

This PR includes internal changes to improve support for React Native like:

- `Event` and `CloseEvent` global objects
- workaround for RTCPeerConnection `getConfiguration()` that is not implemented

## Type of change

- [x] Internal refactoring
- [ ] Bug fix (bugfix - non-breaking)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Code snippets


