### PR TITLE
Add support for callStateUrl and callStateEvents

### DIFF
--- a/.changeset/unlucky-planets-fly.md
+++ b/.changeset/unlucky-planets-fly.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/core': minor
+---
+
+Add support for `callStateUrl` and `callStateEvents` when dialing and connecting Voice Call.

--- a/packages/core/src/types/voiceCall.ts
+++ b/packages/core/src/types/voiceCall.ts
@@ -151,20 +151,24 @@ export interface SipHeader {
   value: string
 }
 
-export interface VoiceCallPhoneParams {
+interface VoiceCallParams {
+  timeout?: number
+  callStateUrl?: string
+  callStateEvents?: CallingCallState[]
+}
+
+export interface VoiceCallPhoneParams extends VoiceCallParams {
   type: 'phone'
   from?: string
   to: string
-  timeout?: number
 }
 
 export type OmitType<T> = Omit<T, 'type'>
 
-export interface VoiceCallSipParams {
+export interface VoiceCallSipParams extends VoiceCallParams {
   type: 'sip'
   from: string
   to: string
-  timeout?: number
   headers?: SipHeader[]
   codecs?: SipCodec[]
   webrtcMedia?: boolean
@@ -789,14 +793,18 @@ export type InternalVoiceCallEntity = {
  * ==========
  */
 
+type CallDeviceParamsShared = {
+  timeout?: number
+  max_duration?: number
+  call_state_url?: string
+  call_state_events?: string[]
+}
 export interface CallingCallPhoneDevice {
   type: 'phone'
   params: {
     from_number: string
     to_number: string
-    timeout: number
-    max_duration: number
-  }
+  } & CallDeviceParamsShared
 }
 
 export interface CallingCallSIPDevice {
@@ -805,12 +813,10 @@ export interface CallingCallSIPDevice {
     from: string
     from_name?: string
     to: string
-    timeout?: number
-    max_duration?: number
     headers?: SipHeader[]
     codecs?: SipCodec[]
     webrtc_media?: boolean
-  }
+  } & CallDeviceParamsShared
 }
 
 type CallingCallDevice = CallingCallPhoneDevice | CallingCallSIPDevice


### PR DESCRIPTION
# Description

Add support for callStateUrl and callStateEvents to be used to invoke webhook when the call state changes.

## Type of change

- [ ] Internal refactoring
- [ ] Bug fix (bugfix - non-breaking)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Code snippets

> Dial

```ts
      const call = await client.dialPhone({
        to: '+123456',
        from: '+19876',
        timeout: 30,
        callStateUrl: 'http://mydomain.com/hook',
        callStateEvents: ['ended', 'answered']
      })
```

> Connect with ringback too

```ts
        const peer = await call.connect({
          devices: new Voice.DeviceBuilder().add(
            Voice.DeviceBuilder.Sip({
              from: 'sip:user1@domain.com',
              to: 'sip:user2@domain.com',
              timeout: 30,
              callStateUrl: 'http://mydomain.com/hook',
              callStateEvents: ['ended', 'answered'],
            })
          ),
          ringback: new Voice.Playlist().add(
            Voice.Playlist.Ringtone({
              name: 'it',
            })
          ),
        })
```
