### PR TITLE
Implement SAT refresh on expiration for CF

### DIFF
--- a/.changeset/green-wolves-lick.md
+++ b/.changeset/green-wolves-lick.md
@@ -1,0 +1,6 @@
+---
+'@signalwire/core': patch
+'@signalwire/js': patch
+---
+
+Added support for user-defined refresh token function to update SAT

--- a/internal/playground-js/src/fabric-callee/index.js
+++ b/internal/playground-js/src/fabric-callee/index.js
@@ -134,6 +134,10 @@ async function getClient() {
       host: document.getElementById('host').value,
       token: document.getElementById('token').value,
       rootElement: document.getElementById('rootElement'),
+      onRefreshToken: async () => {
+        // Fetch the new token and update the client using 👇
+        // await client.updateToken(newToken)
+      },
     })
   }
 

--- a/packages/core/src/BaseJWTSession.ts
+++ b/packages/core/src/BaseJWTSession.ts
@@ -151,11 +151,13 @@ export class BaseJWTSession extends BaseSession {
     if (!this.expiresAt) {
       return
     }
+    const refreshTokenFn =
+      this.options._onRefreshToken || this.options.onRefreshToken
     if (this.expiresIn <= this._refreshTokenNotificationDiff) {
       this.dispatch(authExpiringAction())
 
-      if (this.options._onRefreshToken) {
-        this.options._onRefreshToken()
+      if (typeof refreshTokenFn === 'function') {
+        refreshTokenFn()
       } else {
         this.logger.warn('The token is going to expire!')
       }

--- a/packages/core/src/BaseJWTSession.ts
+++ b/packages/core/src/BaseJWTSession.ts
@@ -94,7 +94,7 @@ export class BaseJWTSession extends BaseSession {
     try {
       this._rpcConnectResult = await this.execute(RPCConnect(params))
       await this.persistRelayProtocol()
-      this._checkTokenExpiration()
+      await this._checkTokenExpiration()
     } catch (error) {
       this.logger.debug('BaseJWTSession authenticate error', error)
       throw error
@@ -147,7 +147,7 @@ export class BaseJWTSession extends BaseSession {
    * Set a timer to dispatch a notification when the JWT is going to expire.
    * @return void
    */
-  protected _checkTokenExpiration() {
+  protected async _checkTokenExpiration() {
     if (!this.expiresAt) {
       return
     }
@@ -157,7 +157,11 @@ export class BaseJWTSession extends BaseSession {
       this.dispatch(authExpiringAction())
 
       if (typeof refreshTokenFn === 'function') {
-        refreshTokenFn()
+        try {
+          await refreshTokenFn()
+        } catch (error) {
+          this.logger.error(error)
+        }
       } else {
         this.logger.warn('The token is going to expire!')
       }

--- a/packages/core/src/utils/interfaces.ts
+++ b/packages/core/src/utils/interfaces.ts
@@ -105,6 +105,8 @@ export interface SessionOptions {
   // From `LogLevelDesc` of loglevel to simplify our docs
   /** logging level */
   logLevel?: 'trace' | 'debug' | 'info' | 'warn' | 'error' | 'silent'
+  /** To refresh the auth token */
+  onRefreshToken?(): void
   /**
    * The SDK invokes this method and uses the new token to re-auth.
    * TODO: rename it: getNewToken, getRefreshedToken, fetchToken (?)

--- a/packages/core/src/utils/interfaces.ts
+++ b/packages/core/src/utils/interfaces.ts
@@ -106,14 +106,14 @@ export interface SessionOptions {
   /** logging level */
   logLevel?: 'trace' | 'debug' | 'info' | 'warn' | 'error' | 'silent'
   /** To refresh the auth token */
-  onRefreshToken?(): void
+  onRefreshToken?(): Promise<void>
   /**
    * The SDK invokes this method and uses the new token to re-auth.
    * TODO: rename it: getNewToken, getRefreshedToken, fetchToken (?)
    *
    * @internal
    * */
-  _onRefreshToken?(): void
+  _onRefreshToken?(): Promise<void>
   sessionChannel?: SessionChannel
 }
 export interface UserOptions extends SessionOptions {

--- a/packages/js/src/fabric/SignalWire.ts
+++ b/packages/js/src/fabric/SignalWire.ts
@@ -15,6 +15,7 @@ interface SignalWireContract {
   disconnect: WSClient['disconnect']
   dial: WSClient['dial']
   handlePushNotification: WSClient['handlePushNotification']
+  updateToken: WSClient['updateToken']
 }
 
 export const SignalWire = (
@@ -34,6 +35,7 @@ export const SignalWire = (
         disconnect: wsClient.disconnect.bind(wsClient),
         dial: wsClient.dial.bind(wsClient),
         handlePushNotification: wsClient.handlePushNotification.bind(wsClient),
+        updateToken: wsClient.updateToken.bind(wsClient),
         // @ts-expect-error
         __httpClient: httpClient,
         __wsClient: wsClient,

--- a/packages/js/src/fabric/WSClient.ts
+++ b/packages/js/src/fabric/WSClient.ts
@@ -244,4 +244,19 @@ export class WSClient {
       throw error
     }
   }
+
+  updateToken(token: string): Promise<void> {
+    return new Promise((resolve, reject) => {
+      // @ts-expect-error
+      this.wsClient.once('session.auth_error', (error) => {
+        reject(error)
+      })
+      this.wsClient.once('session.connected', () => {
+        resolve()
+      })
+
+      // @ts-expect-error
+      this.wsClient.reauthenticate(token)
+    })
+  }
 }


### PR DESCRIPTION
# Description

To refresh the token, allow the user to pass the `onRefreshToken` function on the SignalWire client for Call Fabric.

ref: https://github.com/signalwire/cloud-product/issues/7070

## Type of change

- [ ] Internal refactoring
- [ ] Bug fix (bugfix - non-breaking)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Code snippets
```javascript
client = await SignalWire({
      host: document.getElementById('host').value,
      token: document.getElementById('token').value,
      rootElement: document.getElementById('rootElement'),
      onRefreshToken: async () => {
        // Fetch the new token and update the client using 👇
        const newToken = await fetch('/foo') 
        await client.updateToken(newToken)
      },
    })
```
