### PR TITLE
Stop and replace video tracks in case of NotReadableError

### DIFF
--- a/.changeset/nine-badgers-swim.md
+++ b/.changeset/nine-badgers-swim.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/webrtc': patch
+---
+
+Make `updateConstraints()` more resilient trying to stop the current MediaStream in case of `NotReadableError`.

--- a/packages/webrtc/src/BaseConnection.ts
+++ b/packages/webrtc/src/BaseConnection.ts
@@ -475,64 +475,55 @@ export class BaseConnection<EventTypes extends EventEmitter.ValidEventTypes>
           return resolve()
         }
 
+        /**
+         * On some devices/browsers you cannot open more than one MediaStream at
+         * a time, per process. When this happens we'll try to do the following:
+         * 1. Stop the current media tracks
+         * 2. Try to get new media tracks with the new constraints
+         * 3. If we get an error: restore the media tracks using the previous
+         *    constraints.
+         * @see
+         * https://bugzilla.mozilla.org/show_bug.cgi?id=1238038
+         *
+         * Instead of just replace the track, force-stop the current one to free
+         * up the device
+         */
+
+        let oldConstraints: MediaStreamConstraints = {}
+        this.localStream?.getTracks().forEach((track) => {
+          /**
+           * We'll keep a reference of the original constraints so if something
+           * fails we should be able to restore them.
+           */
+          // @ts-expect-error
+          oldConstraints[track.kind] = track.getConstraints()
+
+          // @ts-expect-error
+          if (constraints[track.kind] !== undefined) {
+            this.logger.info('updateConstraints stop old tracks first?')
+            this.logger.info('Track readyState:', track.kind, track.readyState)
+            stopTrack(track)
+            track.stop()
+            this.localStream?.removeTrack(track)
+          }
+        })
+
         let newStream!: MediaStream
         try {
           newStream = await getUserMedia(constraints)
         } catch (error) {
-          /**
-           * On some devices/browsers you cannot open more than one MediaStream
-           * at a time, per process. When this happens we'll try to do the
-           * following:
-           * 1. Stop the current media tracks
-           * 2. Try to get new media tracks with the new constraints
-           * 3. If we get an error: restore the media tracks using the previous
-           *    constraints.
-           * @see
-           * https://bugzilla.mozilla.org/show_bug.cgi?id=1238038
-           *
-           * Instead of just replace the track, force-stop the current one to
-           * free up the device
-           */
-          if (
-            error instanceof DOMException &&
-            error.name === 'NotReadableError'
-          ) {
-            let oldConstraints: MediaStreamConstraints = {}
-            this.localStream?.getTracks().forEach((track) => {
-              /**
-               * We'll keep a reference of the original constraints so if
-               * something fails we should be able to restore them.
-               */
-              // @ts-expect-error
-              oldConstraints[track.kind] = track.getConstraints()
+          this.logger.error(
+            'Error updating device constraints:',
+            error.name,
+            error.message,
+            error
+          )
 
-              // @ts-expect-error
-              if (constraints[track.kind] !== undefined) {
-                this.logger.debug(
-                  'updateConstraints stop old tracks to retrieve new ones'
-                )
-                stopTrack(track)
-                this.localStream?.removeTrack(track)
-              }
-            })
+          this.logger.info('Restoring previous constraints', oldConstraints)
+          await this.updateConstraints(oldConstraints, {
+            attempt: attempt + 1,
+          })
 
-            try {
-              return resolve(
-                this.updateConstraints(constraints, {
-                  attempt: attempt + 1,
-                })
-              )
-            } catch (error) {
-              this.logger.error('Restoring previous constraints')
-              return resolve(
-                this.updateConstraints(oldConstraints, {
-                  attempt: attempt + 1,
-                })
-              )
-            }
-          }
-
-          this.logger.error('updateConstraints', error)
           return reject(error)
         }
 

--- a/packages/webrtc/src/BaseConnection.ts
+++ b/packages/webrtc/src/BaseConnection.ts
@@ -500,8 +500,8 @@ export class BaseConnection<EventTypes extends EventEmitter.ValidEventTypes>
 
           // @ts-expect-error
           if (constraints[track.kind] !== undefined) {
-            this.logger.info('updateConstraints stop old tracks first?')
-            this.logger.info('Track readyState:', track.kind, track.readyState)
+            this.logger.debug('updateConstraints stop old tracks first?')
+            this.logger.debug('Track readyState:', track.kind, track.readyState)
             stopTrack(track)
             track.stop()
             this.localStream?.removeTrack(track)
@@ -510,6 +510,7 @@ export class BaseConnection<EventTypes extends EventEmitter.ValidEventTypes>
 
         let newStream!: MediaStream
         try {
+          this.logger.info('updateConstraints with', constraints)
           newStream = await getUserMedia(constraints)
         } catch (error) {
           this.logger.error(

--- a/packages/webrtc/src/BaseConnection.ts
+++ b/packages/webrtc/src/BaseConnection.ts
@@ -472,7 +472,7 @@ export class BaseConnection<EventTypes extends EventEmitter.ValidEventTypes>
           this.logger.debug(
             'Either `video` and `audio` (or both) constraints were set to `false` so their corresponding senders (if any) were stopped'
           )
-          return
+          return resolve()
         }
 
         let newStream!: MediaStream

--- a/packages/webrtc/src/BaseConnection.ts
+++ b/packages/webrtc/src/BaseConnection.ts
@@ -480,27 +480,28 @@ export class BaseConnection<EventTypes extends EventEmitter.ValidEventTypes>
           newStream = await getUserMedia(constraints)
         } catch (error) {
           /**
-           * In Firefox you cannot open more than one
-           * microphone at a time, per process. When this
-           * happens we'll try to do the following:
-           * 1. Stop the current audio track
-           * 2. Try to get another audio track with the new
-           *    constraints
-           * 3. If we get an error: restore the media tracks
-           *    using the previous constraints.
+           * On some devices/browsers you cannot open more than one MediaStream
+           * at a time, per process. When this happens we'll try to do the
+           * following:
+           * 1. Stop the current media tracks
+           * 2. Try to get new media tracks with the new constraints
+           * 3. If we get an error: restore the media tracks using the previous
+           *    constraints.
            * @see
            * https://bugzilla.mozilla.org/show_bug.cgi?id=1238038
+           *
+           * Instead of just replace the track, force-stop the current one to
+           * free up the device
            */
           if (
             error instanceof DOMException &&
-            error.message === 'Concurrent mic process limit.'
+            error.name === 'NotReadableError'
           ) {
             let oldConstraints: MediaStreamConstraints = {}
             this.localStream?.getTracks().forEach((track) => {
               /**
-               * We'll keep a reference of the original
-               * constraints so if something fails we should
-               * be able to restore them.
+               * We'll keep a reference of the original constraints so if
+               * something fails we should be able to restore them.
                */
               // @ts-expect-error
               oldConstraints[track.kind] = track.getConstraints()


### PR DESCRIPTION
# Description

I extended the _stop & replace_ logic while updating the device constraints mid-call to the video tracks too. 

Before: we were applying the logic only for the `Concurrent mic process limit` error => microphone only
After: we run the logic in case the browser throws a `NotReadableError`. This will work for both microphones and cameras.

The `Concurrent mic process limit` is a `NotReadableError` so nothing has changed for the audio part.

## Type of change

- [ ] Internal refactoring
- [x] Bug fix (bugfix - non-breaking)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Code snippets

No changes required.
