### PR TITLE
Avoid useless bye during call setup

### DIFF
--- a/.changeset/spotty-carrots-remember.md
+++ b/.changeset/spotty-carrots-remember.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/webrtc': patch
+---
+
+Bugfix: make sure there is a valid RTCPeerConnection instance before hangup.

--- a/packages/webrtc/src/BaseConnection.ts
+++ b/packages/webrtc/src/BaseConnection.ts
@@ -290,7 +290,7 @@ export class BaseConnection<EventTypes extends EventEmitter.ValidEventTypes>
     this.logger.debug('Set RTCPeer', rtcPeer.uuid, rtcPeer)
     this.rtcPeerMap.set(rtcPeer.uuid, rtcPeer)
 
-    if (this.peer && this.callId !== rtcPeer.uuid) {
+    if (this.peer && this.peer.instance && this.callId !== rtcPeer.uuid) {
       const oldPeerId = this.peer.uuid
       this.logger.debug('>>> Stop old RTCPeer', oldPeerId)
       // Hangup the previous RTCPeer


### PR DESCRIPTION
# Description

Make sure there's a valid RTCPeerConnection before sending the _bye_ to avoid useless requests and to stop the active tracks.
This bug was introduced with the CF changes where we need the `peer` in case of inbound calls.

## Type of change

- [ ] Internal refactoring
- [x] Bug fix (bugfix - non-breaking)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Code snippets

No changes required.
