### PR TITLE
Resolve CF `dial()` on the room.subscribed event

### DIFF
--- a/.changeset/lazy-cheetahs-carry.md
+++ b/.changeset/lazy-cheetahs-carry.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/js': patch
+---
+
+[internal] Resolve CF `.dial()` on room joined too.

--- a/packages/js/src/fabric/WSClient.ts
+++ b/packages/js/src/fabric/WSClient.ts
@@ -101,6 +101,7 @@ export class WSClient {
 
         // @ts-expect-error
         call.emitter.once('verto.display', () => resolve(call))
+        call.once('room.subscribed', () => resolve(call))
 
         await call.join()
 


### PR DESCRIPTION
# Description

Resolve the `client.dial()` method on both events: in case of verto call or video room.

## Type of change

- [ ] Internal refactoring
- [x] Bug fix (bugfix - non-breaking)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Code snippets

No changes required
