### PR TITLE
Add subscribe to `verto.answer`

### DIFF
--- a/.changeset/wise-melons-sparkle.md
+++ b/.changeset/wise-melons-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/webrtc': patch
+---
+
+Include `subscribe` in the answer for auto-subscribe events.

--- a/packages/webrtc/src/BaseConnection.ts
+++ b/packages/webrtc/src/BaseConnection.ts
@@ -820,7 +820,7 @@ export class BaseConnection<EventTypes extends EventEmitter.ValidEventTypes>
    *   - new: the first time we send out the answer.
    * @internal
    */
-  async executeAnswer(sdp: string, rtcPeerId: string) {
+  async executeAnswer(sdp: string, rtcPeerId: string, nodeId?: string) {
     // Set state to `answering` only when `new`, otherwise keep it as `answering`.
     if (this.state === 'new') {
       this.setState('answering')
@@ -833,8 +833,8 @@ export class BaseConnection<EventTypes extends EventEmitter.ValidEventTypes>
       const response: any = await this.vertoExecute({
         message,
         callID: rtcPeerId,
-        node_id: this.nodeId || 'f6cf30a9-1ff1-4f89-b674-e0208ad5d9cd@',
-        // subscribe, // TODO: subscribe events?
+        node_id: nodeId ?? this.options.nodeId,
+        subscribe: this.getSubscriptions(),
       })
       this.logger.debug('Answer response', response)
 


### PR DESCRIPTION
# Description

We need to do the same we do on the verto.invite to have all the events auto-subscribed by our server.

## Type of change

- [x] Internal refactoring
- [ ] Bug fix (bugfix - non-breaking)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Code snippets

No changes
