### PR TITLE
Add support for REJECT_ALL

### DIFF
--- a/.changeset/flat-bananas-brake.md
+++ b/.changeset/flat-bananas-brake.md
@@ -1,0 +1,5 @@
+---
+'@sw-internal/playground-js': patch
+---
+
+Update callee demo to reject all the calls

--- a/.changeset/spotty-months-rescue.md
+++ b/.changeset/spotty-months-rescue.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/webrtc': minor
+---
+
+Allow to reject all the inbound legs

--- a/internal/playground-js/src/fabric-callee/index.html
+++ b/internal/playground-js/src/fabric-callee/index.html
@@ -103,6 +103,13 @@
               </div>
               <div class="d-grid gap-2">
                 <button
+                  id="btnPushNotifications"
+                  class="btn btn-info"
+                  onclick="enablePushNotifications()"
+                >
+                  Enable Push Notifications
+                </button>
+                <button
                   id="btnConnect"
                   class="btn btn-success"
                   onclick="connect()"
@@ -140,6 +147,14 @@
                   disabled="true"
                 >
                   Reject Call
+                </button>
+                <button
+                  id="rejectAllCallsBtn"
+                  class="btn btn-danger px-3 mt-2"
+                  onClick="rejectAllCalls()"
+                  disabled="true"
+                >
+                  Reject All Calls
                 </button>
               </div>
 

--- a/internal/playground-js/src/fabric-callee/index.js
+++ b/internal/playground-js/src/fabric-callee/index.js
@@ -32,6 +32,7 @@ const inCallElements = [
   tapPushNotificationBtn,
   acceptCallBtn,
   rejectCallBtn,
+  rejectAllCallsBtn,
 ]
 
 const playbackElements = [
@@ -121,11 +122,13 @@ function uiReady() {
 function enableCallButtons() {
   acceptCallBtn.disabled = false
   rejectCallBtn.disabled = false
+  rejectAllCallsBtn.disabled = false
 }
 
 function disableCallButtons() {
   acceptCallBtn.disabled = true
   rejectCallBtn.disabled = true
+  rejectAllCallsBtn.disabled = true
 }
 
 async function getClient() {
@@ -223,6 +226,12 @@ window.acceptCall = async () => {
 window.rejectCall = async () => {
   disableCallButtons()
   await window.__call.hangup()
+  restoreUI()
+}
+
+window.rejectAllCalls = async () => {
+  disableCallButtons()
+  await window.__call.hangupAll()
   restoreUI()
 }
 
@@ -606,21 +615,7 @@ async function readPushNotification(payload, pnKey) {
   }
 }
 
-/**
- * On document ready auto-fill the input values from the localStorage.
- */
-window.ready(async function () {
-  document.getElementById('host').value =
-    localStorage.getItem('fabric.callee.host') || ''
-  document.getElementById('token').value =
-    localStorage.getItem('fabric.callee.token') || ''
-  document.getElementById('payload').value =
-    localStorage.getItem('fabric.callee.payload') || ''
-  document.getElementById('audio').checked =
-    (localStorage.getItem('fabric.callee.audio') || '1') === '1'
-  document.getElementById('video').checked =
-    (localStorage.getItem('fabric.callee.video') || '1') === '1'
-
+window.enablePushNotifications = async () => {
   //Initialize Firebase App
   const config = {
     apiKey: import.meta.env.VITE_FB_API_KEY,
@@ -675,4 +670,22 @@ window.ready(async function () {
   } catch (error) {
     console.error('Service Worker registration failed: ', error)
   }
+}
+
+/**
+ * On document ready auto-fill the input values from the localStorage.
+ */
+window.ready(async function () {
+  document.getElementById('host').value =
+    localStorage.getItem('fabric.callee.host') || ''
+  document.getElementById('token').value =
+    localStorage.getItem('fabric.callee.token') || ''
+  document.getElementById('payload').value =
+    localStorage.getItem('fabric.callee.payload') || ''
+  document.getElementById('audio').checked =
+    (localStorage.getItem('fabric.callee.audio') || '1') === '1'
+  document.getElementById('video').checked =
+    (localStorage.getItem('fabric.callee.video') || '1') === '1'
+
+  await window.enablePushNotifications()
 })

--- a/packages/webrtc/src/BaseConnection.ts
+++ b/packages/webrtc/src/BaseConnection.ts
@@ -908,6 +908,30 @@ export class BaseConnection<EventTypes extends EventEmitter.ValidEventTypes>
     }
   }
 
+  async hangupAll() {
+    const rtcPeerId = this.callId
+    if (!rtcPeerId) {
+      throw new Error('Invalid RTCPeer ID to hangup')
+    }
+
+    try {
+      const message = VertoBye({
+        cause: 'REJECT_ALL',
+        causeCode: '825',
+        ...this.dialogParams(rtcPeerId),
+      })
+      await this.vertoExecute({
+        message,
+        callID: rtcPeerId,
+        node_id: this.nodeId,
+      })
+    } catch (error) {
+      this.logger.error('HangupAll error:', error)
+    } finally {
+      this.setState('hangup')
+    }
+  }
+
   /** @internal */
   dtmf(dtmf: string) {
     const rtcPeerId = this.callId


### PR DESCRIPTION
# Description

Expose a new method `hangupAll` (name to review) to allow end user to decide if they want to reject all the legs created to reach all the devices.
Assuming an address resolves to 10 devices, dialing that address will make 10 different legs. With _reject all_ they can hangup all the legs with one request.

Note: useful in CF only for now.

## Type of change

- [ ] Internal refactoring
- [ ] Bug fix (bugfix - non-breaking)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Code snippets

```js
await callObject.hangupAll()
```
