### PR TITLE
Remove applyEmitterTransform function from all the SDKs 

### DIFF
--- a/.changeset/silver-needles-give.md
+++ b/.changeset/silver-needles-give.md
@@ -1,0 +1,8 @@
+---
+'@signalwire/realtime-api': patch
+'@signalwire/webrtc': patch
+'@signalwire/core': patch
+'@signalwire/js': patch
+---
+
+Cleanup the SDK by removing applyEmitterTransform

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main, dev]
+    branches: [main, dev, aa/video-emitter-transform]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main, dev, aa/video-emitter-transform]
+    branches: [main, dev]
   workflow_dispatch:
 
 concurrency:

--- a/packages/core/src/BaseComponent.ts
+++ b/packages/core/src/BaseComponent.ts
@@ -838,16 +838,6 @@ export class BaseComponent<
     return new Map()
   }
 
-  /**
-   * Returns a structure with the emitter transforms that we want to `apply`
-   * for each BaseConsumer. This allow us to define a static structure for
-   * each class and later consume it within `applyEmitterTransforms`.
-   * @internal
-   */
-  protected getEmitterTransforms(): Map<string | string[], EventTransform> {
-    return new Map()
-  }
-
   /** @internal */
   protected get _sessionAuthStatus(): SessionAuthStatus {
     return getAuthStatus(this.store.getState())
@@ -899,73 +889,6 @@ export class BaseComponent<
       case 'unauthorized':
         return Promise.reject(new Error('Unauthorized'))
     }
-  }
-
-  private _setEmitterTransform({
-    event,
-    handler,
-    local,
-  }: {
-    event: string
-    handler: EventTransform
-    local: boolean
-  }) {
-    const internalEvent = this._getInternalEvent(
-      event as EventEmitter.EventNames<EventTypes>
-    )
-
-    if (
-      local
-        ? /**
-           * When `local === true` we filter out `Remote Events`
-           */
-          !isLocalEvent(event)
-        : /**
-           * When `local !== true` we filter out `Local Events` AND
-           * events the user hasn't subscribed to.
-           */
-          isLocalEvent(event) || !this.eventNames().includes(internalEvent)
-    ) {
-      return
-    }
-
-    this._emitterTransforms.set(internalEvent, handler)
-  }
-
-  /**
-   * Loop through the `getEmitterTransforms` Map and translate those into the
-   * internal `_emitterTransforms` Map to quickly select & use the transform starting
-   * from the server-side event.
-   * @internal
-   */
-  protected applyEmitterTransforms(
-    { local = false }: { local: boolean } = { local: false }
-  ) {
-    this.getEmitterTransforms().forEach((handlersObj, key) => {
-      if (Array.isArray(key)) {
-        key.forEach((k) => {
-          this._setEmitterTransform({
-            event: k,
-            handler: handlersObj,
-            local,
-          })
-        })
-      } else {
-        this._setEmitterTransform({
-          event: key,
-          handler: handlersObj,
-          local,
-        })
-      }
-
-      /**
-       * Set a transform using the `key` to select it easily when
-       * creating Proxy objects.
-       * The transform by `type` will be used by nested fields while the top-level
-       * by `internalEvent` for each single event transform.
-       */
-      this._emitterTransforms.set(handlersObj.type, handlersObj)
-    })
   }
 
   /** @internal */

--- a/packages/core/src/BaseConsumer.ts
+++ b/packages/core/src/BaseConsumer.ts
@@ -22,16 +22,6 @@ export class BaseConsumer<
 
   constructor(public options: BaseComponentOptions<EventTypes>) {
     super(options)
-
-    /**
-     * Local events can be attached right away because we
-     * have enough information during build time on how to
-     * namespace them. Other events depend on info coming
-     * from the server and for those we have to wait until
-     * the `subscribe()` happen.
-     */
-    this.applyEmitterTransforms({ local: true })
-
     /**
      * TODO: To Review
      * Reset _latestExecuteParams when on session connect/disconnet
@@ -86,7 +76,6 @@ export class BaseConsumer<
     this._latestExecuteParams = execParams
     return new Promise(async (resolve, reject) => {
       try {
-        this.applyEmitterTransforms()
         await this.execute(execParams)
         return resolve(undefined)
       } catch (error) {

--- a/packages/js/src/video/childMemberJoinedWorker.ts
+++ b/packages/js/src/video/childMemberJoinedWorker.ts
@@ -63,8 +63,6 @@ export const childMemberJoinedWorker: SDKWorker<
        **/
       // @ts-expect-error
       instance._attachListeners(member.id)
-      // @ts-expect-error
-      instance.applyEmitterTransforms()
 
       yield sagaEffects.put(
         componentActions.upsert({

--- a/packages/realtime-api/src/messaging/MessagingClient.ts
+++ b/packages/realtime-api/src/messaging/MessagingClient.ts
@@ -55,11 +55,6 @@ const MessagingClient = function (options?: MessagingClientOptions) {
     emitter,
   })
 
-  client.once('session.connected', () => {
-    // @ts-expect-error
-    messaging.applyEmitterTransforms()
-  })
-
   const send: Messaging['send'] = async (...args) => {
     await clientConnect(client)
 

--- a/packages/realtime-api/src/voice/Call.ts
+++ b/packages/realtime-api/src/voice/Call.ts
@@ -106,7 +106,6 @@ export class CallConsumer extends ApplyEventListeners<RealTimeCallApiEvents> {
     this._payload = options.payload
 
     this._attachListeners(this.__uuid)
-    this.applyEmitterTransforms({ local: true })
 
     this.on('call.state', () => {
       /**

--- a/packages/webrtc/src/BaseConnection.ts
+++ b/packages/webrtc/src/BaseConnection.ts
@@ -139,8 +139,6 @@ export class BaseConnection<EventTypes extends EventEmitter.ValidEventTypes>
     this.setState('new')
     this.logger.trace('New Call with Options:', this.options)
 
-    this.applyEmitterTransforms({ local: true })
-
     this._initPeer()
   }
 
@@ -842,7 +840,6 @@ export class BaseConnection<EventTypes extends EventEmitter.ValidEventTypes>
 
       // TODO: Review
       this._attachListeners('')
-      this.applyEmitterTransforms()
 
       /** Call is active so set the RTCPeer */
       this.setActiveRTCPeer(rtcPeerId)

--- a/packages/webrtc/src/workers/roomSubscribedWorker.ts
+++ b/packages/webrtc/src/workers/roomSubscribedWorker.ts
@@ -52,9 +52,6 @@ export const roomSubscribedWorker: SDKWorker<
   // @ts-expect-error
   instance._attachListeners(action.payload.room_session.id)
 
-  // @ts-expect-error
-  instance.applyEmitterTransforms()
-
   /**
    * In here we joined a room_session so we can swap between RTCPeers
    */

--- a/packages/webrtc/src/workers/vertoEventWorker.ts
+++ b/packages/webrtc/src/workers/vertoEventWorker.ts
@@ -140,8 +140,6 @@ export const vertoEventWorker: SDKWorker<
       case 'verto.display': {
         // @ts-expect-error
         instance._attachListeners('')
-        // @ts-expect-error
-        instance.applyEmitterTransforms()
         /** Call is active so set the RTCPeer */
         instance.setActiveRTCPeer(rtcPeerId)
 


### PR DESCRIPTION
# Description

Cleanup the SDK by removing the applyEmitterTransform function

ref: https://github.com/signalwire/cloud-product/issues/7148

## Type of change

- [x] Internal refactoring
- [ ] Bug fix (bugfix - non-breaking)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Code snippets

In case of new feature or breaking changes, please include code snippets.
