### PR TITLE
Remove eventsPrefix from the namespaces

### DIFF
--- a/.changeset/nasty-olives-press.md
+++ b/.changeset/nasty-olives-press.md
@@ -1,0 +1,7 @@
+---
+'@signalwire/realtime-api': patch
+'@signalwire/webrtc': patch
+'@signalwire/core': patch
+---
+
+Cleanup the SDK by removing eventsPrefix from the namespaces

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main, dev]
+    branches: [main, dev, aa/video-emitter-transform]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main, dev, aa/video-emitter-transform]
+    branches: [main, dev]
   workflow_dispatch:
 
 concurrency:

--- a/packages/core/src/BaseComponent.test.ts
+++ b/packages/core/src/BaseComponent.test.ts
@@ -5,8 +5,6 @@ import { EventEmitter } from './utils/EventEmitter'
 describe('BaseComponent', () => {
   describe('as an event emitter', () => {
     class JestComponent extends BaseComponent<any> {
-      protected _eventsPrefix = 'video' as const
-
       constructor(namespace = '') {
         super({
           store: configureJestStore(),
@@ -48,31 +46,6 @@ describe('BaseComponent', () => {
       expect(
         customInstance.listenerCount('custom:video.test.event_two')
       ).toEqual(1)
-    })
-
-    it('should keep track of the original events with the _eventsPrefix', () => {
-      const firstInstance = new JestComponent('first_namespace')
-      firstInstance.on('first.event_one', () => {})
-      firstInstance.once('video.first.eventOne', () => {})
-      firstInstance.on('first.event_two', () => {})
-      firstInstance.once('video.first.eventTwo', () => {})
-      firstInstance.once('video.first.eventTwoExtra', () => {})
-
-      const secondInstance = new JestComponent('second_namespace')
-      secondInstance.on('second.event_one', () => {})
-      secondInstance.once('video.second.eventOne', () => {})
-      secondInstance.on('second.event_two', () => {})
-      secondInstance.once('video.second.eventTwo', () => {})
-
-      expect(firstInstance.eventNames()).toStrictEqual([
-        'first_namespace:video.first.event_one',
-        'first_namespace:video.first.event_two',
-        'first_namespace:video.first.event_two_extra',
-      ])
-      expect(secondInstance.eventNames()).toStrictEqual([
-        'second_namespace:video.second.event_one',
-        'second_namespace:video.second.event_two',
-      ])
     })
 
     it('should remove the listeners with .off', () => {

--- a/packages/core/src/BaseComponent.test.ts
+++ b/packages/core/src/BaseComponent.test.ts
@@ -5,6 +5,8 @@ import { EventEmitter } from './utils/EventEmitter'
 describe('BaseComponent', () => {
   describe('as an event emitter', () => {
     class JestComponent extends BaseComponent<any> {
+      protected _eventsPrefix = 'video' as const
+
       constructor(namespace = '') {
         super({
           store: configureJestStore(),

--- a/packages/core/src/BaseComponent.test.ts
+++ b/packages/core/src/BaseComponent.test.ts
@@ -5,8 +5,6 @@ import { EventEmitter } from './utils/EventEmitter'
 describe('BaseComponent', () => {
   describe('as an event emitter', () => {
     class JestComponent extends BaseComponent<any> {
-      protected _eventsPrefix = 'video' as const
-
       constructor(namespace = '') {
         super({
           store: configureJestStore(),
@@ -23,109 +21,82 @@ describe('BaseComponent', () => {
       instance = new JestComponent()
     })
 
-    it('should transform the event name to the internal format', () => {
-      instance.on('test.event_one', () => {})
-      instance.on('test.eventOne', () => {})
-      instance.once('video.test.eventOne', () => {})
-
-      instance.once('video.test.eventTwo', () => {})
-
-      expect(instance.listenerCount('video.test.event_one')).toEqual(3)
-      expect(instance.listenerCount('video.test.event_two')).toEqual(1)
-    })
-
-    it('should transform the event name to the internal format with namespace', () => {
-      const customInstance = new JestComponent('custom')
-      customInstance.on('test.event_one', () => {})
-      customInstance.on('test.eventOne', () => {})
-      customInstance.once('video.test.eventOne', () => {})
-
-      customInstance.once('video.test.eventTwo', () => {})
-
-      expect(
-        customInstance.listenerCount('custom:video.test.event_one')
-      ).toEqual(3)
-      expect(
-        customInstance.listenerCount('custom:video.test.event_two')
-      ).toEqual(1)
-    })
-
     it('should remove the listeners with .off', () => {
       const instance = new JestComponent('custom')
       const mockOne = jest.fn()
-      instance.on('test.eventOne', mockOne)
-      instance.once('test.eventOne', mockOne)
+      instance._on('test.eventOne', mockOne)
+      instance._once('test.eventOne', mockOne)
       const mockTwo = jest.fn()
-      instance.on('test.eventTwo', mockTwo)
-      instance.once('test.eventTwo', mockTwo)
+      instance._on('test.eventTwo', mockTwo)
+      instance._once('test.eventTwo', mockTwo)
 
-      expect(instance.listenerCount('custom:video.test.event_one')).toEqual(2)
-      expect(instance.listenerCount('custom:video.test.event_two')).toEqual(2)
+      expect(instance.listenerCount('test.eventOne')).toEqual(2)
+      expect(instance.listenerCount('test.eventTwo')).toEqual(2)
 
-      expect(instance.eventNames()).toStrictEqual([
-        'custom:video.test.event_one',
-        'custom:video.test.event_two',
+      expect(instance.baseEventNames()).toStrictEqual([
+        'test.eventOne',
+        'test.eventTwo',
       ])
 
       // No-op
-      instance.off('test.eventOne', () => {})
-      expect(instance.listenerCount('custom:video.test.event_one')).toEqual(2)
+      instance._off('test.eventOne', () => {})
+      expect(instance.listenerCount('test.eventOne')).toEqual(2)
 
-      instance.off('test.eventOne', mockOne)
-      expect(instance.listenerCount('custom:video.test.event_one')).toEqual(0)
+      instance._off('test.eventOne', mockOne)
+      expect(instance.listenerCount('test.eventOne')).toEqual(0)
 
-      instance.off('test.eventTwo', mockTwo)
-      expect(instance.listenerCount('custom:video.test.event_two')).toEqual(0)
+      instance._off('test.eventTwo', mockTwo)
+      expect(instance.listenerCount('test.eventTwo')).toEqual(0)
 
-      expect(instance.eventNames()).toStrictEqual([])
+      expect(instance.baseEventNames()).toStrictEqual([])
     })
 
     it('should remove all the listeners with .removeAllListeners', () => {
       const instance = new JestComponent('custom')
       const mockOne = jest.fn()
-      instance.on('test.eventOne', mockOne)
-      instance.once('test.eventOne', mockOne)
+      instance._on('test.eventOne', mockOne)
+      instance._once('test.eventOne', mockOne)
       const mockTwo = jest.fn()
-      instance.on('test.eventTwo', mockTwo)
-      instance.once('test.eventTwo', mockTwo)
+      instance._on('test.eventTwo', mockTwo)
+      instance._once('test.eventTwo', mockTwo)
 
-      expect(instance.listenerCount('custom:video.test.event_one')).toEqual(2)
-      expect(instance.listenerCount('custom:video.test.event_two')).toEqual(2)
+      expect(instance.listenerCount('test.eventOne')).toEqual(2)
+      expect(instance.listenerCount('test.eventTwo')).toEqual(2)
 
-      expect(instance.eventNames()).toStrictEqual([
-        'custom:video.test.event_one',
-        'custom:video.test.event_two',
+      expect(instance.baseEventNames()).toStrictEqual([
+        'test.eventOne',
+        'test.eventTwo',
       ])
 
       instance.removeAllListeners()
 
-      expect(instance.listenerCount('custom:video.test.event_one')).toEqual(0)
-      expect(instance.listenerCount('custom:video.test.event_two')).toEqual(0)
-      expect(instance.eventNames()).toStrictEqual([])
+      expect(instance.listenerCount('test.eventOne')).toEqual(0)
+      expect(instance.listenerCount('test.eventTwo')).toEqual(0)
+      expect(instance.baseEventNames()).toStrictEqual([])
     })
 
     it('should handle snake_case events', (done) => {
-      const serverEvent = 'video.event.server_side'
+      const serverEvent = 'event.server_side'
       const payload = { test: 1 }
-      instance.on('event.server_side', (data) => {
+      instance._on('event.server_side', (data) => {
         expect(data).toStrictEqual(payload)
 
         done()
       })
 
-      instance.emit(serverEvent, payload)
+      instance.baseEmitter.emit(serverEvent, payload)
     })
 
     it('should handle camelCase events', (done) => {
-      const serverEvent = 'video.event.server_side'
+      const serverEvent = 'event.serverSide'
       const payload = { test: 1 }
-      instance.on('event.serverSide', (data) => {
+      instance._on('event.serverSide', (data) => {
         expect(data).toStrictEqual(payload)
 
         done()
       })
 
-      instance.emit(serverEvent, payload)
+      instance.baseEmitter.emit(serverEvent, payload)
     })
   })
 })

--- a/packages/core/src/chat/BaseChat.ts
+++ b/packages/core/src/chat/BaseChat.ts
@@ -36,7 +36,6 @@ export type BaseChatApiEvents<T = BaseChatApiEventsHandlerMapping> = {
 }
 
 export class BaseChatConsumer extends BasePubSubConsumer<BaseChatApiEvents> {
-  protected override _eventsPrefix = PRODUCT_PREFIX_CHAT
   protected override subscribeMethod: JSONRPCSubscribeMethod = `${PRODUCT_PREFIX_CHAT}.subscribe`
 
   constructor(options: BaseComponentOptions<BaseChatApiEvents>) {

--- a/packages/core/src/pubSub/BasePubSub.ts
+++ b/packages/core/src/pubSub/BasePubSub.ts
@@ -49,7 +49,6 @@ const toInternalPubSubChannels = (
 export class BasePubSubConsumer<
   EventTypes extends EventEmitter.ValidEventTypes = BasePubSubApiEvents
 > extends ApplyEventListeners<EventTypes> {
-  protected override _eventsPrefix = PRODUCT_PREFIX_PUBSUB
   protected override subscribeMethod: JSONRPCSubscribeMethod = `${PRODUCT_PREFIX_PUBSUB}.subscribe`
 
   constructor(options: BaseComponentOptions<EventTypes>) {

--- a/packages/realtime-api/src/video/RoomSession.ts
+++ b/packages/realtime-api/src/video/RoomSession.ts
@@ -51,7 +51,6 @@ export interface RoomSessionConsumerOptions
   > {}
 
 export class RoomSessionConsumer extends BaseConsumer<RealTimeRoomApiEvents> {
-  protected _eventsPrefix = 'video' as const
   private _payload: RoomSessionPayload
 
   /** @internal */

--- a/packages/realtime-api/src/video/Video.ts
+++ b/packages/realtime-api/src/video/Video.ts
@@ -113,9 +113,6 @@ class VideoAPI extends AutoSubscribeConsumer<RealTimeVideoApiEvents> {
   }
 
   /** @internal */
-  protected _eventsPrefix = 'video' as const
-
-  /** @internal */
   protected subscribeParams = {
     get_initial_state: true,
   }

--- a/packages/realtime-api/src/voice/Call.ts
+++ b/packages/realtime-api/src/voice/Call.ts
@@ -94,8 +94,6 @@ export interface Call
 }
 
 export class CallConsumer extends ApplyEventListeners<RealTimeCallApiEvents> {
-  protected _eventsPrefix = 'calling' as const
-
   private _peer: Call | undefined
   private _payload: CallingCall
   private _connectPayload: CallingCallConnectEventParams

--- a/packages/realtime-api/src/voice/CallCollect.ts
+++ b/packages/realtime-api/src/voice/CallCollect.ts
@@ -40,7 +40,6 @@ export class CallCollectAPI
   extends ApplyEventListeners<CallCollectEventsHandlerMapping>
   implements VoiceCallCollectContract
 {
-  protected _eventsPrefix = 'calling' as const
   private _payload: CallingCallCollectEventParams
 
   constructor(options: CallCollectOptions) {

--- a/packages/realtime-api/src/voice/CallDetect.ts
+++ b/packages/realtime-api/src/voice/CallDetect.ts
@@ -35,7 +35,6 @@ export class CallDetectAPI
   extends ApplyEventListeners<CallDetectEventsHandlerMapping>
   implements VoiceCallDetectContract
 {
-  protected _eventsPrefix = 'calling' as const
   private _payload: CallingCallDetectEventParams
   private _waitForBeep: boolean
   private _waitingForReady: boolean

--- a/packages/realtime-api/src/voice/CallPlayback.ts
+++ b/packages/realtime-api/src/voice/CallPlayback.ts
@@ -37,8 +37,6 @@ export class CallPlaybackAPI
   extends ApplyEventListeners<CallPlaybackEventsHandlerMapping>
   implements VoiceCallPlaybackContract
 {
-  protected _eventsPrefix = 'calling' as const
-
   public _paused: boolean
   private _volume: number
   private _payload: CallingCallPlayEventParams

--- a/packages/realtime-api/src/voice/CallPrompt.ts
+++ b/packages/realtime-api/src/voice/CallPrompt.ts
@@ -40,7 +40,6 @@ export class CallPromptAPI
   extends ApplyEventListeners<CallPromptEventsHandlerMapping>
   implements VoiceCallPromptContract
 {
-  protected _eventsPrefix = 'calling' as const
   private _payload: CallingCallCollectEventParams
 
   constructor(options: CallPromptOptions) {

--- a/packages/realtime-api/src/voice/CallRecording.ts
+++ b/packages/realtime-api/src/voice/CallRecording.ts
@@ -34,7 +34,6 @@ export class CallRecordingAPI
   extends ApplyEventListeners<CallRecordingEventsHandlerMapping>
   implements VoiceCallRecordingContract
 {
-  protected _eventsPrefix = 'calling' as const
   private _payload: CallingCallRecordEventParams
 
   constructor(options: CallRecordingOptions) {

--- a/packages/realtime-api/src/voice/Voice.ts
+++ b/packages/realtime-api/src/voice/Voice.ts
@@ -199,9 +199,6 @@ export interface Voice
 
 /** @internal */
 class VoiceAPI extends ApplyEventListeners<VoiceClientApiEvents> {
-  /** @internal */
-  protected _eventsPrefix = 'calling' as const
-
   private _tag: string
 
   constructor(options: BaseComponentOptions<VoiceClientApiEvents>) {

--- a/packages/webrtc/src/BaseConnection.ts
+++ b/packages/webrtc/src/BaseConnection.ts
@@ -115,9 +115,6 @@ export class BaseConnection<EventTypes extends EventEmitter.ValidEventTypes>
   /** @internal */
   public doReinvite = false
 
-  /** @internal */
-  protected _eventsPrefix = 'video' as const
-
   private state: BaseConnectionState = 'new'
   private prevState: BaseConnectionState = 'new'
   private activeRTCPeerId: string


### PR DESCRIPTION
# Description

Cleanup the SDK by removing eventsPrefix from the namespaces

ref: https://github.com/signalwire/cloud-product/issues/7148

## Type of change

- [x] Internal refactoring
- [ ] Bug fix (bugfix - non-breaking)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Code snippets

In case of new feature or breaking changes, please include code snippets.
