### PR TITLE
Release 2023-08-08

### DIFF
--- a/.changeset/cold-jars-jog.md
+++ b/.changeset/cold-jars-jog.md
@@ -1,5 +1,0 @@
----
-'@signalwire/web-api': minor
----
-
-Expose the `validateRequest` function to validate SignalWire requests.

--- a/.changeset/great-ducks-explain.md
+++ b/.changeset/great-ducks-explain.md
@@ -1,5 +1,0 @@
----
-'@signalwire/node': major
----
-
-First release of the `@signalwire/node` SDK.

--- a/.changeset/hip-dancers-mix.md
+++ b/.changeset/hip-dancers-mix.md
@@ -1,5 +1,0 @@
----
-'@signalwire/web-api': major
----
-
-First release of the `@signalwire/web-api` SDK.

--- a/.changeset/spicy-moles-shout.md
+++ b/.changeset/spicy-moles-shout.md
@@ -1,5 +1,0 @@
----
-'@signalwire/core': patch
----
-
-Set peerDependencies for TS build

--- a/package-lock.json
+++ b/package-lock.json
@@ -14762,7 +14762,7 @@
     },
     "packages/core": {
       "name": "@signalwire/core",
-      "version": "3.18.1",
+      "version": "3.18.2",
       "license": "MIT",
       "dependencies": {
         "@redux-saga/core": "^1.2.3",
@@ -14795,11 +14795,11 @@
     },
     "packages/js": {
       "name": "@signalwire/js",
-      "version": "3.23.1",
+      "version": "3.23.2",
       "license": "MIT",
       "dependencies": {
-        "@signalwire/core": "3.18.1",
-        "@signalwire/webrtc": "3.10.0",
+        "@signalwire/core": "3.18.2",
+        "@signalwire/webrtc": "3.10.1",
         "jwt-decode": "^3.1.2"
       },
       "engines": {
@@ -14808,11 +14808,11 @@
     },
     "packages/node": {
       "name": "@signalwire/node",
-      "version": "0.0.1-beta.4",
+      "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
-        "@signalwire/realtime-api": "^3.4.0",
-        "@signalwire/web-api": "^0.0.1-beta.4"
+        "@signalwire/realtime-api": "^3.10.2",
+        "@signalwire/web-api": "^3.0.0"
       },
       "engines": {
         "node": ">=12"
@@ -14820,10 +14820,10 @@
     },
     "packages/realtime-api": {
       "name": "@signalwire/realtime-api",
-      "version": "3.10.1",
+      "version": "3.10.2",
       "license": "MIT",
       "dependencies": {
-        "@signalwire/core": "3.18.1",
+        "@signalwire/core": "3.18.2",
         "ws": "^8.13.0"
       },
       "devDependencies": {
@@ -14835,11 +14835,11 @@
     },
     "packages/web-api": {
       "name": "@signalwire/web-api",
-      "version": "0.0.1-beta.4",
+      "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
         "@signalwire/compatibility-api": "^3.1.3",
-        "@signalwire/core": "3.18.1",
+        "@signalwire/core": "3.18.2",
         "node-abort-controller": "^2.0.0",
         "node-fetch": "^2.6.1"
       },
@@ -14853,10 +14853,10 @@
     },
     "packages/webrtc": {
       "name": "@signalwire/webrtc",
-      "version": "3.10.0",
+      "version": "3.10.1",
       "license": "MIT",
       "dependencies": {
-        "@signalwire/core": "3.18.1",
+        "@signalwire/core": "3.18.2",
         "sdp": "^3.2.0"
       },
       "engines": {

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.18.2] - 2023-08-08
+
+### Changed
+
+- [#844](https://github.com/signalwire/signalwire-js/pull/844) [`af7072b7`](https://github.com/signalwire/signalwire-js/commit/af7072b7415940b9ef00bb2d35b3ed6b6ba979a5) - Set peerDependencies for TS build
+
 ## [3.18.1] - 2023-07-26
 
 ### Changed

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -12,4 +12,4 @@ The SignalWire Core package contains lower level objects and shared utilities fo
 
 ## License
 
-`@signalwire/core` is copyright © 2018-2022 [SignalWire](http://signalwire.com). It is free software, and may be redistributed under the terms specified in the [MIT-LICENSE](https://github.com/signalwire/signalwire-js/blob/master/LICENSE) file.
+`@signalwire/core` is copyright © 2018-2023 [SignalWire](http://signalwire.com). It is free software, and may be redistributed under the terms specified in the [MIT-LICENSE](https://github.com/signalwire/signalwire-js/blob/master/LICENSE) file.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,7 +3,7 @@
   "description": "Shared code for the SignalWire JS SDK",
   "author": "SignalWire Team <open.source@signalwire.com>",
   "license": "MIT",
-  "version": "3.18.1",
+  "version": "3.18.2",
   "main": "dist/index.node.js",
   "module": "dist/index.esm.js",
   "files": [

--- a/packages/js/CHANGELOG.md
+++ b/packages/js/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.23.2] - 2023-08-08
+
+### Dependencies
+
+- Updated dependencies [[`af7072b7`](https://github.com/signalwire/signalwire-js/commit/af7072b7415940b9ef00bb2d35b3ed6b6ba979a5)]:
+  - @signalwire/core@3.18.2
+  - @signalwire/webrtc@3.10.1
+
 ## [3.23.1] - 2023-07-26
 
 ### Changed

--- a/packages/js/README.md
+++ b/packages/js/README.md
@@ -37,4 +37,4 @@ SignalWire JavaScript SDK follows Semantic Versioning 2.0 as defined at <http://
 
 ## License
 
-`@signalwire/js` is copyright © 2018-2022 [SignalWire](http://signalwire.com). It is free software, and may be redistributed under the terms specified in the [MIT-LICENSE](https://github.com/signalwire/signalwire-js/blob/master/LICENSE) file.
+`@signalwire/js` is copyright © 2018-2023 [SignalWire](http://signalwire.com). It is free software, and may be redistributed under the terms specified in the [MIT-LICENSE](https://github.com/signalwire/signalwire-js/blob/master/LICENSE) file.

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -3,7 +3,7 @@
   "description": "SignalWire JS SDK",
   "author": "SignalWire Team <open.source@signalwire.com>",
   "license": "MIT",
-  "version": "3.23.1",
+  "version": "3.23.2",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",
   "unpkg": "dist/index.umd.js",
@@ -39,8 +39,8 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@signalwire/core": "3.18.1",
-    "@signalwire/webrtc": "3.10.0",
+    "@signalwire/core": "3.18.2",
+    "@signalwire/webrtc": "3.10.1",
     "jwt-decode": "^3.1.2"
   },
   "types": "dist/js/src/index.d.ts"

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -1,5 +1,21 @@
 # @signalwire/node
 
+All notable changes to this project will be documented in this file.
+
+This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [3.0.0] - 2023-08-08
+
+### Major Changes
+
+- [#846](https://github.com/signalwire/signalwire-js/pull/846) [`48b9341d`](https://github.com/signalwire/signalwire-js/commit/48b9341d11238f9842b854205a28d0f4dc3aee8d) - First release of the `@signalwire/node` SDK.
+
+### Patch Changes
+
+- Updated dependencies [[`48b9341d`](https://github.com/signalwire/signalwire-js/commit/48b9341d11238f9842b854205a28d0f4dc3aee8d), [`48b9341d`](https://github.com/signalwire/signalwire-js/commit/48b9341d11238f9842b854205a28d0f4dc3aee8d)]:
+  - @signalwire/web-api@1.0.0
+  - @signalwire/realtime-api@3.10.2
+
 ## 0.0.1-beta.4
 
 ### Patch Changes

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -13,7 +13,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Patch Changes
 
 - Updated dependencies [[`48b9341d`](https://github.com/signalwire/signalwire-js/commit/48b9341d11238f9842b854205a28d0f4dc3aee8d), [`48b9341d`](https://github.com/signalwire/signalwire-js/commit/48b9341d11238f9842b854205a28d0f4dc3aee8d)]:
-  - @signalwire/web-api@1.0.0
+  - @signalwire/web-api@3.0.0
   - @signalwire/realtime-api@3.10.2
 
 ## 0.0.1-beta.4

--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -8,4 +8,4 @@
 
 ## License
 
-`@signalwire/node` is copyright © 2018-2022 [SignalWire](http://signalwire.com). It is free software, and may be redistributed under the terms specified in the [MIT-LICENSE](https://github.com/signalwire/signalwire-js/blob/master/LICENSE) file.
+`@signalwire/node` is copyright © 2018-2023 [SignalWire](http://signalwire.com). It is free software, and may be redistributed under the terms specified in the [MIT-LICENSE](https://github.com/signalwire/signalwire-js/blob/master/LICENSE) file.

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@signalwire/realtime-api": "^3.10.2",
-    "@signalwire/web-api": "^1.0.0"
+    "@signalwire/web-api": "^3.0.0"
   },
   "types": "dist/node/src/index.d.ts"
 }

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -3,7 +3,7 @@
   "description": "SignalWire Node.js SDK",
   "author": "SignalWire Team <open.source@signalwire.com>",
   "license": "MIT",
-  "version": "0.0.1-beta.4",
+  "version": "3.0.0",
   "main": "dist/index.node.js",
   "exports": {
     "require": "./dist/index.node.js",
@@ -37,8 +37,8 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@signalwire/realtime-api": "^3.4.0",
-    "@signalwire/web-api": "^0.0.1-beta.4"
+    "@signalwire/realtime-api": "^3.10.2",
+    "@signalwire/web-api": "^1.0.0"
   },
   "types": "dist/node/src/index.d.ts"
 }

--- a/packages/realtime-api/CHANGELOG.md
+++ b/packages/realtime-api/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.10.2] - 2023-08-08
+
+### Dependencies
+
+- Updated dependencies [[`af7072b7`](https://github.com/signalwire/signalwire-js/commit/af7072b7415940b9ef00bb2d35b3ed6b6ba979a5)]:
+  - @signalwire/core@3.18.2
+
 ## [3.10.1] - 2023-07-26
 
 ### Fixed

--- a/packages/realtime-api/README.md
+++ b/packages/realtime-api/README.md
@@ -35,4 +35,4 @@ SignalWire RealTime SDK follows Semantic Versioning 2.0 as defined at <http://se
 
 ## License
 
-`@signalwire/realtime-api` is copyright © 2018-2022 [SignalWire](http://signalwire.com). It is free software, and may be redistributed under the terms specified in the [MIT-LICENSE](https://github.com/signalwire/signalwire-js/blob/master/LICENSE) file.
+`@signalwire/realtime-api` is copyright © 2018-2023 [SignalWire](http://signalwire.com). It is free software, and may be redistributed under the terms specified in the [MIT-LICENSE](https://github.com/signalwire/signalwire-js/blob/master/LICENSE) file.

--- a/packages/realtime-api/package.json
+++ b/packages/realtime-api/package.json
@@ -3,7 +3,7 @@
   "description": "SignalWire RealTime SDK for Node.js",
   "author": "SignalWire Team <open.source@signalwire.com>",
   "license": "MIT",
-  "version": "3.10.1",
+  "version": "3.10.2",
   "main": "dist/index.node.js",
   "exports": {
     "require": "./dist/index.node.js",
@@ -37,7 +37,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@signalwire/core": "3.18.1",
+    "@signalwire/core": "3.18.2",
     "ws": "^8.13.0"
   },
   "devDependencies": {

--- a/packages/web-api/CHANGELOG.md
+++ b/packages/web-api/CHANGELOG.md
@@ -1,5 +1,22 @@
 # @signalwire/web-api
 
+All notable changes to this project will be documented in this file.
+
+This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [3.0.0] - 2023-08-08
+
+### Added
+
+- [#846](https://github.com/signalwire/signalwire-js/pull/846) [`48b9341d`](https://github.com/signalwire/signalwire-js/commit/48b9341d11238f9842b854205a28d0f4dc3aee8d) - First release of the `@signalwire/web-api` SDK.
+
+- [#846](https://github.com/signalwire/signalwire-js/pull/846) [`48b9341d`](https://github.com/signalwire/signalwire-js/commit/48b9341d11238f9842b854205a28d0f4dc3aee8d) - Expose the `validateRequest` function to validate SignalWire requests.
+
+### Dependencies
+
+- Updated dependencies [[`af7072b7`](https://github.com/signalwire/signalwire-js/commit/af7072b7415940b9ef00bb2d35b3ed6b6ba979a5)]:
+  - @signalwire/core@3.18.2
+
 ## 0.0.1-beta.4
 
 ### Patch Changes

--- a/packages/web-api/README.md
+++ b/packages/web-api/README.md
@@ -8,4 +8,4 @@
 
 ## License
 
-`@signalwire/web-api` is copyright © 2018-2022 [SignalWire](http://signalwire.com). It is free software, and may be redistributed under the terms specified in the [MIT-LICENSE](https://github.com/signalwire/signalwire-js/blob/master/LICENSE) file.
+`@signalwire/web-api` is copyright © 2018-2023 [SignalWire](http://signalwire.com). It is free software, and may be redistributed under the terms specified in the [MIT-LICENSE](https://github.com/signalwire/signalwire-js/blob/master/LICENSE) file.

--- a/packages/web-api/package.json
+++ b/packages/web-api/package.json
@@ -3,7 +3,7 @@
   "description": "SignalWire Web-API SDK for Node.js",
   "author": "SignalWire Team <open.source@signalwire.com>",
   "license": "MIT",
-  "version": "0.0.1-beta.4",
+  "version": "3.0.0",
   "main": "dist/index.node.js",
   "exports": {
     "require": "./dist/index.node.js",
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@signalwire/compatibility-api": "^3.1.3",
-    "@signalwire/core": "3.18.1",
+    "@signalwire/core": "3.18.2",
     "node-abort-controller": "^2.0.0",
     "node-fetch": "^2.6.1"
   },

--- a/packages/webrtc/CHANGELOG.md
+++ b/packages/webrtc/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.10.1] - 2023-08-08
+
+### Dependencies
+
+- Updated dependencies [[`af7072b7`](https://github.com/signalwire/signalwire-js/commit/af7072b7415940b9ef00bb2d35b3ed6b6ba979a5)]:
+  - @signalwire/core@3.18.2
+
 ## [3.10.0] - 2023-07-26
 
 ### Added

--- a/packages/webrtc/README.md
+++ b/packages/webrtc/README.md
@@ -9,4 +9,4 @@ The SignalWire WebRTC package contains the various WebRTC object used by other S
 
 ## License
 
-`@signalwire/webrtc` is copyright © 2018-2022 [SignalWire](http://signalwire.com). It is free software, and may be redistributed under the terms specified in the [MIT-LICENSE](https://github.com/signalwire/signalwire-js/blob/master/LICENSE) file.
+`@signalwire/webrtc` is copyright © 2018-2023 [SignalWire](http://signalwire.com). It is free software, and may be redistributed under the terms specified in the [MIT-LICENSE](https://github.com/signalwire/signalwire-js/blob/master/LICENSE) file.

--- a/packages/webrtc/package.json
+++ b/packages/webrtc/package.json
@@ -3,7 +3,7 @@
   "description": "SignalWire WebRTC library",
   "author": "SignalWire Team <open.source@signalwire.com>",
   "license": "MIT",
-  "version": "3.10.0",
+  "version": "3.10.1",
   "main": "dist/cjs/webrtc/src/index.js",
   "module": "dist/mjs/webrtc/src/index.js",
   "files": [
@@ -37,7 +37,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@signalwire/core": "3.18.1",
+    "@signalwire/core": "3.18.2",
     "sdp": "^3.2.0"
   },
   "types": "dist/cjs/webrtc/src/index.d.ts"


### PR DESCRIPTION
# Description

Prepare release for all the SDKs. Note this include the first release of `@signalwire/node` and `@signalwire/web-api` starting as **3.0.0**.

## Type of change

- [x] Release
- [ ] Internal refactoring
- [ ] Bug fix (bugfix - non-breaking)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Code snippets

---
