### PR TITLE
Local video overlay with object-fit cover

### DIFF
--- a/.changeset/rotten-turkeys-tickle.md
+++ b/.changeset/rotten-turkeys-tickle.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/js': patch
+---
+
+Add `object-fit: cover` to the local video overlay element

--- a/packages/js/src/utils/videoElement.ts
+++ b/packages/js/src/utils/videoElement.ts
@@ -122,6 +122,7 @@ const makeLayoutChangedHandler =
         localVideo.style.width = '100%'
         localVideo.style.height = '100%'
         localVideo.style.pointerEvents = 'none'
+        localVideo.style.objectFit = 'cover'
 
         myLayer.appendChild(localVideo)
 


### PR DESCRIPTION
# Description

This PR adds `object-fit: cover` to the local video element to cover new layouts where the video is zoomed a bit.

## Type of change

- [ ] Internal refactoring
- [x] Bug fix (bugfix - non-breaking)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Code snippets

-- No changes
