### PR TITLE
Add result getter to CallDetect

### DIFF
--- a/.changeset/itchy-buckets-enjoy.md
+++ b/.changeset/itchy-buckets-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/realtime-api': minor
+---
+
+Add a new `result` getter to `CallDetect` to retrieve the result of the detector.

--- a/.changeset/sixty-lobsters-clap.md
+++ b/.changeset/sixty-lobsters-clap.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/core': patch
+---
+
+Update contract types for CallDetect adding a `result` getter.

--- a/packages/core/src/types/voiceCall.ts
+++ b/packages/core/src/types/voiceCall.ts
@@ -519,8 +519,10 @@ export interface VoiceCallDetectContract {
   readonly callId: string
   /** @ignore */
   readonly controlId: string
-  /** @ignore The result of the detection. */
+  /** @ignore The type of this detecting session. */
   readonly type?: CallingCallDetectType
+  /** @ignore The result value of the detection. */
+  readonly result: DetectorResult
 
   stop(): Promise<this>
   /**
@@ -1109,6 +1111,7 @@ export interface CallingCallSendDigitsEvent extends SwEvent {
  * 'calling.call.detect'
  */
 type CallingCallDetectState = 'finished' | 'error'
+/** @deprecated */
 export type CallingCallDetectEndState = CallingCallDetectState
 interface CallingCallDetectFax {
   type: 'fax'
@@ -1151,6 +1154,9 @@ export type Detector =
   | CallingCallDetectFax
   | CallingCallDetectMachine
   | CallingCallDetectDigit
+
+export type DetectorResult = Detector['params']['event']
+
 type CallingCallDetectType = Detector['type']
 export interface CallingCallDetectEventParams {
   node_id: string

--- a/packages/realtime-api/src/voice/Call.ts
+++ b/packages/realtime-api/src/voice/Call.ts
@@ -1029,7 +1029,7 @@ export class CallConsumer extends BaseConsumer<RealTimeCallApiEvents> {
       const controlId = uuid()
 
       // TODO: build params in a method
-      const { timeout, type, ...rest } = params
+      const { timeout, type, waitForBeep = false, ...rest } = params
 
       this.execute({
         method: 'calling.detect',
@@ -1051,7 +1051,7 @@ export class CallConsumer extends BaseConsumer<RealTimeCallApiEvents> {
               control_id: controlId,
               call_id: this.id,
               node_id: this.nodeId,
-              waitForBeep: params.waitForBeep ?? false,
+              waitForBeep,
             },
           })
           this.instanceMap.set<CallDetect>(controlId, detectInstance)


### PR DESCRIPTION
# Description

This PR contains one fix and one improvement for our AMD method:

1. Fix an issue when using `waitForBeep`
2. Expose a new `detector.result` getter to retrieve the result of the Detector.

## Type of change

- [ ] Internal refactoring
- [x] Bug fix (bugfix - non-breaking)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Code snippets

```ts
const detect = await call.amd()
await detect.ended()

console.log(detect.type, detect.result)

// Type represent the current detector type (machine / fax / digit)
// Result contains the detected value (could be a DTMF or MACHINE / HUMAN / READY / NOT_READY / UNKNOWN or error) 
```
