### PR TITLE
Add support for record pause and resume

### DIFF
--- a/.changeset/six-islands-invite.md
+++ b/.changeset/six-islands-invite.md
@@ -1,0 +1,6 @@
+---
+'@signalwire/realtime-api': minor
+'@signalwire/core': minor
+---
+
+Add support for recording pause and resume

--- a/internal/e2e-realtime-api/src/voiceRecording.test.ts
+++ b/internal/e2e-realtime-api/src/voiceRecording.test.ts
@@ -88,7 +88,11 @@ const handler = () => {
           text: 'Hello, this is the callee side. How can i help you?',
         })
 
+        await recording.pause()
+
         await playback.ended()
+
+        await recording.resume()
 
         // Stop the recording using terminator
         await call.sendDigits('#')

--- a/internal/e2e-realtime-api/src/voiceRecording.test.ts
+++ b/internal/e2e-realtime-api/src/voiceRecording.test.ts
@@ -15,8 +15,8 @@ const CALL_RECORDING_GETTERS = [
 ]
 const handler = () => {
   return new Promise<number>(async (resolve, reject) => {
-    // Expect exact 10 tests
-    tap.plan(10)
+    // Expect exact 12 tests
+    tap.plan(12)
 
     const client = new Voice.Client({
       host: process.env.RELAY_HOST || 'relay.swire.io',
@@ -53,6 +53,14 @@ const handler = () => {
 
         // Resolve the answer promise to inform the caller
         waitForTheAnswerResolve()
+
+        call.on('recording.updated', (recording) => {
+          tap.match(
+            recording.state,
+            /paused|recording/,
+            'Outbound - Recording has updated'
+          )
+        })
 
         call.on('recording.ended', (recording) => {
           tap.hasProps(

--- a/packages/core/src/types/voiceCall.ts
+++ b/packages/core/src/types/voiceCall.ts
@@ -493,6 +493,8 @@ export interface VoiceCallRecordingContract {
   /** @ignore */
   readonly record: CallingCallRecordEventParams['record'] | undefined
 
+  pause(params?: CallingCallRecordPauseMethodParams): Promise<this>
+  resume(): Promise<this>
   stop(): Promise<this>
   ended(): Promise<this>
 }
@@ -948,6 +950,10 @@ export interface CallingCallRecordEventParams {
 export interface CallingCallRecordEvent extends SwEvent {
   event_type: ToInternalVoiceEvent<CallRecord>
   params: CallingCallRecordEventParams
+}
+
+export interface CallingCallRecordPauseMethodParams {
+  behavior?: 'silence' | 'skip'
 }
 
 /**
@@ -1502,6 +1508,8 @@ export type VoiceCallJSONRPCMethod =
   | 'calling.play.volume'
   | 'calling.play.stop'
   | 'calling.record'
+  | 'calling.record.pause'
+  | 'calling.record.resume'
   | 'calling.record.stop'
   | 'calling.play_and_collect'
   | 'calling.play_and_collect.stop'

--- a/packages/core/src/types/voiceCall.ts
+++ b/packages/core/src/types/voiceCall.ts
@@ -929,11 +929,15 @@ export interface CallingCallPlayEvent extends SwEvent {
 /**
  * 'calling.call.record'
  */
-export type CallingCallRecordState = 'recording' | 'no_input' | 'finished'
+export type CallingCallRecordState =
+  | 'recording'
+  | 'paused'
+  | 'no_input'
+  | 'finished'
 
 export type CallingCallRecordEndState = Exclude<
   CallingCallRecordState,
-  'recording'
+  'recording' | 'paused'
 >
 
 export interface CallingCallRecordEventParams {

--- a/packages/realtime-api/src/voice/CallRecording.test.ts
+++ b/packages/realtime-api/src/voice/CallRecording.test.ts
@@ -18,7 +18,7 @@ describe('CallRecording', () => {
       instance.execute = jest.fn()
     })
 
-    it('should control an active playback', async () => {
+    it('should control an active recording', async () => {
       const baseExecuteParams = {
         method: '',
         params: {
@@ -27,6 +27,33 @@ describe('CallRecording', () => {
           control_id: 'control_id',
         },
       }
+
+      await instance.pause()
+      // @ts-expect-error
+      expect(instance.execute).toHaveBeenLastCalledWith({
+        method: 'calling.record.pause',
+        params: {
+          ...baseExecuteParams.params,
+          behavior: 'silence',
+        },
+      })
+
+      await instance.pause({ behavior: 'skip' })
+      // @ts-expect-error
+      expect(instance.execute).toHaveBeenLastCalledWith({
+        method: 'calling.record.pause',
+        params: {
+          ...baseExecuteParams.params,
+          behavior: 'skip',
+        },
+      })
+
+      await instance.resume()
+      // @ts-expect-error
+      expect(instance.execute).toHaveBeenLastCalledWith({
+        ...baseExecuteParams,
+        method: 'calling.record.resume',
+      })
 
       await instance.stop()
       // @ts-expect-error

--- a/packages/realtime-api/src/voice/CallRecording.ts
+++ b/packages/realtime-api/src/voice/CallRecording.ts
@@ -6,6 +6,7 @@ import {
   CallingCallRecordEventParams,
   EventEmitter,
   BaseConsumer,
+  CallingCallRecordPauseMethodParams,
 } from '@signalwire/core'
 
 /**
@@ -32,12 +33,14 @@ export class CallRecordingAPI
   extends BaseConsumer<CallRecordingEventsHandlerMapping>
   implements VoiceCallRecordingContract
 {
+  public _paused: boolean
   private _payload: CallingCallRecordEventParams
 
   constructor(options: CallRecordingOptions) {
     super(options)
 
     this._payload = options.payload
+    this._paused = false
   }
 
   get id() {
@@ -79,6 +82,35 @@ export class CallRecordingAPI
   /** @internal */
   protected setPayload(payload: CallingCallRecordEventParams) {
     this._payload = payload
+  }
+
+  async pause(params?: CallingCallRecordPauseMethodParams) {
+    const { behavior = 'silence' } = params || {}
+
+    await this.execute({
+      method: 'calling.record.pause',
+      params: {
+        node_id: this.nodeId,
+        call_id: this.callId,
+        control_id: this.controlId,
+        behavior,
+      },
+    })
+
+    return this
+  }
+
+  async resume() {
+    await this.execute({
+      method: 'calling.record.resume',
+      params: {
+        node_id: this.nodeId,
+        call_id: this.callId,
+        control_id: this.controlId,
+      },
+    })
+
+    return this
   }
 
   async stop() {

--- a/packages/realtime-api/src/voice/workers/voiceCallRecordWorker.ts
+++ b/packages/realtime-api/src/voice/workers/voiceCallRecordWorker.ts
@@ -34,7 +34,18 @@ export const voiceCallRecordWorker = function* (
 
   switch (payload.state) {
     case 'recording': {
-      callInstance.emit('recording.started', recordingInstance)
+      const type = recordingInstance._paused
+        ? 'recording.updated'
+        : 'recording.started'
+      recordingInstance._paused = false
+
+      callInstance.emit(type, recordingInstance)
+      break
+    }
+    // @ts-expect-error
+    case 'paused': {
+      recordingInstance._paused = true
+      callInstance.emit('playback.updated', recordingInstance)
       break
     }
     case 'no_input':

--- a/packages/realtime-api/src/voice/workers/voiceCallRecordWorker.ts
+++ b/packages/realtime-api/src/voice/workers/voiceCallRecordWorker.ts
@@ -42,10 +42,9 @@ export const voiceCallRecordWorker = function* (
       callInstance.emit(type, recordingInstance)
       break
     }
-    // @ts-expect-error
     case 'paused': {
       recordingInstance._paused = true
-      callInstance.emit('playback.updated', recordingInstance)
+      callInstance.emit('recording.updated', recordingInstance)
       break
     }
     case 'no_input':


### PR DESCRIPTION
# Description

Allow users to pause and resume call recording. 

Ref: https://github.com/signalwire/cloud-product/issues/7799

## Type of change

- [ ] Internal refactoring
- [ ] Bug fix (bugfix - non-breaking)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Code snippets

```js
call.on('recording.started', (recording) => {})

call.on('recording.updated', (recording) => {})

call.on('recording.ended', (recording) => {})

call.on('recording.failed', (recording) => {})

// Start the recording
const recording = await call.recordAudio({
  initialTimeout: 0,
  direction: 'both',
  terminators: '#',
})
...
await recording.pause({ behavior: "skip" }) // Optional parameters
...
await recording.resume()
...
await recording.stop()
```
