### PR TITLE
Add alias 'topics' for 'contexts'

### DIFF
--- a/.changeset/fresh-steaks-join.md
+++ b/.changeset/fresh-steaks-join.md
@@ -1,0 +1,6 @@
+---
+'@signalwire/realtime-api': minor
+'@signalwire/core': minor
+---
+
+Add alias 'topics' for 'contexts'

--- a/internal/e2e-realtime-api/src/voice.test.ts
+++ b/internal/e2e-realtime-api/src/voice.test.ts
@@ -8,7 +8,7 @@ const handler = () => {
       host: process.env.RELAY_HOST || 'relay.swire.io',
       project: process.env.RELAY_PROJECT as string,
       token: process.env.RELAY_TOKEN as string,
-      contexts: [process.env.VOICE_CONTEXT as string],
+      topics: [process.env.VOICE_CONTEXT as string],
       // logLevel: "trace",
       debug: {
         logWsTraffic: true,

--- a/packages/core/src/BaseSession.ts
+++ b/packages/core/src/BaseSession.ts
@@ -348,7 +348,9 @@ export class BaseSession {
     if (this._relayProtocolIsValid()) {
       params.protocol = this.relayProtocol
     }
-    if (this.options.contexts?.length) {
+    if (this.options.topics?.length) {
+      params.contexts = this.options.topics
+    } else if (this.options.contexts?.length) {
       params.contexts = this.options.contexts
     }
     this._rpcConnectResult = await this.execute(RPCConnect(params))

--- a/packages/core/src/RPCMessages/RPCConnect.ts
+++ b/packages/core/src/RPCMessages/RPCConnect.ts
@@ -10,6 +10,7 @@ export type RPCConnectParams = {
   protocol?: string
   authorization_state?: string
   contexts?: string[]
+  topics?: string[]
 }
 
 export const DEFAULT_CONNECT_VERSION = {

--- a/packages/core/src/utils/interfaces.ts
+++ b/packages/core/src/utils/interfaces.ts
@@ -97,6 +97,8 @@ export interface SessionOptions {
   token: string
   /** SignalWire contexts, e.g. 'home', 'office'.. */
   contexts?: string[]
+  /** An alias for contexts - Topics has more priority over contexts */
+  topics?: string[]
   // From `LogLevelDesc` of loglevel to simplify our docs
   /** logging level */
   logLevel?: 'trace' | 'debug' | 'info' | 'warn' | 'error' | 'silent'

--- a/packages/realtime-api/src/voice/VoiceClient.ts
+++ b/packages/realtime-api/src/voice/VoiceClient.ts
@@ -7,10 +7,15 @@ interface VoiceClient extends Voice {
   new (opts: VoiceClientOptions): this
 }
 
-export interface VoiceClientOptions
-  extends Omit<UserOptions, '_onRefreshToken'> {
-  contexts: string[]
-}
+export type VoiceClientOptions = Omit<UserOptions, '_onRefreshToken'> &
+  (
+    | {
+        contexts: string[]
+      }
+    | {
+        topics: string[]
+      }
+  )
 
 /**
  * You can use instances of this class to initiate or receive calls. Please see

--- a/packages/realtime-api/src/voice/workers/voiceCallReceiveWorker.ts
+++ b/packages/realtime-api/src/voice/workers/voiceCallReceiveWorker.ts
@@ -14,8 +14,8 @@ export const voiceCallReceiveWorker = function* (
   } = options
 
   // Contexts is required
-  const { contexts = [] } = client?.options ?? {}
-  if (!contexts.length) {
+  const { contexts = [], topics = [] } = client?.options ?? {}
+  if (!contexts.length && !topics.length) {
     throw new Error('Invalid contexts to receive inbound calls')
   }
 


### PR DESCRIPTION
# Description

Allow users to pass `topics` as an alias of `contexts`.

ref: https://github.com/signalwire/cloud-product/issues/7764

## Type of change

- [ ] Internal refactoring
- [ ] Bug fix (bugfix - non-breaking)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Code snippets

```js
const client = new Voice.Client({
      host: process.env.RELAY_HOST || 'relay.swire.io',
      project: process.env.RELAY_PROJECT as string,
      token: process.env.RELAY_TOKEN as string,
      topics: [process.env.VOICE_CONTEXT as string],
      // contexts: [process.env.VOICE_CONTEXT as string],
})
```

When both topics and contexts are passed, topics will have more priority.
