### PR TITLE
Emit `destroy` for inbound calls when the caller cancel the dial

### DIFF
--- a/.changeset/yellow-pugs-call.md
+++ b/.changeset/yellow-pugs-call.md
@@ -1,0 +1,7 @@
+---
+'@sw-internal/playground-js': patch
+'@signalwire/webrtc': patch
+'@signalwire/js': patch
+---
+
+Expose `destroy` event for inbound calls in Call Fabric to handle cases where the caller cancel the dial before the callee answers.

--- a/internal/playground-js/src/fabric-callee/index.js
+++ b/internal/playground-js/src/fabric-callee/index.js
@@ -206,7 +206,7 @@ window.tapPushNotification = async () => {
       case 'inboundCall':
         window.__call = resultObject
         window.__call.on('destroy', () => {
-          console.warn('Call got cancelled!!')
+          console.warn('Inbound Call got cancelled!!')
         })
         enableCallButtons()
         connectStatus.innerHTML = 'Ringing...'

--- a/internal/playground-js/src/fabric-callee/index.js
+++ b/internal/playground-js/src/fabric-callee/index.js
@@ -205,6 +205,9 @@ window.tapPushNotification = async () => {
     switch (resultType) {
       case 'inboundCall':
         window.__call = resultObject
+        window.__call.on('destroy', () => {
+          console.warn('Call got cancelled!!')
+        })
         enableCallButtons()
         connectStatus.innerHTML = 'Ringing...'
         break

--- a/internal/playground-js/src/fabric/index.js
+++ b/internal/playground-js/src/fabric/index.js
@@ -245,12 +245,12 @@ window.connect = async () => {
     nodeId: steeringId,
   })
 
+  window.__call = call
+  roomObj = call
+
   await call.start()
 
   console.debug('Call Obj', call)
-
-  window.__call = call
-  roomObj = call
 
   const joinHandler = (params) => {
     console.debug('>> room.joined', params)

--- a/internal/playground-js/vite.config.ts
+++ b/internal/playground-js/vite.config.ts
@@ -87,6 +87,14 @@ export default defineConfig({
         videoManager: path.resolve(__dirname, 'src/videoManager/index.html'),
         fabricHttp: path.resolve(__dirname, 'src/fabric-http/index.html'),
         fabricCallee: path.resolve(__dirname, 'src/fabric-callee/index.html'),
+        sw: path.resolve(__dirname, 'src/fabric-callee/sw.js'),
+      },
+      output: {
+        entryFileNames: (assetInfo) => {
+          return ['sw'].includes(assetInfo.name)
+            ? 'src/fabric-callee/[name].js' // put service worker in the correct folder
+            : 'assets/[name]-[hash].js' // others in `assets/` as default
+        },
       },
     },
   },

--- a/packages/js/src/fabric/WSClient.ts
+++ b/packages/js/src/fabric/WSClient.ts
@@ -105,7 +105,7 @@ export class WSClient {
           return new Promise(async (resolve, reject) => {
             try {
               // @ts-expect-error
-              call.emitter.once('verto.display', () => resolve(call))
+              call.once('verto.display', () => resolve(call))
               call.once('room.subscribed', () => resolve(call))
 
               // // @ts-expect-error

--- a/packages/js/src/fabric/WSClient.ts
+++ b/packages/js/src/fabric/WSClient.ts
@@ -37,6 +37,7 @@ export class WSClient {
   }
 
   connect() {
+    this.logger.info('>>> Connect??')
     // @ts-ignore
     this.wsClient.runWorker('WSClientWorker', {
       worker: WSClientWorker,
@@ -107,6 +108,13 @@ export class WSClient {
               call.emitter.once('verto.display', () => resolve(call))
               call.once('room.subscribed', () => resolve(call))
 
+              // // @ts-expect-error
+              // call.updateMediaOptions({
+              //   audio: true,
+              //   video: false,
+              //   negotiateAudio: true,
+              //   negotiateVideo: false,
+              // })
               await call.join()
             } catch (error) {
               getLogger().error('WSClient call start', error)

--- a/packages/js/src/fabric/WSClient.ts
+++ b/packages/js/src/fabric/WSClient.ts
@@ -37,7 +37,6 @@ export class WSClient {
   }
 
   connect() {
-    this.logger.info('>>> Connect??')
     // @ts-ignore
     this.wsClient.runWorker('WSClientWorker', {
       worker: WSClientWorker,
@@ -108,13 +107,6 @@ export class WSClient {
               call.once('verto.display', () => resolve(call))
               call.once('room.subscribed', () => resolve(call))
 
-              // // @ts-expect-error
-              // call.updateMediaOptions({
-              //   audio: true,
-              //   video: false,
-              //   negotiateAudio: true,
-              //   negotiateVideo: false,
-              // })
               await call.join()
             } catch (error) {
               getLogger().error('WSClient call start', error)

--- a/packages/webrtc/src/BaseConnection.ts
+++ b/packages/webrtc/src/BaseConnection.ts
@@ -654,8 +654,6 @@ export class BaseConnection<EventTypes extends EventEmitter.ValidEventTypes>
       this.direction = 'outbound'
       this.peer = this._buildPeer('offer')
       try {
-        this.runRTCPeerWorkers(this.peer.uuid)
-
         await this.peer.start()
         resolve(this as any as T)
       } catch (error) {
@@ -673,8 +671,6 @@ export class BaseConnection<EventTypes extends EventEmitter.ValidEventTypes>
         this.peer = this._buildPeer('answer')
       }
       try {
-        this.runRTCPeerWorkers(this.peer.uuid)
-
         await this.peer.start()
         resolve(this as any as T)
       } catch (error) {

--- a/packages/webrtc/src/BaseConnection.ts
+++ b/packages/webrtc/src/BaseConnection.ts
@@ -962,7 +962,7 @@ export class BaseConnection<EventTypes extends EventEmitter.ValidEventTypes>
   setState(state: BaseConnectionState) {
     this.prevState = this.state
     this.state = state
-    this.logger.debug(
+    this.logger.trace(
       `Call ${this.id} state change from ${this.prevState} to ${this.state}`
     )
 
@@ -1001,7 +1001,7 @@ export class BaseConnection<EventTypes extends EventEmitter.ValidEventTypes>
 
   /** @internal */
   public onVertoBye = (params: OnVertoByeParams) => {
-    this.logger.info('onVertoBye', params)
+    this.logger.debug('onVertoBye', params)
     const {
       rtcPeerId,
       byeCause = 'NORMAL_CLEARING',
@@ -1031,7 +1031,7 @@ export class BaseConnection<EventTypes extends EventEmitter.ValidEventTypes>
 
     // Set state to hangup only if the rtcPeer is the current one
     if (this.activeRTCPeerId === rtcPeer?.uuid) {
-      this.logger.info('onVertoBye go hangup')
+      this.logger.debug('onVertoBye go hangup')
       this.setState('hangup')
     }
   }

--- a/packages/webrtc/src/RTCPeer.ts
+++ b/packages/webrtc/src/RTCPeer.ts
@@ -453,7 +453,7 @@ export default class RTCPeer<EventTypes extends EventEmitter.ValidEventTypes> {
 
   onRemoteBye({ code, message }: { code: string; message: string }) {
     // It could be a negotiation/signaling error so reject the "startMethod"
-    this._rejectStartMethod({
+    this._rejectStartMethod?.({
       code,
       message,
     })


### PR DESCRIPTION
# Description

This PR add the `destroy` event to handle the case where the caller cancel the dial before the callee answer it.

It also fixes a bug with GH Pages and the CI build for the ServiceWorker.

## Type of change

- [x] Internal refactoring
- [ ] Bug fix (bugfix - non-breaking)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Code snippets


