### PR TITLE
Expose `detect_interruptions` and handle `beep` in the detect events

### DIFF
--- a/.changeset/eighty-otters-drive.md
+++ b/.changeset/eighty-otters-drive.md
@@ -1,0 +1,6 @@
+---
+'@signalwire/realtime-api': minor
+'@signalwire/core': minor
+---
+
+Expose `detect_interruptions` params for detect methods and handle `beep` in the detect events

--- a/packages/core/src/types/voiceCall.ts
+++ b/packages/core/src/types/voiceCall.ts
@@ -374,8 +374,10 @@ export interface VoiceCallDetectMachineParams
   type: 'machine'
   initialTimeout?: number
   endSilenceTimeout?: number
+  machineReadyTimeout?: number
   machineVoiceThreshold?: number
   machineWordsThreshold?: number
+  detectInterruptions?: boolean
 }
 
 export interface VoiceCallDetectFaxParams extends VoiceCallDetectBaseParams {
@@ -1122,6 +1124,7 @@ interface CallingCallDetectFax {
 interface CallingCallDetectMachine {
   type: 'machine'
   params: {
+    beep: boolean
     event:
       | 'MACHINE'
       | 'HUMAN'

--- a/packages/realtime-api/src/voice/CallDetect.ts
+++ b/packages/realtime-api/src/voice/CallDetect.ts
@@ -35,7 +35,6 @@ export class CallDetectAPI
 {
   private _payload: CallingCallDetectEventParams
   private _waitForBeep: boolean
-  private _waitingForReady: boolean
   private _result: DetectorResult = 'UNKNOWN'
 
   constructor(options: CallDetectOptions) {
@@ -43,7 +42,6 @@ export class CallDetectAPI
 
     this._payload = options.payload
     this._waitForBeep = options.payload.waitForBeep
-    this._waitingForReady = false
   }
 
   get id() {
@@ -78,12 +76,11 @@ export class CallDetectAPI
     return this._waitForBeep
   }
 
-  get waitingForReady() {
-    return this._waitingForReady
-  }
-
-  set waitingForReady(ready: boolean) {
-    this._waitingForReady = ready
+  get beep() {
+    if (this.detect?.params.event === 'MACHINE') {
+      return this.detect.params.beep
+    }
+    return undefined
   }
 
   /** @internal */

--- a/packages/realtime-api/src/voice/CallDetect.ts
+++ b/packages/realtime-api/src/voice/CallDetect.ts
@@ -78,7 +78,7 @@ export class CallDetectAPI
 
   get beep() {
     if (this.detect?.params.event === 'MACHINE') {
-      return this.detect.params.beep
+      return Boolean(this.detect.params.beep)
     }
     return undefined
   }

--- a/packages/realtime-api/src/voice/workers/voiceCallDetectWorker.ts
+++ b/packages/realtime-api/src/voice/workers/voiceCallDetectWorker.ts
@@ -35,10 +35,8 @@ export const voiceCallDetectWorker = function* (
   const { detect } = payload
   if (!detect) return
 
-  const {
-    type,
-    params: { event },
-  } = detect
+  const { type, params } = detect
+  const { event } = params
 
   switch (event) {
     case 'finished':
@@ -60,15 +58,12 @@ export const voiceCallDetectWorker = function* (
 
   switch (type) {
     case 'machine':
-      if (detectInstance.waitingForReady && event === 'READY') {
+      if (params.beep && detectInstance.waitForBeep) {
         // @ts-expect-error
         callInstance.emit('detect.ended', detectInstance)
 
         // To resolve the ended() promise in CallDetect
         detectInstance.emit('detect.ended', detectInstance)
-      }
-      if (detectInstance.waitForBeep) {
-        detectInstance.waitingForReady = true
       }
       break
     case 'digit':


### PR DESCRIPTION
# Description

Allow user to pass `detect_interruptions` params to detect methods and handle `beep` detection in case of answering machine.

ref: https://github.com/signalwire/cloud-product/issues/7519 

## Type of change

- [ ] Internal refactoring
- [ ] Bug fix (bugfix - non-breaking)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Code snippets

```js
// Start the detector
const detector = await call.amd({ detectInterruptions: true|false })
```
