### PR TITLE
Add support for `lock` and `unlock` video RoomSessions

### DIFF
--- a/.changeset/curly-peaches-do.md
+++ b/.changeset/curly-peaches-do.md
@@ -1,0 +1,6 @@
+---
+'@sw-internal/e2e-realtime-api': patch
+'@sw-internal/e2e-js': patch
+---
+
+Update E2E tests for lock unlock rooms

--- a/.changeset/lemon-icons-compete.md
+++ b/.changeset/lemon-icons-compete.md
@@ -1,0 +1,7 @@
+---
+'@signalwire/realtime-api': minor
+'@signalwire/core': minor
+'@signalwire/js': minor
+---
+
+Add support for `lock` and `unlock` RoomSessions.

--- a/internal/e2e-js/tests/roomSessionLockUnlock.spec.ts
+++ b/internal/e2e-js/tests/roomSessionLockUnlock.spec.ts
@@ -1,0 +1,96 @@
+import { test, expect } from '../fixtures'
+import type { Video } from '@signalwire/js'
+import {
+  SERVER_URL,
+  createTestRoomSession,
+  randomizeRoomName,
+  expectRoomJoined,
+  expectMCUVisible,
+} from '../utils'
+
+test.describe('RoomSession Lock/Unlock', () => {
+  test.skip('should join a room and be able to lock/unlock it', async ({
+    createCustomPage,
+  }) => {
+    const page = await createCustomPage({ name: 'lock-unlock' })
+    await page.goto(SERVER_URL)
+
+    const roomName = randomizeRoomName('lock-unlock-e2e')
+    const permissions = ['room.lock', 'room.unlock']
+    await createTestRoomSession(page, {
+      vrt: {
+        room_name: roomName,
+        user_name: 'lockers',
+        auto_create_room: true,
+        permissions,
+      },
+      initialEvents: ['room.updated'],
+    })
+
+    // --------------- Joining the room ---------------
+    const joinParams = await expectRoomJoined(page)
+
+    expect(joinParams.room).toBeDefined()
+    expect(joinParams.room_session).toBeDefined()
+    expect(joinParams.room.name).toBe(roomName)
+    // Room locked must be false
+    expect(joinParams.room_session.locked).toBe(false)
+
+    // Checks that the video is visible
+    await expectMCUVisible(page)
+
+    // --------------- Lock the room ---------------
+    await page.evaluate(
+      async ({ roomSessionId }) => {
+        // @ts-expect-error
+        const roomObj: Video.RoomSession = window._roomObj
+
+        const roomLocked = new Promise((resolve) => {
+          roomObj.on('room.updated', (params) => {
+            if (
+              params.room_session.id === roomSessionId &&
+              params.room_session.locked === true
+            ) {
+              resolve(true)
+            }
+          })
+        })
+
+        await roomObj.lock()
+
+        return roomLocked
+      },
+      { roomSessionId: joinParams.room_session.id }
+    )
+
+    /**
+     * Check the MCU content??
+     */
+
+    await page.waitForTimeout(1000)
+
+    // --------------- Unlock the room ---------------
+    await page.evaluate(
+      async ({ roomSessionId }) => {
+        // @ts-expect-error
+        const roomObj: Video.RoomSession = window._roomObj
+
+        const roomUnlocked = new Promise((resolve) => {
+          roomObj.on('room.updated', (params) => {
+            if (
+              params.room_session.id === roomSessionId &&
+              params.room_session.locked === false
+            ) {
+              resolve(true)
+            }
+          })
+        })
+
+        await roomObj.unlock()
+
+        return roomUnlocked
+      },
+      { roomSessionId: joinParams.room_session.id }
+    )
+  })
+})

--- a/internal/e2e-js/tests/roomSessionLockUnlock.spec.ts
+++ b/internal/e2e-js/tests/roomSessionLockUnlock.spec.ts
@@ -9,7 +9,7 @@ import {
 } from '../utils'
 
 test.describe('RoomSession Lock/Unlock', () => {
-  test.skip('should join a room and be able to lock/unlock it', async ({
+  test('should join a room and be able to lock/unlock it', async ({
     createCustomPage,
   }) => {
     const page = await createCustomPage({ name: 'lock-unlock' })

--- a/packages/core/src/rooms/methods.ts
+++ b/packages/core/src/rooms/methods.ts
@@ -142,6 +142,12 @@ export const showVideoMuted = createRoomMethod<BaseRPCResult, void>(
     transformResolve: baseCodeTransform,
   }
 )
+export const lock = createRoomMethod<BaseRPCResult, void>('video.lock', {
+  transformResolve: baseCodeTransform,
+})
+export const unlock = createRoomMethod<BaseRPCResult, void>('video.unlock', {
+  transformResolve: baseCodeTransform,
+})
 
 export const setHideVideoMuted: RoomMethodDescriptor<void, boolean> = {
   value: function (value) {
@@ -483,6 +489,9 @@ export type DeleteMeta = ReturnType<typeof deleteMeta.value>
 
 export type GetStreams = ReturnType<typeof getStreams.value>
 export type StartStream = ReturnType<typeof startStream.value>
+
+export type Lock = ReturnType<typeof lock.value>
+export type Unlock = ReturnType<typeof unlock.value>
 // End Room Methods
 
 /**

--- a/packages/core/src/types/videoRoomSession.ts
+++ b/packages/core/src/types/videoRoomSession.ts
@@ -83,6 +83,8 @@ export interface VideoRoomSessionContract {
   previewUrl?: string
   /** Current layout name used in the room. */
   layoutName: string
+  /** Whether the room is locked */
+  locked: boolean
   /** Metadata associated to this room session. */
   meta?: Record<string, unknown>
   /**
@@ -728,6 +730,8 @@ export interface VideoRoomSessionContract {
    * ```
    */
   startStream(params: Rooms.StartStreamParams): Promise<Rooms.RoomSessionStream>
+  lock(): Rooms.Lock
+  unlock(): Rooms.Unlock
 }
 
 /**

--- a/packages/core/src/utils/interfaces.ts
+++ b/packages/core/src/utils/interfaces.ts
@@ -336,6 +336,8 @@ export type RoomMethod =
   | 'video.stream.list'
   | 'video.stream.start'
   | 'video.stream.stop'
+  | 'video.lock'
+  | 'video.unlock'
 
 export interface WebSocketClient {
   addEventListener: WebSocket['addEventListener']

--- a/packages/js/src/BaseRoomSession.test.ts
+++ b/packages/js/src/BaseRoomSession.test.ts
@@ -73,6 +73,8 @@ describe('Room Object', () => {
     expect(room.setLayout).toBeDefined()
     expect(room.hideVideoMuted).toBeDefined()
     expect(room.showVideoMuted).toBeDefined()
+    expect(room.lock).toBeDefined()
+    expect(room.unlock).toBeDefined()
     expect(room.getRecordings).toBeDefined()
     expect(room.startRecording).toBeDefined()
     expect(room.getPlaybacks).toBeDefined()

--- a/packages/js/src/BaseRoomSession.ts
+++ b/packages/js/src/BaseRoomSession.ts
@@ -490,6 +490,8 @@ export const RoomSessionAPI = extendComponent<
   demote: Rooms.demote,
   getStreams: Rooms.getStreams,
   startStream: Rooms.startStream,
+  lock: Rooms.lock,
+  unlock: Rooms.unlock,
 })
 
 type RoomSessionObjectEventsHandlerMapping = RoomSessionObjectEvents &

--- a/packages/js/src/RoomSession.ts
+++ b/packages/js/src/RoomSession.ts
@@ -55,6 +55,8 @@ export const UNSAFE_PROP_ACCESS = [
   'deleteMemberMeta',
   'promote',
   'demote',
+  'lock',
+  'unlock',
 ]
 
 /**

--- a/packages/realtime-api/src/video/RoomSession.ts
+++ b/packages/realtime-api/src/video/RoomSession.ts
@@ -105,6 +105,10 @@ export class RoomSessionConsumer extends BaseConsumer<RealTimeRoomApiEvents> {
     return this._payload.room_session.recording
   }
 
+  get locked() {
+    return this._payload.room_session.locked
+  }
+
   get eventChannel() {
     return this._payload.room_session.event_channel
   }
@@ -272,6 +276,8 @@ export const RoomSessionAPI = extendComponent<
   demote: Rooms.demote,
   getStreams: Rooms.getStreams,
   startStream: Rooms.startStream,
+  lock: Rooms.lock,
+  unlock: Rooms.unlock,
 })
 
 export const createRoomSessionObject = (


### PR DESCRIPTION
# Description

New APIs to lock and unlock Video RoomSessions.

## Type of change

- [ ] Internal refactoring
- [ ] Bug fix (bugfix - non-breaking)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Code snippets

```ts
await roomSession.lock()


await roomSession.unlock()
```
