### PR TITLE
Hand raise API for the video SDK

### DIFF
--- a/.changeset/red-turkeys-rest.md
+++ b/.changeset/red-turkeys-rest.md
@@ -1,0 +1,7 @@
+---
+'@signalwire/realtime-api': minor
+'@signalwire/core': minor
+'@signalwire/js': minor
+---
+
+Introduce the hand raise API for the Video SDKs (browser and realtime-api)

--- a/internal/e2e-js/tests/roomSessionRaiseHand.spec.ts
+++ b/internal/e2e-js/tests/roomSessionRaiseHand.spec.ts
@@ -1,0 +1,146 @@
+import type { Video } from '@signalwire/js'
+import { test, expect } from '../fixtures'
+import {
+  SERVER_URL,
+  createTestRoomSession,
+  randomizeRoomName,
+  expectRoomJoined,
+  expectMCUVisible,
+} from '../utils'
+
+test.describe('RoomSession Raise/Lower hand', () => {
+  test('should join a room and be able to set hand prioritization', async ({
+    createCustomPage,
+  }) => {
+    const page = await createCustomPage({ name: 'raise-lower' })
+    await page.goto(SERVER_URL)
+
+    const roomName = randomizeRoomName('raise-lower-e2e')
+    const memberSettings = {
+      vrt: {
+        room_name: roomName,
+        user_name: 'e2e_participant_meta',
+        auto_create_room: true,
+        permissions: ['room.prioritize_handraise'],
+      },
+      initialEvents: ['room.updated'],
+    }
+
+    await createTestRoomSession(page, memberSettings)
+
+    // --------------- Joining the room ---------------
+    const joinParams = await expectRoomJoined(page)
+
+    expect(joinParams.room).toBeDefined()
+    expect(joinParams.room_session).toBeDefined()
+    expect(joinParams.room.name).toBe(roomName)
+    expect(joinParams.room.prioritize_handraise).toBe(false)
+
+    // Checks that the video is visible
+    await expectMCUVisible(page)
+
+    // --------------- Set hand raise priority ---------------
+    await page.evaluate(
+      async ({ roomSessionId }) => {
+        // @ts-expect-error
+        const roomObj: Video.RoomSession = window._roomObj
+
+        const memberUpdated = new Promise((resolve) => {
+          roomObj.on('room.updated', (params) => {
+            if (
+              params.room_session.id === roomSessionId &&
+              params.room_session.prioritize_handraise == true
+            ) {
+              resolve(true)
+            }
+          })
+        })
+
+        await roomObj.setPrioritizeHandraise(true)
+
+        return memberUpdated
+      },
+      { roomSessionId: joinParams.room_session.id }
+    )
+  })
+
+  test("should join a room and be able to raise/lower member's hand", async ({
+    createCustomPage,
+  }) => {
+    const page = await createCustomPage({ name: 'raise-lower' })
+    await page.goto(SERVER_URL)
+
+    const roomName = randomizeRoomName('raise-lower-e2e')
+    const memberSettings = {
+      vrt: {
+        room_name: roomName,
+        user_name: 'e2e_participant_meta',
+        auto_create_room: true,
+        permissions: ['room.member.raisehand', 'room.member.lowerhand'],
+      },
+      initialEvents: ['member.joined', 'member.updated', 'member.left'],
+    }
+
+    await createTestRoomSession(page, memberSettings)
+
+    // --------------- Joining the room ---------------
+    const joinParams = await expectRoomJoined(page)
+
+    expect(joinParams.room).toBeDefined()
+    expect(joinParams.room_session).toBeDefined()
+    expect(joinParams.room.name).toBe(roomName)
+
+    // Checks that the video is visible
+    await expectMCUVisible(page)
+
+    // --------------- Raise a member's hand ---------------
+    await page.evaluate(
+      async ({ roomSessionId }) => {
+        // @ts-expect-error
+        const roomObj: Video.RoomSession = window._roomObj
+
+        const memberUpdated = new Promise((resolve) => {
+          roomObj.on('member.updated', (params) => {
+            if (
+              params.room_session_id === roomSessionId &&
+              params.member.handraised == true
+            ) {
+              resolve(true)
+            }
+          })
+        })
+
+        await roomObj.setRaisedHand()
+
+        return memberUpdated
+      },
+      { roomSessionId: joinParams.room_session.id }
+    )
+
+    await page.waitForTimeout(1000)
+
+    // --------------- Lower a member's hand ---------------
+    await page.evaluate(
+      async ({ roomSessionId }) => {
+        // @ts-expect-error
+        const roomObj: Video.RoomSession = window._roomObj
+
+        const memberUpdated = new Promise((resolve) => {
+          roomObj.on('member.updated', (params) => {
+            if (
+              params.room_session_id === roomSessionId &&
+              params.member.handraised == false
+            ) {
+              resolve(true)
+            }
+          })
+        })
+
+        await roomObj.setRaisedHand({ raised: false })
+
+        return memberUpdated
+      },
+      { roomSessionId: joinParams.room_session.id }
+    )
+  })
+})

--- a/internal/e2e-js/tests/roomSessionRaiseHand.spec.ts
+++ b/internal/e2e-js/tests/roomSessionRaiseHand.spec.ts
@@ -45,7 +45,7 @@ test.describe('RoomSession Raise/Lower hand', () => {
         // @ts-expect-error
         const roomObj: Video.RoomSession = window._roomObj
 
-        const memberUpdated = new Promise((resolve) => {
+        const roomUpdated = new Promise((resolve) => {
           roomObj.on('room.updated', (params) => {
             if (
               params.room_session.id === roomSessionId &&
@@ -58,7 +58,7 @@ test.describe('RoomSession Raise/Lower hand', () => {
 
         await roomObj.setPrioritizeHandraise(true)
 
-        return memberUpdated
+        return roomUpdated
       },
       { roomSessionId: joinParams.room_session.id }
     )

--- a/internal/e2e-realtime-api/src/playwright/video.test.ts
+++ b/internal/e2e-realtime-api/src/playwright/video.test.ts
@@ -160,6 +160,7 @@ test.describe('Video', () => {
       })
     })
 
+    // Room length should be 0 before start
     const roomSessionsBeforeStart = await findRoomSession()
     expect(roomSessionsBeforeStart).toHaveLength(0)
 
@@ -171,6 +172,7 @@ test.describe('Video', () => {
       initialEvents: ['room.updated'],
     })
 
+    // Room length should be 1 after start
     const roomSessionsAfterStart = await findRoomSession()
     expect(roomSessionsAfterStart).toHaveLength(1)
 
@@ -183,6 +185,7 @@ test.describe('Video', () => {
       return roomSession.room_session
     })
 
+    // Hand raise is not prioritize on both Node & Web room session object
     expect(roomSessionNode.prioritizeHandraise).toBe(false)
     expect(roomSessionWeb.prioritize_handraise).toBe(false)
 
@@ -192,12 +195,12 @@ test.describe('Video', () => {
         const roomSessionWeb = window._roomObj
 
         roomSessionWeb.on('room.updated', (room) => {
-          console.log('>> room.updated web', room)
           resolve(room.room_session)
         })
       })
     })
 
+    // Set the hand raise prioritization via Node SDK
     const roomSessionNodeUpdated = await new Promise<Video.RoomSession>(
       async (resolve, _reject) => {
         roomSessionNode.on('room.updated', (room) => {
@@ -207,6 +210,7 @@ test.describe('Video', () => {
       }
     )
 
+    // Expect hand raise prioritization to be true on both Node & Web SDK objects
     expect(roomSessionNodeUpdated.prioritizeHandraise).toBe(true)
     expect((await roomSessionWebUpdated).prioritize_handraise).toBe(true)
   })

--- a/internal/e2e-realtime-api/src/playwright/videoHandRaise.test.ts
+++ b/internal/e2e-realtime-api/src/playwright/videoHandRaise.test.ts
@@ -25,7 +25,7 @@ test.describe('Video room hand raise/lower', () => {
     await context.close()
   })
 
-  test('should raise member one hand using room session instance', async () => {
+  test('should raise memberOne hand using room session instance via Node SDK', async () => {
     // Expect no hand raise from both members
     expect(memberOne.handraised).toBe(false)
     expect(memberTwo.handraised).toBe(false)
@@ -55,16 +55,18 @@ test.describe('Video room hand raise/lower', () => {
     )
 
     // Wait for member.updated events to be received on the Web SDK for both pages
-    const memberOneUpdatedWeb = await memberOnePageOne
-    await memberOnePageTwo
+    const memberOnePageOneUpdatedWeb = await memberOnePageOne
+    const memberOnePageTwoUpdatedWeb = await memberOnePageTwo
 
     // Expect a hand raise to be true on both Node & Web SDKs for memberOne only
     expect(memberOneUpdatedNode.handraised).toBe(true)
-    expect(memberOneUpdatedWeb.handraised).toBe(true)
+    expect(memberOnePageOneUpdatedWeb.handraised).toBe(true)
+    expect(memberOnePageTwoUpdatedWeb.handraised).toBe(true)
+
     expect(memberTwo.handraised).toBe(false)
   })
 
-  test('should raise member two hand using member instance', async () => {
+  test('should raise memberTwo hand using member instance via Node SDK', async () => {
     // Expect member.updated event on pageOne via Web SDK for memberTwo
     const memberTwoPageOne = expectMemberUpdated({
       page: pageOne,
@@ -77,7 +79,7 @@ test.describe('Video room hand raise/lower', () => {
       memberName: memberTwo.name,
     })
 
-    // Raise memberTwo hand using a member object using Node SDK
+    // Raise memberTwo hand using a member object via Node SDK
     const memberTwoUpdatedNode = await new Promise<Video.RoomSessionMember>(
       async (resolve, _reject) => {
         roomSession.on('member.updated', (member) => {
@@ -90,11 +92,57 @@ test.describe('Video room hand raise/lower', () => {
     )
 
     // Wait for member.updated events to be received on the Web SDK for both pages
-    const memberTwoUpdatedWeb = await memberTwoPageOne
-    await memberTwoPageTwo
+    const memberTwoPageOneUpdatedWeb = await memberTwoPageOne
+    const memberTwoPageTwoUpdatedWeb = await memberTwoPageTwo
 
     // Expect a hand raise to be true on both Node & Web SDKs for memberTwo only
     expect(memberTwoUpdatedNode.handraised).toBe(true)
-    expect(memberTwoUpdatedWeb.handraised).toBe(true)
+    expect(memberTwoPageOneUpdatedWeb.handraised).toBe(true)
+    expect(memberTwoPageTwoUpdatedWeb.handraised).toBe(true)
+  })
+
+  test('should lower memberOne hand using room session instance via Web SDK', async () => {
+    // Expect member.updated event on pageOne via Web SDK for memberOne
+    const memberOnePageOne = expectMemberUpdated({
+      page: pageOne,
+      memberName: memberOne.name,
+    })
+
+    // Expect member.updated event on pageTwo via Web SDK for memberOne
+    const memberOnePageTwo = expectMemberUpdated({
+      page: pageTwo,
+      memberName: memberOne.name,
+    })
+
+    // Expect member.updated event via Node SDK for memberOne
+    const memberOneNode = new Promise<Video.RoomSessionMember>(
+      async (resolve, _reject) => {
+        roomSession.on('member.updated', (member) => {
+          if (member.name === memberOne.name) {
+            resolve(member)
+          }
+        })
+      }
+    )
+
+    await pageOne.evaluate(async () => {
+      // @ts-expect-error
+      const roomSession = window._roomObj
+
+      // MemberId is not needed here since roomSession on pageOne refers to memberOne's roomSession
+      await roomSession.setRaisedHand({ raised: false })
+    })
+
+    // Wait for member.updated events to be received on the Web SDK for both pages
+    const memberOnePageOneUpdatedWeb = await memberOnePageOne
+    const memberOnePageTwoUpdatedWeb = await memberOnePageTwo
+
+    // Wait for member.updated events to be received on the Node SDK
+    const memberOneUpdatedNode = await memberOneNode
+
+    // Expect a hand raise to be false on both Node & Web SDKs for memberOne only
+    expect(memberOneUpdatedNode.handraised).toBe(false)
+    expect(memberOnePageOneUpdatedWeb.handraised).toBe(false)
+    expect(memberOnePageTwoUpdatedWeb.handraised).toBe(false)
   })
 })

--- a/internal/e2e-realtime-api/src/playwright/videoHandRaise.test.ts
+++ b/internal/e2e-realtime-api/src/playwright/videoHandRaise.test.ts
@@ -1,0 +1,100 @@
+import { test, expect, BrowserContext, Page } from '@playwright/test'
+import { Video } from '@signalwire/realtime-api'
+import { createRoomAndJoinTwoMembers, expectMemberUpdated } from './videoUtils'
+
+test.describe('Video room hand raise/lower', () => {
+  let context: BrowserContext
+  let pageOne: Page
+  let pageTwo: Page
+  let memberOne: Video.RoomSessionMember
+  let memberTwo: Video.RoomSessionMember
+  let roomSession: Video.RoomSession
+
+  test.beforeAll(async ({ browser }) => {
+    context = await browser.newContext()
+
+    const data = await createRoomAndJoinTwoMembers(browser)
+    pageOne = data.pageOne
+    pageTwo = data.pageTwo
+    memberOne = data.memberOne
+    memberTwo = data.memberTwo
+    roomSession = data.roomSession
+  })
+
+  test.afterAll(async () => {
+    await context.close()
+  })
+
+  test('should raise member one hand using room session instance', async () => {
+    // Expect no hand raise from both members
+    expect(memberOne.handraised).toBe(false)
+    expect(memberTwo.handraised).toBe(false)
+
+    // Expect member.updated event on pageOne via Web SDK for memberOne
+    const memberOnePageOne = expectMemberUpdated({
+      page: pageOne,
+      memberName: memberOne.name,
+    })
+
+    // Expect member.updated event on pageTwo via Web SDK for memberOne
+    const memberOnePageTwo = expectMemberUpdated({
+      page: pageTwo,
+      memberName: memberOne.name,
+    })
+
+    // Raise a hand of memberOne using Node SDK
+    const memberOneUpdatedNode = await new Promise<Video.RoomSessionMember>(
+      async (resolve, _reject) => {
+        roomSession.on('member.updated', (member) => {
+          if (member.name === memberOne.name) {
+            resolve(member)
+          }
+        })
+        await roomSession.setRaisedHand({ memberId: memberOne.id })
+      }
+    )
+
+    // Wait for member.updated events to be received on the Web SDK for both pages
+    const memberOneUpdatedWeb = await memberOnePageOne
+    await memberOnePageTwo
+
+    // Expect a hand raise to be true on both Node & Web SDKs for memberOne only
+    expect(memberOneUpdatedNode.handraised).toBe(true)
+    expect(memberOneUpdatedWeb.handraised).toBe(true)
+    expect(memberTwo.handraised).toBe(false)
+  })
+
+  test('should raise member two hand using member instance', async () => {
+    // Expect member.updated event on pageOne via Web SDK for memberTwo
+    const memberTwoPageOne = expectMemberUpdated({
+      page: pageOne,
+      memberName: memberTwo.name,
+    })
+
+    // Expect member.updated event on pageTwo via Web SDK for memberTwo
+    const memberTwoPageTwo = expectMemberUpdated({
+      page: pageTwo,
+      memberName: memberTwo.name,
+    })
+
+    // Raise memberTwo hand using a member object using Node SDK
+    const memberTwoUpdatedNode = await new Promise<Video.RoomSessionMember>(
+      async (resolve, _reject) => {
+        roomSession.on('member.updated', (member) => {
+          if (member.name === memberTwo.name) {
+            resolve(member)
+          }
+        })
+        await memberTwo.setRaisedHand()
+      }
+    )
+
+    // Wait for member.updated events to be received on the Web SDK for both pages
+    const memberTwoUpdatedWeb = await memberTwoPageOne
+    await memberTwoPageTwo
+
+    // Expect a hand raise to be true on both Node & Web SDKs for memberTwo only
+    expect(memberTwoUpdatedNode.handraised).toBe(true)
+    expect(memberTwoUpdatedWeb.handraised).toBe(true)
+  })
+})

--- a/internal/e2e-realtime-api/src/playwright/videoHandRaise.test.ts
+++ b/internal/e2e-realtime-api/src/playwright/videoHandRaise.test.ts
@@ -3,7 +3,6 @@ import { Video } from '@signalwire/realtime-api'
 import { createRoomAndJoinTwoMembers, expectMemberUpdated } from './videoUtils'
 
 test.describe('Video room hand raise/lower', () => {
-  let context: BrowserContext
   let pageOne: Page
   let pageTwo: Page
   let memberOne: Video.RoomSessionMember
@@ -11,18 +10,12 @@ test.describe('Video room hand raise/lower', () => {
   let roomSession: Video.RoomSession
 
   test.beforeAll(async ({ browser }) => {
-    context = await browser.newContext()
-
     const data = await createRoomAndJoinTwoMembers(browser)
     pageOne = data.pageOne
     pageTwo = data.pageTwo
     memberOne = data.memberOne
     memberTwo = data.memberTwo
     roomSession = data.roomSession
-  })
-
-  test.afterAll(async () => {
-    await context.close()
   })
 
   test('should raise memberOne hand using room session instance via Node SDK', async () => {

--- a/internal/e2e-realtime-api/src/playwright/videoUtils.ts
+++ b/internal/e2e-realtime-api/src/playwright/videoUtils.ts
@@ -21,6 +21,10 @@ const PERMISSIONS = [
   'room.recording',
   'room.playback',
   'room.playback_seek',
+  'room.member.raisehand',
+  'room.member.lowerhand',
+  'room.self.raisehand',
+  'room.self.lowerhand',
 ]
 
 type CreateVRTParams = {

--- a/internal/playground-js/src/heroku/index.html
+++ b/internal/playground-js/src/heroku/index.html
@@ -207,6 +207,25 @@
                 </button>
               </div>
 
+              <div class="btn-group w-100" role="group">
+                <button
+                  id="raiseHandBtn"
+                  class="btn btn-warning px-3 mt-2"
+                  onClick="raiseHand()"
+                  disabled="true"
+                >
+                  Raise hand
+                </button>
+                <button
+                  id="lowerHandBtn"
+                  class="btn btn-warning px-3 mt-2"
+                  onClick="lowerHand()"
+                  disabled="true"
+                >
+                  Lower hand
+                </button>
+              </div>
+
               <h5 class="mt-3" for="layout">Controls</h5>
               <div class="col-12">
                 <select

--- a/internal/playground-js/src/heroku/index.js
+++ b/internal/playground-js/src/heroku/index.js
@@ -34,6 +34,8 @@ const inCallElements = [
   unmirrorSelfBtn,
   deafSelfBtn,
   undeafSelfBtn,
+  raiseHandBtn,
+  lowerHandBtn,
   controlSliders,
   controlLayout,
   hideVMutedBtn,
@@ -532,6 +534,14 @@ window.hideVideoMuted = () => {
 
 window.showVideoMuted = () => {
   roomObj.showVideoMuted()
+}
+
+window.raiseHand = () => {
+  roomObj.setRaisedHand({ raised: true })
+}
+
+window.lowerHand = () => {
+  roomObj.setRaisedHand({ raised: false })
 }
 
 window.changeLayout = (select) => {

--- a/packages/core/src/rooms/methods.test.ts
+++ b/packages/core/src/rooms/methods.test.ts
@@ -240,4 +240,74 @@ describe('Room Custom Methods', () => {
       )
     })
   })
+
+  describe('setRaisedHand', () => {
+    it.each([
+      {
+        input: {
+          memberId: 'c22d7124-5a01-49fe-8da0-46bec8e75f12',
+        },
+        method: 'video.member.raisehand',
+      },
+      {
+        input: {
+          memberId: 'c22d7124-5a01-49fe-8da0-46bec8e75f12',
+          raised: true,
+        },
+        method: 'video.member.raisehand',
+      },
+      {
+        input: {
+          memberId: 'c22d7124-5a01-49fe-8da0-46bec8e75f12',
+          raised: false,
+        },
+        method: 'video.member.lowerhand',
+      },
+      {
+        input: {},
+        method: 'video.member.raisehand',
+      },
+    ])('should execute with proper params', async ({ input, method }) => {
+      ;(instance.execute as jest.Mock).mockResolvedValueOnce({})
+      instance.roomSessionId = 'mocked'
+      instance.memberId = 'c22d7124-5a01-49fe-8da0-46bec8e75f12'
+
+      await instance.setRaisedHand(input)
+
+      expect(instance.execute).toHaveBeenCalledTimes(1)
+      expect(instance.execute).toHaveBeenCalledWith(
+        {
+          method,
+          params: {
+            room_session_id: 'mocked',
+            member_id: 'c22d7124-5a01-49fe-8da0-46bec8e75f12',
+          },
+        },
+        {
+          transformResolve: expect.anything(),
+        }
+      )
+    })
+  })
+
+  describe('setPrioritizeHandraise', () => {
+    it.each([true, false])(
+      'should execute with proper params',
+      async (enable) => {
+        ;(instance.execute as jest.Mock).mockResolvedValueOnce({})
+        instance.roomSessionId = 'mocked'
+
+        await instance.setPrioritizeHandraise(enable)
+
+        expect(instance.execute).toHaveBeenCalledTimes(1)
+        expect(instance.execute).toHaveBeenCalledWith({
+          method: 'video.prioritize_handraise',
+          params: {
+            room_session_id: 'mocked',
+            enable,
+          },
+        })
+      }
+    )
+  })
 })

--- a/packages/core/src/rooms/methods.ts
+++ b/packages/core/src/rooms/methods.ts
@@ -471,6 +471,18 @@ export const startStream: RoomMethodDescriptor<any, StartStreamParams> = {
   },
 }
 
+export const setPrioritizeHandraise: RoomMethodDescriptor<any, boolean> = {
+  value: function (params) {
+    return this.execute({
+      method: 'video.prioritize_handraise',
+      params: {
+        room_session_id: this.roomSessionId,
+        enable: params,
+      },
+    })
+  },
+}
+
 export type GetLayouts = ReturnType<typeof getLayouts.value>
 export type GetMembers = ReturnType<typeof getMembers.value>
 export type HideVideoMuted = ReturnType<typeof hideVideoMuted.value>
@@ -492,6 +504,9 @@ export type StartStream = ReturnType<typeof startStream.value>
 
 export type Lock = ReturnType<typeof lock.value>
 export type Unlock = ReturnType<typeof unlock.value>
+export type SetPrioritizeHandraise = ReturnType<
+  typeof setPrioritizeHandraise.value
+>
 // End Room Methods
 
 /**
@@ -715,6 +730,42 @@ export const deleteMemberMeta = createRoomMemberMethod<BaseRPCResult, void>(
   }
 )
 
+export interface SetRaisedHandRoomParams {
+  memberId: string
+  raised?: boolean
+}
+
+export interface SetRaisedHandMemberParams {
+  raised?: boolean
+}
+
+export const setRaisedHand: RoomMethodDescriptor<
+  void,
+  SetRaisedHandRoomParams | SetRaisedHandMemberParams
+> = {
+  value: function (value) {
+    const { raised = true, memberId = this.memberId } =
+      (value as SetRaisedHandRoomParams) || {}
+
+    if (!memberId) {
+      throw new TypeError('Invalid or missing "memberId" argument')
+    }
+
+    return this.execute(
+      {
+        method: raised ? 'video.member.raisehand' : 'video.member.lowerhand',
+        params: {
+          room_session_id: this.roomSessionId,
+          member_id: memberId,
+        },
+      },
+      {
+        transformResolve: baseCodeTransform,
+      }
+    )
+  },
+}
+
 export type AudioMuteMember = ReturnType<typeof audioMuteMember.value>
 export type AudioUnmuteMember = ReturnType<typeof audioUnmuteMember.value>
 export type VideoMuteMember = ReturnType<typeof videoMuteMember.value>
@@ -740,4 +791,5 @@ export type UpdateMemberMeta = ReturnType<typeof updateMemberMeta.value>
 export type DeleteMemberMeta = ReturnType<typeof deleteMemberMeta.value>
 export type PromoteMember = ReturnType<typeof promote.value>
 export type DemoteMember = ReturnType<typeof demote.value>
+export type SetRaisedHand = ReturnType<typeof setRaisedHand.value>
 // End Room Member Methods

--- a/packages/core/src/rooms/methods.ts
+++ b/packages/core/src/rooms/methods.ts
@@ -730,14 +730,22 @@ export const deleteMemberMeta = createRoomMemberMethod<BaseRPCResult, void>(
   }
 )
 
-export interface SetRaisedHandParams {
-  memberId?: string
+export interface SetRaisedHandRoomParams {
+  memberId: string
   raised?: boolean
 }
 
-export const setRaisedHand: RoomMethodDescriptor<void, SetRaisedHandParams> = {
+export interface SetRaisedHandMemberParams {
+  raised?: boolean
+}
+
+export const setRaisedHand: RoomMethodDescriptor<
+  void,
+  SetRaisedHandRoomParams | SetRaisedHandMemberParams
+> = {
   value: function (value) {
-    const { raised = true, memberId = this.memberId } = value || {}
+    const { raised = true, memberId = this.memberId } =
+      (value as SetRaisedHandRoomParams) || {}
 
     if (!memberId) {
       throw new TypeError('Invalid or missing "memberId" argument')

--- a/packages/core/src/rooms/methods.ts
+++ b/packages/core/src/rooms/methods.ts
@@ -731,7 +731,7 @@ export const deleteMemberMeta = createRoomMemberMethod<BaseRPCResult, void>(
 )
 
 export interface SetRaisedHandRoomParams {
-  memberId?: string
+  memberId: string
   raised?: boolean
 }
 

--- a/packages/core/src/rooms/methods.ts
+++ b/packages/core/src/rooms/methods.ts
@@ -731,7 +731,7 @@ export const deleteMemberMeta = createRoomMemberMethod<BaseRPCResult, void>(
 )
 
 export interface SetRaisedHandRoomParams {
-  memberId: string
+  memberId?: string
   raised?: boolean
 }
 

--- a/packages/core/src/rooms/methods.ts
+++ b/packages/core/src/rooms/methods.ts
@@ -730,22 +730,14 @@ export const deleteMemberMeta = createRoomMemberMethod<BaseRPCResult, void>(
   }
 )
 
-export interface SetRaisedHandRoomParams {
-  memberId: string
+export interface SetRaisedHandParams {
+  memberId?: string
   raised?: boolean
 }
 
-export interface SetRaisedHandMemberParams {
-  raised?: boolean
-}
-
-export const setRaisedHand: RoomMethodDescriptor<
-  void,
-  SetRaisedHandRoomParams | SetRaisedHandMemberParams
-> = {
+export const setRaisedHand: RoomMethodDescriptor<void, SetRaisedHandParams> = {
   value: function (value) {
-    const { raised = true, memberId = this.memberId } =
-      (value as SetRaisedHandRoomParams) || {}
+    const { raised = true, memberId = this.memberId } = value || {}
 
     if (!memberId) {
       throw new TypeError('Invalid or missing "memberId" argument')

--- a/packages/core/src/types/videoMember.ts
+++ b/packages/core/src/types/videoMember.ts
@@ -148,6 +148,8 @@ export interface VideoMemberContract extends VideoMemberUpdatableProps {
   currentPosition?: VideoPosition
   /** Metadata associated to this member. */
   meta?: Record<string, unknown>
+  /** Indicate if the member hand is raised or not */
+  handraised: Boolean
 
   /**
    * Mutes the outbound audio for this member (e.g., the one coming from a
@@ -286,7 +288,7 @@ export interface VideoMemberContract extends VideoMemberUpdatableProps {
    * await member.remove()
    * ```
    */
-  setRaisedHand(params?: Rooms.SetRaisedHandMemberParams): Rooms.SetRaisedHand
+  setRaisedHand(params?: Rooms.SetRaisedHandParams): Rooms.SetRaisedHand
 }
 
 /**

--- a/packages/core/src/types/videoMember.ts
+++ b/packages/core/src/types/videoMember.ts
@@ -76,7 +76,7 @@ export type MemberListUpdated = 'memberList.updated'
 /**
  * See {@link MEMBER_UPDATED_EVENTS} for the full list of events.
  */
-export type MemberUpdatedEventNames = typeof MEMBER_UPDATED_EVENTS[number]
+export type MemberUpdatedEventNames = (typeof MEMBER_UPDATED_EVENTS)[number]
 export type MemberTalkingStarted = 'member.talking.started'
 export type MemberTalkingEnded = 'member.talking.ended'
 /**
@@ -109,7 +109,7 @@ export type VideoMemberEventNames =
   | MemberListUpdated
 
 export type InternalMemberUpdatedEventNames =
-  typeof INTERNAL_MEMBER_UPDATED_EVENTS[number]
+  (typeof INTERNAL_MEMBER_UPDATED_EVENTS)[number]
 
 /**
  * List of internal events
@@ -277,6 +277,16 @@ export interface VideoMemberContract extends VideoMemberUpdatableProps {
    * ```
    */
   remove(): Rooms.RemoveMember
+
+  /**
+   * Removes this member from the room.
+   *
+   * @example
+   * ```typescript
+   * await member.remove()
+   * ```
+   */
+  setRaisedHand(params?: Rooms.SetRaisedHandMemberParams): Rooms.SetRaisedHand
 }
 
 /**

--- a/packages/core/src/types/videoMember.ts
+++ b/packages/core/src/types/videoMember.ts
@@ -288,7 +288,7 @@ export interface VideoMemberContract extends VideoMemberUpdatableProps {
    * await member.remove()
    * ```
    */
-  setRaisedHand(params?: Rooms.SetRaisedHandParams): Rooms.SetRaisedHand
+  setRaisedHand(params?: Rooms.SetRaisedHandMemberParams): Rooms.SetRaisedHand
 }
 
 /**

--- a/packages/core/src/types/videoMember.ts
+++ b/packages/core/src/types/videoMember.ts
@@ -281,11 +281,11 @@ export interface VideoMemberContract extends VideoMemberUpdatableProps {
   remove(): Rooms.RemoveMember
 
   /**
-   * Removes this member from the room.
+   * Raise or lower this member's hand.
    *
    * @example
    * ```typescript
-   * await member.remove()
+   * await member.setRaisedHand()
    * ```
    */
   setRaisedHand(params?: Rooms.SetRaisedHandMemberParams): Rooms.SetRaisedHand

--- a/packages/core/src/types/videoRoomSession.ts
+++ b/packages/core/src/types/videoRoomSession.ts
@@ -98,6 +98,8 @@ export interface VideoRoomSessionContract {
   streaming: boolean
   /** List of active streams in the room session. */
   streams?: Rooms.RoomSessionStream[]
+  /** Prioritize the hand raise for the layout */
+  prioritizeHandraise: Boolean
 
   /**
    * Puts the microphone on mute. The other participants will not hear audio
@@ -769,7 +771,7 @@ export interface VideoRoomSessionContract {
    * await room.setHandRaised({ memberId: id, raised: false })
    * ```
    */
-  setRaisedHand(params: Rooms.SetRaisedHandRoomParams): Rooms.SetRaisedHand
+  setRaisedHand(params?: Rooms.SetRaisedHandParams): Rooms.SetRaisedHand
 }
 
 /**
@@ -815,6 +817,7 @@ type InternalVideoRoomEntity = {
   recordings?: any[]
   playbacks?: any[]
   streams?: any[]
+  prioritize_handraise: boolean
 }
 
 /**

--- a/packages/core/src/types/videoRoomSession.ts
+++ b/packages/core/src/types/videoRoomSession.ts
@@ -732,6 +732,44 @@ export interface VideoRoomSessionContract {
   startStream(params: Rooms.StartStreamParams): Promise<Rooms.RoomSessionStream>
   lock(): Rooms.Lock
   unlock(): Rooms.Unlock
+  /**
+   * Set the priority of members hand raise
+   * @param param a boolean flag to enable/disable the hand raise prioritization
+   *
+   * @permissions
+   *  - `video.prioritize_handraise`: to set the teh hand raise priority
+   *
+   * You need to specify the permissions when [creating the Video Room
+   * Token](https://developer.signalwire.com/apis/reference/create_room_token)
+   * on the server side.
+   *
+   * @example
+   * ```typescript
+   * await room.setPrioritizeHandraise(true)
+   * ```
+   */
+  setPrioritizeHandraise(params: boolean): Rooms.SetPrioritizeHandraise
+  /**
+   * Raise or lower the hand of a specific participant in the room.
+   * @param params
+   * @param params.memberId id of the member to remove
+   * @param params.raised boolean flag to raise or lower the hand
+   *
+   * @permissions
+   *  - `video.member.raisehand`: to raise a hand
+   *  - `video.member.lowerhand`: to lower a hand
+   *
+   * You need to specify the permissions when [creating the Video Room
+   * Token](https://developer.signalwire.com/apis/reference/create_room_token)
+   * on the server side.
+   *
+   * @example
+   * ```typescript
+   * const id = 'de550c0c-3fac-4efd-b06f-b5b8614b8966'  // you can get this from getMembers()
+   * await room.setHandRaised({ memberId: id, raised: false })
+   * ```
+   */
+  setRaisedHand(params: Rooms.SetRaisedHandRoomParams): Rooms.SetRaisedHand
 }
 
 /**

--- a/packages/core/src/types/videoRoomSession.ts
+++ b/packages/core/src/types/videoRoomSession.ts
@@ -739,7 +739,7 @@ export interface VideoRoomSessionContract {
    * @param param a boolean flag to enable/disable the hand raise prioritization
    *
    * @permissions
-   *  - `video.prioritize_handraise`: to set the teh hand raise priority
+   *  - `video.prioritize_handraise`: to set the hand raise priority
    *
    * You need to specify the permissions when [creating the Video Room
    * Token](https://developer.signalwire.com/apis/reference/create_room_token)

--- a/packages/core/src/types/videoRoomSession.ts
+++ b/packages/core/src/types/videoRoomSession.ts
@@ -771,7 +771,7 @@ export interface VideoRoomSessionContract {
    * await room.setHandRaised({ memberId: id, raised: false })
    * ```
    */
-  setRaisedHand(params?: Rooms.SetRaisedHandRoomParams): Rooms.SetRaisedHand
+  setRaisedHand(params: Rooms.SetRaisedHandRoomParams): Rooms.SetRaisedHand
 }
 
 /**

--- a/packages/core/src/types/videoRoomSession.ts
+++ b/packages/core/src/types/videoRoomSession.ts
@@ -771,7 +771,7 @@ export interface VideoRoomSessionContract {
    * await room.setHandRaised({ memberId: id, raised: false })
    * ```
    */
-  setRaisedHand(params?: Rooms.SetRaisedHandParams): Rooms.SetRaisedHand
+  setRaisedHand(params?: Rooms.SetRaisedHandRoomParams): Rooms.SetRaisedHand
 }
 
 /**

--- a/packages/core/src/utils/interfaces.ts
+++ b/packages/core/src/utils/interfaces.ts
@@ -338,6 +338,9 @@ export type RoomMethod =
   | 'video.stream.stop'
   | 'video.lock'
   | 'video.unlock'
+  | 'video.member.raisehand'
+  | 'video.member.lowerhand'
+  | 'video.prioritize_handraise'
 
 export interface WebSocketClient {
   addEventListener: WebSocket['addEventListener']

--- a/packages/js/src/BaseRoomSession.ts
+++ b/packages/js/src/BaseRoomSession.ts
@@ -492,6 +492,8 @@ export const RoomSessionAPI = extendComponent<
   startStream: Rooms.startStream,
   lock: Rooms.lock,
   unlock: Rooms.unlock,
+  setRaisedHand: Rooms.setRaisedHand,
+  setPrioritizeHandraise: Rooms.setPrioritizeHandraise,
 })
 
 type RoomSessionObjectEventsHandlerMapping = RoomSessionObjectEvents &

--- a/packages/js/src/utils/interfaces.ts
+++ b/packages/js/src/utils/interfaces.ts
@@ -77,6 +77,8 @@ export type DeprecatedVideoMemberHandlerParams = {
 export type VideoMemberHandlerParams = { member: VideoMemberEntity }
 export type VideoMemberUpdatedHandlerParams = {
   member: VideoMemberEntityUpdated
+  room_id?: string
+  room_session_id?: string
 }
 export type VideoMemberListUpdatedParams = { members: VideoMemberEntity[] }
 

--- a/packages/realtime-api/src/video/RoomSession.ts
+++ b/packages/realtime-api/src/video/RoomSession.ts
@@ -278,6 +278,8 @@ export const RoomSessionAPI = extendComponent<
   startStream: Rooms.startStream,
   lock: Rooms.lock,
   unlock: Rooms.unlock,
+  setRaisedHand: Rooms.setRaisedHand,
+  setPrioritizeHandraise: Rooms.setPrioritizeHandraise,
 })
 
 export const createRoomSessionObject = (

--- a/packages/realtime-api/src/video/RoomSession.ts
+++ b/packages/realtime-api/src/video/RoomSession.ts
@@ -113,6 +113,10 @@ export class RoomSessionConsumer extends BaseConsumer<RealTimeRoomApiEvents> {
     return this._payload.room_session.event_channel
   }
 
+  get prioritizeHandraise() {
+    return this._payload.room_session.prioritize_handraise
+  }
+
   /** @internal */
   protected override getSubscriptions() {
     const eventNamesWithPrefix = this.eventNames().map(

--- a/packages/realtime-api/src/video/RoomSessionMember.test.ts
+++ b/packages/realtime-api/src/video/RoomSessionMember.test.ts
@@ -26,7 +26,6 @@ describe('Member Object', () => {
     return new Promise(async (resolve) => {
       const roomSession = createRoomSessionObject({
         store,
-        // @ts-expect-error
         emitter,
         payload: {
           // @ts-expect-error
@@ -83,82 +82,109 @@ describe('Member Object', () => {
         member_id: memberId,
       },
     })
-    // await member.audioUnmute()
-    // expectExecute({
-    //   method: 'video.member.audio_unmute',
-    //   params: {
-    //     room_session_id: roomSessionId,
-    //     member_id: memberId,
-    //   },
-    // })
-    // await member.videoMute()
-    // expectExecute({
-    //   method: 'video.member.video_mute',
-    //   params: {
-    //     room_session_id: roomSessionId,
-    //     member_id: memberId,
-    //   },
-    // })
-    // await member.videoUnmute()
-    // expectExecute({
-    //   method: 'video.member.video_unmute',
-    //   params: {
-    //     room_session_id: roomSessionId,
-    //     member_id: memberId,
-    //   },
-    // })
-    // await member.setDeaf(true)
-    // expectExecute({
-    //   method: 'video.member.deaf',
-    //   params: {
-    //     room_session_id: roomSessionId,
-    //     member_id: memberId,
-    //   },
-    // })
-    // await member.setDeaf(false)
-    // expectExecute({
-    //   method: 'video.member.undeaf',
-    //   params: {
-    //     room_session_id: roomSessionId,
-    //     member_id: memberId,
-    //   },
-    // })
-    // await member.setInputVolume({ volume: 10 })
-    // expectExecute({
-    //   method: 'video.member.set_input_volume',
-    //   params: {
-    //     room_session_id: roomSessionId,
-    //     member_id: memberId,
-    //     volume: 10,
-    //   },
-    // })
-    // await member.setOutputVolume({ volume: 10 })
-    // expectExecute({
-    //   method: 'video.member.set_output_volume',
-    //   params: {
-    //     room_session_id: roomSessionId,
-    //     member_id: memberId,
-    //     volume: 10,
-    //   },
-    // })
-    // await member.setInputSensitivity({ value: 10 })
-    // expectExecute({
-    //   method: 'video.member.set_input_sensitivity',
-    //   params: {
-    //     room_session_id: roomSessionId,
-    //     member_id: memberId,
-    //     value: 10,
-    //   },
-    // })
-
-    // await member.remove()
-    // // @ts-expect-error
-    // expect(member.execute).toHaveBeenLastCalledWith({
-    //   method: 'video.member.remove',
-    //   params: {
-    //     room_session_id: member.roomSessionId,
-    //     member_id: member.id,
-    //   },
-    // })
+    await member.audioUnmute()
+    expectExecute({
+      method: 'video.member.audio_unmute',
+      params: {
+        room_session_id: roomSessionId,
+        member_id: memberId,
+      },
+    })
+    await member.videoMute()
+    expectExecute({
+      method: 'video.member.video_mute',
+      params: {
+        room_session_id: roomSessionId,
+        member_id: memberId,
+      },
+    })
+    await member.videoUnmute()
+    expectExecute({
+      method: 'video.member.video_unmute',
+      params: {
+        room_session_id: roomSessionId,
+        member_id: memberId,
+      },
+    })
+    await member.setDeaf(true)
+    expectExecute({
+      method: 'video.member.deaf',
+      params: {
+        room_session_id: roomSessionId,
+        member_id: memberId,
+      },
+    })
+    await member.setDeaf(false)
+    expectExecute({
+      method: 'video.member.undeaf',
+      params: {
+        room_session_id: roomSessionId,
+        member_id: memberId,
+      },
+    })
+    await member.setInputVolume({ volume: 10 })
+    expectExecute({
+      method: 'video.member.set_input_volume',
+      params: {
+        room_session_id: roomSessionId,
+        member_id: memberId,
+        volume: 10,
+      },
+    })
+    await member.setOutputVolume({ volume: 10 })
+    expectExecute({
+      method: 'video.member.set_output_volume',
+      params: {
+        room_session_id: roomSessionId,
+        member_id: memberId,
+        volume: 10,
+      },
+    })
+    await member.setInputSensitivity({ value: 10 })
+    expectExecute({
+      method: 'video.member.set_input_sensitivity',
+      params: {
+        room_session_id: roomSessionId,
+        member_id: memberId,
+        value: 10,
+      },
+    })
+    await member.remove()
+    // @ts-expect-error
+    expect(member.execute).toHaveBeenLastCalledWith({
+      method: 'video.member.remove',
+      params: {
+        room_session_id: member.roomSessionId,
+        member_id: member.id,
+      },
+    })
+    await member.setRaisedHand()
+    // @ts-expect-error
+    expect(member.execute).toHaveBeenLastCalledWith(
+      {
+        method: 'video.member.raisehand',
+        params: {
+          room_session_id: member.roomSessionId,
+          member_id: member.id,
+        },
+      },
+      {
+        transformResolve: expect.anything(),
+      }
+    )
+    await member.setRaisedHand({ raised: false })
+    // @ts-expect-error
+    expect(member.execute).toHaveBeenLastCalledWith(
+      {
+        method: 'video.member.lowerhand',
+        params: {
+          room_session_id: member.roomSessionId,
+          member_id: member.id,
+        },
+      },
+      {
+        transformResolve: expect.anything(),
+      }
+    )
   })
 })

--- a/packages/realtime-api/src/video/RoomSessionMember.ts
+++ b/packages/realtime-api/src/video/RoomSessionMember.ts
@@ -119,6 +119,10 @@ class RoomSessionMemberComponent extends BaseComponent<{}> {
     return this._payload.member.talking
   }
 
+  get handraised() {
+    return this._payload.member.handraised
+  }
+
   /** @internal */
   protected setPayload(payload: RoomSessionMemberEventParams) {
     // Reshape the payload since the `video.member.talking` event does not return all the parameters of a member

--- a/packages/realtime-api/src/video/RoomSessionMember.ts
+++ b/packages/realtime-api/src/video/RoomSessionMember.ts
@@ -158,6 +158,7 @@ const RoomSessionMemberAPI = extendComponent<
   setSpeakerVolume: Rooms.setOutputVolumeMember,
   setOutputVolume: Rooms.setOutputVolumeMember,
   setInputSensitivity: Rooms.setInputSensitivityMember,
+  setRaisedHand: Rooms.setRaisedHand,
 })
 
 export const createRoomSessionMemberObject = (


### PR DESCRIPTION
# Description

Implement the hand raise APIs for the Video SDKs (browser and realtime)

ref: https://github.com/signalwire/cloud-product/issues/7901

## Type of change

- [ ] Internal refactoring
- [ ] Bug fix (bugfix - non-breaking)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Code snippets

In the browser SDK
```js
await room.setRaisedHand({
    memberId: "1234....", // Optional
    raised: false,  // Optional. Default is true
})

await room.setPrioritizeHandraise(false)
```

In the realtime SDK
```js
await room.setRaisedHand({
    memberId: "1234....", // Mandatory
    raised: false,  // Optional. Default is true
})

await room.setPrioritizeHandraise(true)

await member.setRaisedHand({ raised: false }) // Optional param. Default it true
```
