### PR TITLE
Implement catchable voice call workers saga

### DIFF
--- a/.changeset/sixty-months-marry.md
+++ b/.changeset/sixty-months-marry.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/realtime-api': patch
+---
+
+Catchable voice calling workers saga

--- a/packages/realtime-api/src/voice/workers/voiceCallingWorker.ts
+++ b/packages/realtime-api/src/voice/workers/voiceCallingWorker.ts
@@ -6,6 +6,7 @@ import {
   SDKActions,
   VoiceCallAction,
   SDKWorkerParams,
+  sagaHelpers,
 } from '@signalwire/core'
 import { fork } from '@redux-saga/core/effects'
 import type { Client } from '../../client/index'
@@ -103,6 +104,13 @@ export const voiceCallingWroker: SDKWorker<Client> = function* (
     }
   }
 
+  const workerCatchable = sagaHelpers.createCatchableSaga<VoiceCallAction>(
+    worker,
+    (error) => {
+      getLogger().error('Voice calling event error', error)
+    }
+  )
+
   const isCallingEvent = (action: SDKActions) =>
     action.type.startsWith('calling.')
 
@@ -112,7 +120,7 @@ export const voiceCallingWroker: SDKWorker<Client> = function* (
       isCallingEvent
     )
 
-    yield sagaEffects.fork(worker, action)
+    yield sagaEffects.fork(workerCatchable, action)
   }
 
   getLogger().trace('voiceCallingWroker ended')


### PR DESCRIPTION
# Description

Introduce a catchable worker saga for voice-calling APIs to minimize the error effect. If any of the child workers throws an error, the parent will not stop listening to the newer events.

## Type of change

- [x] Internal refactoring
- [ ] Bug fix (bugfix - non-breaking)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Code snippets

_no change_