### PR TITLE
Fix member.updated events

### DIFF
--- a/.changeset/long-timers-rhyme.md
+++ b/.changeset/long-timers-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/core': patch
+---
+
+Bugfix: remove video prefix from member.updated events to emit them properly

--- a/packages/core/src/memberPosition/workers.test.ts
+++ b/packages/core/src/memberPosition/workers.test.ts
@@ -88,17 +88,14 @@ describe('memberPositionWorker', () => {
       .run()
       .finally(() => {
         expect(emitSpy).toHaveBeenCalledWith(
-          'video.member.updated.visible',
+          'member.updated.visible',
           action.payload
         )
         expect(emitSpy).toHaveBeenCalledWith(
-          'video.member.updated.video_muted',
+          'member.updated.video_muted',
           action.payload
         )
-        expect(emitSpy).toHaveBeenCalledWith(
-          'video.member.updated',
-          action.payload
-        )
+        expect(emitSpy).toHaveBeenCalledWith('member.updated', action.payload)
         expect(memberList.get(memberId)?.member.visible).toBe(true)
         expect(memberList.get(memberId)?.member.video_muted).toBe(false)
         expect(memberList.get(memberId)?.member.updated).toStrictEqual([

--- a/packages/core/src/memberPosition/workers.ts
+++ b/packages/core/src/memberPosition/workers.ts
@@ -22,7 +22,6 @@ const defaultDispatcher = function* (
   payload: any,
   instance?: any
 ) {
-  console.warn('xxxx', type, instance, instance.eventNames())
   instance.emit(type, payload)
 }
 


### PR DESCRIPTION
# Description

Fix how the Browser SDK emits the `member.updated` events.

## Type of change

- [ ] Internal refactoring
- [x] Bug fix (bugfix - non-breaking)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Code snippets

_no changes_
