### PR TITLE
Fix #7921 and added test cases

### DIFF
--- a/.changeset/early-cheetahs-tease.md
+++ b/.changeset/early-cheetahs-tease.md
@@ -4,7 +4,7 @@
 '@signalwire/core': patch
 ---
 
-- Added stated to `CallingCallCollectEventParams`
+- Added state to `CallingCallCollectEventParams`
 - Made sure voiceCallCollectWorker doesn't clean up CallCollect instance and emit ended/failed event if the state is "collecting"
 - Resolve CallCollect.ended() promise only when state is NOT "collecting" AND final is either undefined/true AND result.type is one od ENDED_STATES
 - Added more test cases for Call.collect() in @sw-internal/e2e-realtime-api

--- a/.changeset/early-cheetahs-tease.md
+++ b/.changeset/early-cheetahs-tease.md
@@ -4,7 +4,7 @@
 '@signalwire/core': patch
 ---
 
-- Added state to `CallingCallCollectEventParams`
-- Made sure voiceCallCollectWorker doesn't clean up CallCollect instance and emit ended/failed event if the state is "collecting"
-- Resolve CallCollect.ended() promise only when state is NOT "collecting" AND final is either undefined/true AND result.type is one od ENDED_STATES
-- Added more test cases for Call.collect() in @sw-internal/e2e-realtime-api
+- Added `state` param to `CallingCallCollectEventParams`
+- Made sure `voiceCallCollectWorker` doesn't clean up `CallCollect` instance and emit `ended`/`failed` event if the `state` is `"collecting"`
+- Resolve `CallCollect.ended()` promise only when `state` is NOT `"collecting"` AND `final` is either `undefined`/`true` AND `result.type` is one of `ENDED_STATES`
+- Added more test cases for `Call.collect()` in `@sw-internal/e2e-realtime-api`

--- a/.changeset/early-cheetahs-tease.md
+++ b/.changeset/early-cheetahs-tease.md
@@ -1,0 +1,10 @@
+---
+'@sw-internal/e2e-realtime-api': patch
+'@signalwire/realtime-api': patch
+'@signalwire/core': patch
+---
+
+- Added stated to `CallingCallCollectEventParams`
+- Made sure voiceCallCollectWorker doesn't clean up CallCollect instance and emit ended/failed event if the state is "collecting"
+- Resolve CallCollect.ended() promise only when state is NOT "collecting" AND final is either undefined/true AND result.type is one od ENDED_STATES
+- Added more test cases for Call.collect() in @sw-internal/e2e-realtime-api

--- a/internal/e2e-realtime-api/src/utils.ts
+++ b/internal/e2e-realtime-api/src/utils.ts
@@ -43,6 +43,7 @@ interface CreateTestRunnerParams {
   testHandler: TestHandler
   executionTime?: number
   useDomainApp?: boolean
+  exitOnSuccess?: boolean
 }
 
 export const createTestRunner = ({
@@ -51,6 +52,7 @@ export const createTestRunner = ({
   testHandler,
   executionTime = MAX_EXECUTION_TIME,
   useDomainApp = false,
+  exitOnSuccess = true,
 }: CreateTestRunnerParams) => {
   let timer: ReturnType<typeof setTimeout>
 
@@ -65,6 +67,9 @@ export const createTestRunner = ({
     clearTimeout(timer)
     if (exitCode === 0) {
       console.log(`Test Runner ${name} Passed!`)
+      if (!exitOnSuccess) {
+        return;
+      }
     } else {
       console.log(`Test Runner ${name} finished with exitCode: ${exitCode}`)
     }

--- a/internal/e2e-realtime-api/src/utils.ts
+++ b/internal/e2e-realtime-api/src/utils.ts
@@ -87,7 +87,7 @@ export const createTestRunner = ({
             name: `d-app-${uuid}`,
             identifier: uuid,
             call_handler: 'relay_context',
-            call_relay_context: `d-app-ctx-${uuid}`,
+            call_relay_context:`d-app-ctx-${uuid}`,
           })
         }
         const exitCode = await testHandler(params)

--- a/internal/e2e-realtime-api/src/voiceSpeechCollect.test.ts
+++ b/internal/e2e-realtime-api/src/voiceSpeechCollect.test.ts
@@ -36,7 +36,7 @@ const handler: TestHandler = ({ domainApp }) => {
 
       try {
         const resultAnswer = await call.answer()
-        tap.ok(resultAnswer.id, 'Inboud call answered')
+        tap.ok(resultAnswer.id, 'Inbound call answered')
         tap.equal(
           call.id,
           resultAnswer.id,

--- a/internal/e2e-realtime-api/src/voiceSpeechCollect.test.ts
+++ b/internal/e2e-realtime-api/src/voiceSpeechCollect.test.ts
@@ -58,9 +58,9 @@ const handler: TestHandler = ({ domainApp }) => {
         })
 
         const callCollect = await call.collect({
-          initialTimeout: 4.0,
+          initialTimeout: 10.0,
           speech: {
-            endSilenceTimeout: 2.0,
+            endSilenceTimeout: 6.0,
             speechTimeout: 60.0,
             language:'en-US',
             model: 'enhanced.phone_call',
@@ -75,14 +75,12 @@ const handler: TestHandler = ({ domainApp }) => {
 
         // Wait until the caller ends entring the digits
         await waitForCollectEnd
-
+        // const collected = await callCollect.stop();
         const collected = await callCollect.ended() // block the script until the collect ended
-        tap.equal(collected.text, 'one two three four five six seven eight nine ten', 'Collect the correct text')
+        tap.equal(collected.text, 'one two three four five six seven eight nine ten  11 to 8', 'Collect the correct text')
         // await callCollect.stop()
         // await callCollect.startInputTimers()
-
-        await new Promise((resolve) => setTimeout(resolve, 3000))
-        await call.hangup()
+        // await call.hangup()
       } catch (error) {
         console.error('Error', error)
         reject(4)
@@ -115,10 +113,12 @@ const handler: TestHandler = ({ domainApp }) => {
       //   sendDigitResult.id,
       //   'sendDigit returns the same instance'
       // )
-
-      await call.playAudio({
+  
+      call.playAudio({
         url: 'https://od.lk/s/MzJfMjM1ODY4Nzlf/recording3.mp3',
       })
+      await new Promise((resolve) => setTimeout(resolve, 7000))
+      await call.hangup()
       // Resolve the collect end promise to inform the callee
       waitForCollectEndResolve()
 

--- a/internal/e2e-realtime-api/src/voiceSpeechCollect.test.ts
+++ b/internal/e2e-realtime-api/src/voiceSpeechCollect.test.ts
@@ -11,11 +11,12 @@ const handler: TestHandler = ({ domainApp }) => {
     throw new Error('Missing domainApp')
   }
   return new Promise<number>(async (resolve, reject) => {
+    console.log(domainApp.call_relay_context)
     const client = new Voice.Client({
       host: process.env.RELAY_HOST,
       project: process.env.RELAY_PROJECT as string,
       token: process.env.RELAY_TOKEN as string,
-      contexts: [domainApp.call_relay_context],
+      contexts: [domainApp.call_relay_context, "relaye2e"],
       // logLevel: "trace",
       debug: {
         logWsTraffic: true,
@@ -90,14 +91,16 @@ const handler: TestHandler = ({ domainApp }) => {
 
     try {
       const call = await client.dialSip({
-        to: makeSipDomainAppAddress({
-          name: 'to',
-          domain: domainApp.domain,
-        }),
-        from: makeSipDomainAppAddress({
-          name: 'from',
-          domain: domainApp.domain,
-        }),
+        // to: makeSipDomainAppAddress({
+        //   name: 'to',
+        //   domain: domainApp.domain,
+        // }),
+        // from: makeSipDomainAppAddress({
+        //   name: 'from',
+        //   domain: domainApp.domain,
+        // }),
+        to: 'sip:to@dev-min.dapp.swire.io',
+        from: 'sip:from@dev-min.dapp.swire.io',
         timeout: 30,
       })
       tap.ok(call.id, 'Call resolved')

--- a/internal/e2e-realtime-api/src/voiceSpeechCollect.test.ts
+++ b/internal/e2e-realtime-api/src/voiceSpeechCollect.test.ts
@@ -1,5 +1,4 @@
 import tap from 'tap'
-import { uuid } from '@signalwire/core'
 import { Voice } from '@signalwire/realtime-api'
 import {
   type TestHandler,
@@ -55,7 +54,7 @@ const getHandlers= (): TestHandler[] => {
           host: process.env.RELAY_HOST,
           project: process.env.RELAY_PROJECT as string,
           token: process.env.RELAY_TOKEN as string,
-          contexts: [domainApp.call_relay_context, "relaye2e"],
+          contexts: [domainApp.call_relay_context],
           // logLevel: "trace",
           debug: {
             logWsTraffic: true,
@@ -125,17 +124,14 @@ const getHandlers= (): TestHandler[] => {
 
         try {
           const call = await client.dialSip({
-            // NOTE: change back to makeSipDomainAppAddress after backend changes are deployed
-            // to: makeSipDomainAppAddress({
-            //   name: 'to',
-            //   domain: domainApp.domain,
-            // }),
-            // from: makeSipDomainAppAddress({
-            //   name: 'from',
-            //   domain: domainApp.domain,
-            // }),
-            to: `sip:to-${uuid()}@dev-min.dapp.swire.io`,
-            from: `sip:from-${uuid()}@dev-min.dapp.swire.io`,
+            to: makeSipDomainAppAddress({
+              name: 'to',
+              domain: domainApp.domain,
+            }),
+            from: makeSipDomainAppAddress({
+              name: 'from',
+              domain: domainApp.domain,
+            }),
             timeout: 30,
           })
           tap.ok(call.id, 'Call resolved')

--- a/internal/e2e-realtime-api/src/voiceSpeechCollect.test.ts
+++ b/internal/e2e-realtime-api/src/voiceSpeechCollect.test.ts
@@ -6,154 +6,194 @@ import {
   makeSipDomainAppAddress,
 } from './utils'
 
-const handler: TestHandler = ({ domainApp }) => {
-  if (!domainApp) {
-    throw new Error('Missing domainApp')
+const handlers= (): TestHandler[] => {
+  const cases = {
+    'continuous: true and partialResults: true': {
+      continuous: true,
+      partialResult: true,
+      hangupAfter: 15_000,
+      expectedText: 'one two three four five six seven eight nine ten  11 to 8',
+    },
+    'continuous: true and partialResults: false': {
+      continuous: true,
+      partialResult: false,
+      hangupAfter: 15_000,
+      expectedText: 'one two three four five six seven eight nine ten  11 to 8',
+    },
+    'continuous: false and partialResults: true': {
+      continuous: false,
+      partialResult: true,
+      hangupAfter: 15_000,
+      expectedText: 'one two three four five six seven eight nine ten  11 to 8',
+    },
+    'continuous: false and partialResults: false': {
+      continuous: false,
+      partialResult: false,
+      hangupAfter: 15_000,
+      expectedText: 'one two three four five six seven eight nine ten  11 to 8',
+    },
+    'continuous: false and partialResults: true (hangup before palying the audio file finish)': {
+      continuous: true,
+      partialResult: true,
+      hangupAfter: 9_000,
+      expectedText: '123456789  10',
+    },
   }
-  return new Promise<number>(async (resolve, reject) => {
-    console.log(domainApp.call_relay_context)
-    const client = new Voice.Client({
-      host: process.env.RELAY_HOST,
-      project: process.env.RELAY_PROJECT as string,
-      token: process.env.RELAY_TOKEN as string,
-      contexts: [domainApp.call_relay_context, "relaye2e"],
-      // logLevel: "trace",
-      debug: {
-        logWsTraffic: true,
-      },
-    })
 
-    let waitForCollectStartResolve
-    const waitForCollectStart = new Promise((resolve) => {
-      waitForCollectStartResolve = resolve
-    })
-    let waitForCollectEndResolve
-    const waitForCollectEnd = new Promise((resolve) => {
-      waitForCollectEndResolve = resolve
-    })
-
-    client.on('call.received', async (call) => {
-      console.log('Got call', call.id, call.from, call.to, call.direction)
-
-      try {
-        const resultAnswer = await call.answer()
-        tap.ok(resultAnswer.id, 'Inbound call answered')
-        tap.equal(
-          call.id,
-          resultAnswer.id,
-          'Call answered gets the same instance'
-        )
-
-        call.on('collect.started', (collect) => {
-          console.log('>>> collect.started')
-        })
-        call.on('collect.updated', (collect) => {
-          console.log('>>> collect.updated', collect.text)
-        })
-        call.on('collect.ended', (collect) => {
-          console.log('>>> collect.ended', collect.text)
-        })
-        call.on('collect.failed', (collect) => {
-          console.log('>>> collect.failed', collect.reason)
-        })
-
-        const callCollect = await call.collect({
-          initialTimeout: 10.0,
-          speech: {
-            endSilenceTimeout: 6.0,
-            speechTimeout: 60.0,
-            language:'en-US',
-            model: 'enhanced.phone_call',
+  const handlers: TestHandler[] = []
+  for (let [testCase, options] of Object.entries(cases)) {
+    handlers.push(({ domainApp }) => {
+      return new Promise(async (resolve, reject) => { 
+        if (!domainApp) {
+          throw new Error('Missing domainApp')
+        }
+        console.log(`Running collect test with ${testCase}`)
+        console.log(domainApp.call_relay_context)
+        const client = new Voice.Client({
+          host: process.env.RELAY_HOST,
+          project: process.env.RELAY_PROJECT as string,
+          token: process.env.RELAY_TOKEN as string,
+          contexts: [domainApp.call_relay_context, "relaye2e"],
+          // logLevel: "trace",
+          debug: {
+            logWsTraffic: true,
           },
-          partialResults: true,
-          continuous: true,
-          sendStartOfInput: true
         })
 
-        // Resolve the answer promise to inform the caller
-        waitForCollectStartResolve()
+        let waitForCollectStartResolve
+        const waitForCollectStart = new Promise((resolve) => {
+          waitForCollectStartResolve = resolve
+        })
+        let waitForCollectEndResolve
+        const waitForCollectEnd = new Promise((resolve) => {
+          waitForCollectEndResolve = resolve
+        })
 
-        // Wait until the caller ends entring the digits
-        await waitForCollectEnd
-        // const collected = await callCollect.stop();
-        const collected = await callCollect.ended() // block the script until the collect ended
-        tap.equal(collected.text, 'one two three four five six seven eight nine ten  11 to 8', 'Collect the correct text')
-        // await callCollect.stop()
-        // await callCollect.startInputTimers()
-        // await call.hangup()
-      } catch (error) {
-        console.error('Error', error)
-        reject(4)
-      }
-    })
+        client.on('call.received', async (call) => {
+          console.log('Got call', call.id, call.from, call.to, call.direction)
 
-    try {
-      const call = await client.dialSip({
-        // to: makeSipDomainAppAddress({
-        //   name: 'to',
-        //   domain: domainApp.domain,
-        // }),
-        // from: makeSipDomainAppAddress({
-        //   name: 'from',
-        //   domain: domainApp.domain,
-        // }),
-        to: 'sip:to@dev-min.dapp.swire.io',
-        from: 'sip:from@dev-min.dapp.swire.io',
-        timeout: 30,
-      })
-      tap.ok(call.id, 'Call resolved')
+          try {
+            const resultAnswer = await call.answer()
+            tap.ok(resultAnswer.id, 'Inbound call answered')
+            tap.equal(
+              call.id,
+              resultAnswer.id,
+              'Call answered gets the same instance'
+            )
 
-      // Wait until the callee answers the call and start collecting digits
-      await waitForCollectStart
+            call.on('collect.started', (collect) => {
+              console.log('>>> collect.started')
+            })
+            call.on('collect.updated', (collect) => {
+              console.log('>>> collect.updated', collect.text)
+            })
+            call.on('collect.ended', (collect) => {
+              console.log('>>> collect.ended', collect.text)
+            })
+            call.on('collect.failed', (collect) => {
+              console.log('>>> collect.failed', collect.reason)
+            })
 
-      // const sendDigitResult = await call.sendDigits('1w2w3w#')
+            const callCollect = await call.collect({
+              initialTimeout: 10.0,
+              speech: {
+                endSilenceTimeout: 6.0,
+                speechTimeout: 60.0,
+                language:'en-US',
+                model: 'enhanced.phone_call',
+              },
+              partialResults: options.partialResult,
+              continuous: options.continuous,
+              sendStartOfInput: true
+            })
+
+            // Resolve the answer promise to inform the caller
+            waitForCollectStartResolve()
+
+            // Wait until the caller ends entring the digits
+            await waitForCollectEnd
+            // const collected = await callCollect.stop();
+            const collected = await callCollect.ended() // block the script until the collect ended
+            tap.equal(collected.text, options.expectedText, 'Received Correct Text')
+            // await callCollect.stop()
+            // await callCollect.startInputTimers()
+            // await call.hangup()
+            const waitForParams = ['ended', 'ending', ['ending', 'ended']] as const
+            const results = await Promise.all(
+              waitForParams.map((params) => call.waitFor(params as any))
+            )
+            waitForParams.forEach((value, i) => {
+              if (typeof value === 'string') {
+                tap.ok(results[i], `"${value}": completed successfully.`)
+              } else {
+                tap.ok(
+                  results[i],
+                  `${JSON.stringify(value)}: completed successfully.`
+                )
+              }
+            })
+            resolve(0)
+          } catch (error) {
+            console.error('Error', error)
+            reject(4)
+          }
+        })
+
+        try {
+          const call = await client.dialSip({
+            // to: makeSipDomainAppAddress({
+            //   name: 'to',
+            //   domain: domainApp.domain,
+            // }),
+            // from: makeSipDomainAppAddress({
+            //   name: 'from',
+            //   domain: domainApp.domain,
+            // }),
+            to: 'sip:to@dev-min.dapp.swire.io',
+            from: 'sip:from@dev-min.dapp.swire.io',
+            timeout: 30,
+          })
+          tap.ok(call.id, 'Call resolved')
+
+          // Wait until the callee answers the call and start collecting digits
+          await waitForCollectStart
+
+          // const sendDigitResult = await call.sendDigits('1w2w3w#')
+          
+          // tap.equal(
+          //   call.id,
+          //   sendDigitResult.id,
+          //   'sendDigit returns the same instance'
+          // )
       
-      // tap.equal(
-      //   call.id,
-      //   sendDigitResult.id,
-      //   'sendDigit returns the same instance'
-      // )
-  
-      call.playAudio({
-        url: 'https://od.lk/s/MzJfMjM1ODY4Nzlf/recording3.mp3',
-      })
-      await new Promise((resolve) => setTimeout(resolve, 7000))
-      await call.hangup()
-      // Resolve the collect end promise to inform the callee
-      waitForCollectEndResolve()
-
-      const waitForParams = ['ended', 'ending', ['ending', 'ended']] as const
-      const results = await Promise.all(
-        waitForParams.map((params) => call.waitFor(params as any))
-      )
-      waitForParams.forEach((value, i) => {
-        if (typeof value === 'string') {
-          tap.ok(results[i], `"${value}": completed successfully.`)
-        } else {
-          tap.ok(
-            results[i],
-            `${JSON.stringify(value)}: completed successfully.`
-          )
+          call.playAudio({
+            url: 'https://od.lk/s/MzJfMjM1ODY4Nzlf/recording3.mp3',
+          })
+          await new Promise((resolve) => setTimeout(resolve, options.hangupAfter))
+          // Resolve the collect end promise to inform the callee
+          waitForCollectEndResolve()
+          await call.hangup()
+        } catch (error) {
+          console.error('Outbound - voiceDetect error', error)
+          reject(4)
         }
       })
-
-      resolve(0)
-    } catch (error) {
-      console.error('Outbound - voiceDetect error', error)
-      reject(4)
-    }
-  })
+    })
+  }
+  return handlers;
 }
 
 async function main() {
-  const runner = createTestRunner({
-    name: 'Voice Speech Collect E2E',
-    testHandler: handler,
-    executionTime: 60_000,
-    useDomainApp: true,
-  })
+  for (let handler of handlers()) {
+    const runner = createTestRunner({
+      name: 'Voice Speech Collect E2E',
+      testHandler: handler,
+      executionTime: 60_000,
+      useDomainApp: true,
+    })
 
-  await runner.run()
+    await runner.run()
+  }
 }
 
 main()

--- a/internal/e2e-realtime-api/src/voiceSpeechCollect.test.ts
+++ b/internal/e2e-realtime-api/src/voiceSpeechCollect.test.ts
@@ -1,0 +1,156 @@
+import tap from 'tap'
+import { Voice } from '@signalwire/realtime-api'
+import {
+  type TestHandler,
+  createTestRunner,
+  makeSipDomainAppAddress,
+} from './utils'
+
+const handler: TestHandler = ({ domainApp }) => {
+  if (!domainApp) {
+    throw new Error('Missing domainApp')
+  }
+  return new Promise<number>(async (resolve, reject) => {
+    const client = new Voice.Client({
+      host: process.env.RELAY_HOST,
+      project: process.env.RELAY_PROJECT as string,
+      token: process.env.RELAY_TOKEN as string,
+      contexts: [domainApp.call_relay_context],
+      // logLevel: "trace",
+      debug: {
+        logWsTraffic: true,
+      },
+    })
+
+    let waitForCollectStartResolve
+    const waitForCollectStart = new Promise((resolve) => {
+      waitForCollectStartResolve = resolve
+    })
+    let waitForCollectEndResolve
+    const waitForCollectEnd = new Promise((resolve) => {
+      waitForCollectEndResolve = resolve
+    })
+
+    client.on('call.received', async (call) => {
+      console.log('Got call', call.id, call.from, call.to, call.direction)
+
+      try {
+        const resultAnswer = await call.answer()
+        tap.ok(resultAnswer.id, 'Inboud call answered')
+        tap.equal(
+          call.id,
+          resultAnswer.id,
+          'Call answered gets the same instance'
+        )
+
+        call.on('collect.started', (collect) => {
+          console.log('>>> collect.started')
+        })
+        call.on('collect.updated', (collect) => {
+          console.log('>>> collect.updated', collect.text)
+        })
+        call.on('collect.ended', (collect) => {
+          console.log('>>> collect.ended', collect.text)
+        })
+        call.on('collect.failed', (collect) => {
+          console.log('>>> collect.failed', collect.reason)
+        })
+
+        const callCollect = await call.collect({
+          initialTimeout: 4.0,
+          speech: {
+            endSilenceTimeout: 2.0,
+            speechTimeout: 60.0,
+            language:'en-US',
+            model: 'enhanced.phone_call',
+          },
+          partialResults: true,
+          continuous: true,
+          sendStartOfInput: true
+        })
+
+        // Resolve the answer promise to inform the caller
+        waitForCollectStartResolve()
+
+        // Wait until the caller ends entring the digits
+        await waitForCollectEnd
+
+        const collected = await callCollect.ended() // block the script until the collect ended
+        tap.equal(collected.text, 'one two three four five six seven eight nine ten', 'Collect the correct text')
+        // await callCollect.stop()
+        // await callCollect.startInputTimers()
+
+        await new Promise((resolve) => setTimeout(resolve, 3000))
+        await call.hangup()
+      } catch (error) {
+        console.error('Error', error)
+        reject(4)
+      }
+    })
+
+    try {
+      const call = await client.dialSip({
+        to: makeSipDomainAppAddress({
+          name: 'to',
+          domain: domainApp.domain,
+        }),
+        from: makeSipDomainAppAddress({
+          name: 'from',
+          domain: domainApp.domain,
+        }),
+        timeout: 30,
+      })
+      tap.ok(call.id, 'Call resolved')
+
+      // Wait until the callee answers the call and start collecting digits
+      await waitForCollectStart
+
+      // const sendDigitResult = await call.sendDigits('1w2w3w#')
+      
+      // tap.equal(
+      //   call.id,
+      //   sendDigitResult.id,
+      //   'sendDigit returns the same instance'
+      // )
+
+      await call.playAudio({
+        url: 'https://od.lk/s/MzJfMjM1ODY4Nzlf/recording3.mp3',
+      })
+      // Resolve the collect end promise to inform the callee
+      waitForCollectEndResolve()
+
+      const waitForParams = ['ended', 'ending', ['ending', 'ended']] as const
+      const results = await Promise.all(
+        waitForParams.map((params) => call.waitFor(params as any))
+      )
+      waitForParams.forEach((value, i) => {
+        if (typeof value === 'string') {
+          tap.ok(results[i], `"${value}": completed successfully.`)
+        } else {
+          tap.ok(
+            results[i],
+            `${JSON.stringify(value)}: completed successfully.`
+          )
+        }
+      })
+
+      resolve(0)
+    } catch (error) {
+      console.error('Outbound - voiceDetect error', error)
+      reject(4)
+    }
+  })
+}
+
+async function main() {
+  const runner = createTestRunner({
+    name: 'Voice Speech Collect E2E',
+    testHandler: handler,
+    executionTime: 60_000,
+    useDomainApp: true,
+  })
+
+  await runner.run()
+}
+
+main()

--- a/packages/core/src/types/voiceCall.ts
+++ b/packages/core/src/types/voiceCall.ts
@@ -1006,12 +1006,14 @@ export type CallingCallCollectEndState = Exclude<
   'start_of_input'
 >
 
+export type CallingCallCollectState = 'error' | 'collecting' | 'finished';
 export interface CallingCallCollectEventParams {
   node_id: string
   call_id: string
   control_id: string
   result: CallingCallCollectResult
   final?: boolean
+  state?: CallingCallCollectState
 }
 
 export interface CallingCallCollectEvent extends SwEvent {

--- a/packages/realtime-api/src/voice/CallCollect.ts
+++ b/packages/realtime-api/src/voice/CallCollect.ts
@@ -113,6 +113,14 @@ export class CallCollectAPI
     return undefined
   }
 
+  get state() {
+    return this._payload.state
+  }
+
+  get final() {
+    return this._payload.final
+  }
+
   /** @internal */
   protected setPayload(payload: CallingCallCollectEventParams) {
     this._payload = payload
@@ -155,12 +163,8 @@ export class CallCollectAPI
   ended() {
     // Resolve the promise if the collect has already ended
     if (
-      ENDED_STATES.includes(this.result?.type as CallingCallCollectEndState) ||
-      // @ts-ignore
-      (this._payload.state == undefined && this._payload.final == true) ||
-      // @ts-ignore
-      (this._payload.state == 'finished')
-    ) {
+      this.state != 'collecting' && (this.final === undefined || this.final === true)  &&
+      ENDED_STATES.includes(this.result?.type as CallingCallCollectEndState)) {
       return Promise.resolve(this)
     }
 

--- a/packages/realtime-api/src/voice/CallCollect.ts
+++ b/packages/realtime-api/src/voice/CallCollect.ts
@@ -120,7 +120,7 @@ export class CallCollectAPI
 
   async stop() {
     // Execute stop only if we don't have result yet
-    if (!this.result) {
+    //if (!this.result) {
       await this.execute({
         method: 'calling.collect.stop',
         params: {
@@ -129,7 +129,7 @@ export class CallCollectAPI
           control_id: this.controlId,
         },
       })
-    }
+    //}
 
     /**
      * TODO: we should wait for the prompt to be finished to allow
@@ -155,7 +155,11 @@ export class CallCollectAPI
   ended() {
     // Resolve the promise if the collect has already ended
     if (
-      ENDED_STATES.includes(this.result?.type as CallingCallCollectEndState)
+      ENDED_STATES.includes(this.result?.type as CallingCallCollectEndState) ||
+      // @ts-ignore
+      (this._payload.state == undefined && this._payload.final == true) ||
+      // @ts-ignore
+      (this._payload.state == 'finished')
     ) {
       return Promise.resolve(this)
     }

--- a/packages/realtime-api/src/voice/CallCollect.ts
+++ b/packages/realtime-api/src/voice/CallCollect.ts
@@ -128,7 +128,7 @@ export class CallCollectAPI
 
   async stop() {
     // Execute stop only if we don't have result yet
-    //if (!this.result) {
+    if (!this.result) {
       await this.execute({
         method: 'calling.collect.stop',
         params: {
@@ -137,7 +137,7 @@ export class CallCollectAPI
           control_id: this.controlId,
         },
       })
-    //}
+    }
 
     /**
      * TODO: we should wait for the prompt to be finished to allow

--- a/packages/realtime-api/src/voice/CallCollect.ts
+++ b/packages/realtime-api/src/voice/CallCollect.ts
@@ -163,8 +163,9 @@ export class CallCollectAPI
   ended() {
     // Resolve the promise if the collect has already ended
     if (
-      this.state != 'collecting' && (this.final === undefined || this.final === true)  &&
-      ENDED_STATES.includes(this.result?.type as CallingCallCollectEndState)) {
+      this.state != 'collecting' && this.final !== false &&
+      ENDED_STATES.includes(this.result?.type as CallingCallCollectEndState)
+    ) {
       return Promise.resolve(this)
     }
 

--- a/packages/realtime-api/src/voice/workers/voiceCallCollectWorker.ts
+++ b/packages/realtime-api/src/voice/workers/voiceCallCollectWorker.ts
@@ -50,22 +50,27 @@ export const voiceCallCollectWorker = function* (
         case 'no_input':
         case 'no_match':
         case 'error': {
-          callInstance.emit(`${eventPrefix}.failed`, actionInstance)
+          if (payload.state !== 'collecting') {
+            callInstance.emit(`${eventPrefix}.failed`, actionInstance)
 
-          // To resolve the ended() promise in CallPrompt or CallCollect
-          actionInstance.emit(`${eventPrefix}.failed` as never, actionInstance)
+            // To resolve the ended() promise in CallPrompt or CallCollect
+            actionInstance.emit(
+              `${eventPrefix}.failed` as never,
+              actionInstance
+            )
 
-          remove<CallCollect>(payload.control_id)
+            remove<CallCollect>(payload.control_id)
+          }
           break
         }
         case 'speech':
         case 'digit': {
-          callInstance.emit(`${eventPrefix}.ended`, actionInstance)
-
-          // To resolve the ended() promise in CallPrompt or CallCollect
-          actionInstance.emit(`${eventPrefix}.ended` as never, actionInstance)
-
-          remove<CallCollect>(payload.control_id)
+          if (payload.state !== 'collecting') {
+            callInstance.emit(`${eventPrefix}.ended`, actionInstance)
+            // To resolve the ended() promise in CallPrompt or CallCollect
+            actionInstance.emit(`${eventPrefix}.ended` as never, actionInstance)
+            remove<CallCollect>(payload.control_id)
+          }
           break
         }
         default:

--- a/scripts/sw-test/runNodeScript.js
+++ b/scripts/sw-test/runNodeScript.js
@@ -69,6 +69,12 @@ async function runNodeScript(config) {
 
         child.stderr.on('data', (data) => {
           console.error(`stderr: ${data}`)
+          // also pass stderr data to child (test file)
+          // some new test cases want to check data on stderr
+          // since we are using `spawn` and intercepting stderr here we need to write it back onto
+          // child.stderr
+          // NOTE: emit is not available here
+          child.stderr.write(data);
         })
 
         child.on('close', (exitCode) => {


### PR DESCRIPTION
### NOTES
In order to run `internal/e2e-realtime-api/voiceSpeechCollect.test.ts` before merging the backend changed
#### Backend Todos
- setup devbox with FS changes
- setup steering to devbox
- create a sip domain app on staging and handle the call on domain app with a relay context `relaye2e`
- add routing to devbox in kamailio for the domain app you set up in previous step

#### SDK Todos
- in `internal/e2e-realtime-api/src/voiceSpeechCollect.test.ts`, replace `dev-min.dapp.swire.io` sip domain with the sip domain you created in above step.
- copy env file into `internal/e2e-realtime-api/.env.test` and setup 
- run `npm dev:rt-only`
### References
- [#7921](https://github.com/signalwire/cloud-product/issues/7921)

### Description
- Added `state` param to `CallingCallCollectEventParams`
- Made sure `voiceCallCollectWorker` doesn't clean up `CallCollect` instance and emit ended/failed event if the `state` is `"collecting"`
- Resolve `CallCollect.ended()` promise only when state is NOT `"collecting"` AND `final` is either `undefined`/`true` AND `result.type` is one of `ENDED_STATES`.
- Added more test cases for `Call.collect()` in `@sw-internal/e2e-realtime-api`
