### PR TITLE
realtime-api - add optional nodeId to call.dial

### DIFF
--- a/.changeset/metal-shirts-switch.md
+++ b/.changeset/metal-shirts-switch.md
@@ -1,0 +1,6 @@
+---
+'@signalwire/realtime-api': patch
+'@signalwire/core': patch
+---
+
+Add an optional nodeId to call.dial

--- a/packages/core/src/types/voiceCall.ts
+++ b/packages/core/src/types/voiceCall.ts
@@ -406,6 +406,7 @@ export type VoiceCallDisconnectReason =
 export interface VoiceCallDialRegionParams {
   region?: VoiceRegion
   maxPricePerMinute?: number
+  nodeId?: string
 }
 
 export type VoiceCallDialPhoneMethodParams = OmitType<VoiceCallPhoneParams> &

--- a/packages/realtime-api/src/voice/Voice.ts
+++ b/packages/realtime-api/src/voice/Voice.ts
@@ -243,10 +243,11 @@ class VoiceAPI extends BaseConsumer<VoiceClientApiEvents> {
           devices: toInternalDevices(devices),
         }
       } else if ('region' in params) {
-        const { region, devices: deviceBuilder } = params
+        const { region, nodeId, devices: deviceBuilder } = params
         executeParams = {
           tag: this._tag,
           region,
+          node_id: nodeId,
           devices: toInternalDevices(deviceBuilder.devices),
         }
       } else {
@@ -265,6 +266,7 @@ class VoiceAPI extends BaseConsumer<VoiceClientApiEvents> {
   dialPhone({
     region,
     maxPricePerMinute,
+    nodeId,
     ...params
   }: VoiceCallDialPhoneMethodParams) {
     const devices = new DeviceBuilder().add(DeviceBuilder.Phone(params))
@@ -272,6 +274,7 @@ class VoiceAPI extends BaseConsumer<VoiceClientApiEvents> {
     return this.dial({
       maxPricePerMinute,
       region,
+      nodeId,
       devices,
     })
   }
@@ -279,6 +282,7 @@ class VoiceAPI extends BaseConsumer<VoiceClientApiEvents> {
   dialSip({
     region,
     maxPricePerMinute,
+    nodeId,
     ...params
   }: VoiceCallDialSipMethodParams) {
     const devices = new DeviceBuilder().add(DeviceBuilder.Sip(params))
@@ -286,6 +290,7 @@ class VoiceAPI extends BaseConsumer<VoiceClientApiEvents> {
     return this.dial({
       maxPricePerMinute,
       region,
+      nodeId,
       devices,
     })
   }


### PR DESCRIPTION
# Description

Add an optional `nodeId` parameter to `dialSip` and `dialPhone`.
It will be added to `call.dial` command as `node_id` parameter.

## Type of change

- [ ] Internal refactoring
- [ ] Bug fix (bugfix - non-breaking)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Code snippets

In case of new feature or breaking changes, please include code snippets.
