### PR TITLE
Delete domainApp on error

### DIFF
--- a/internal/e2e-realtime-api/src/utils.ts
+++ b/internal/e2e-realtime-api/src/utils.ts
@@ -75,8 +75,8 @@ export const createTestRunner = ({
     run: async () => {
       start()
 
+      const params: TestHandlerParams = {}
       try {
-        const params: TestHandlerParams = {}
         if (useDomainApp) {
           params.domainApp = await createDomainApp({
             name: `d-app-${uuid}`,
@@ -89,11 +89,17 @@ export const createTestRunner = ({
         if (params.domainApp) {
           console.log('Delete domain app..')
           await deleteDomainApp({ id: params.domainApp.id })
+          delete params.domainApp
         }
         done(exitCode)
       } catch (error) {
         clearTimeout(timer)
         console.error(`Test Runner ${name} Failed!`, error)
+        if (params.domainApp) {
+          console.log('Delete domain app..')
+          await deleteDomainApp({ id: params.domainApp.id })
+          delete params.domainApp
+        }
         done(1)
       }
     },


### PR DESCRIPTION
# Description

Tests that create a new DomainApp before executing did not delete the created resource when the test failed.
This change forces the DomainApp to be deleted in both cases.

## Type of change

- [ ] Internal refactoring
- [X] Bug fix (bugfix - non-breaking)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
