### PR TITLE
Release 2023-11-08

### DIFF
--- a/.changeset/curly-peaches-do.md
+++ b/.changeset/curly-peaches-do.md
@@ -1,6 +1,0 @@
----
-'@sw-internal/e2e-realtime-api': patch
-'@sw-internal/e2e-js': patch
----
-
-Update E2E tests for lock unlock rooms

--- a/.changeset/healthy-onions-remember.md
+++ b/.changeset/healthy-onions-remember.md
@@ -1,5 +1,0 @@
----
-'@sw-internal/e2e-realtime-api': patch
----
-
-Bump to tap latest to solve semver vulnerability

--- a/.changeset/lemon-icons-compete.md
+++ b/.changeset/lemon-icons-compete.md
@@ -1,7 +1,0 @@
----
-'@signalwire/realtime-api': minor
-'@signalwire/core': minor
-'@signalwire/js': minor
----
-
-Add support for `lock` and `unlock` RoomSessions.

--- a/.changeset/long-timers-rhyme.md
+++ b/.changeset/long-timers-rhyme.md
@@ -1,5 +1,0 @@
----
-'@signalwire/core': patch
----
-
-Bugfix: remove video prefix from member.updated events to emit them properly

--- a/.changeset/metal-shirts-switch.md
+++ b/.changeset/metal-shirts-switch.md
@@ -1,6 +1,0 @@
----
-'@signalwire/realtime-api': patch
-'@signalwire/core': patch
----
-
-Add an optional nodeId to call.dial

--- a/.changeset/nervous-dogs-change.md
+++ b/.changeset/nervous-dogs-change.md
@@ -1,5 +1,0 @@
----
-'@sw-internal/e2e-realtime-api': patch
----
-
-Split lock/unlock tests

--- a/.changeset/slow-apricots-carry.md
+++ b/.changeset/slow-apricots-carry.md
@@ -1,5 +1,0 @@
----
-'@sw-internal/e2e-realtime-api': patch
----
-
-Delete the domain app when the test ends

--- a/.changeset/wet-windows-cover.md
+++ b/.changeset/wet-windows-cover.md
@@ -1,5 +1,0 @@
----
-'@sw-internal/e2e-js': patch
----
-
-End to end test cases for call fabric with video room and swml script

--- a/internal/e2e-js/CHANGELOG.md
+++ b/internal/e2e-js/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @sw-internal/e2e-js
 
+## 0.0.16
+
+### Patch Changes
+
+- [#884](https://github.com/signalwire/signalwire-js/pull/884) [`e5db7cab`](https://github.com/signalwire/signalwire-js/commit/e5db7cabc2e532a19fad45753e47f7d612d6e248) Thanks [@edolix](https://github.com/edolix)! - Update E2E tests for lock unlock rooms
+
+- [#900](https://github.com/signalwire/signalwire-js/pull/900) [`80cd3252`](https://github.com/signalwire/signalwire-js/commit/80cd32526f97a2db71c786f5bc700f300fce820d) Thanks [@iAmmar7](https://github.com/iAmmar7)! - End to end test cases for call fabric with video room and swml script
+
 ## 0.0.15
 
 ### Patch Changes

--- a/internal/e2e-js/package.json
+++ b/internal/e2e-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sw-internal/e2e-js",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "private": true,
   "main": "index.js",
   "scripts": {

--- a/internal/e2e-realtime-api/CHANGELOG.md
+++ b/internal/e2e-realtime-api/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @sw-internal/e2e-realtime-api
 
+## 0.1.12
+
+### Patch Changes
+
+- [#884](https://github.com/signalwire/signalwire-js/pull/884) [`e5db7cab`](https://github.com/signalwire/signalwire-js/commit/e5db7cabc2e532a19fad45753e47f7d612d6e248) Thanks [@edolix](https://github.com/edolix)! - Update E2E tests for lock unlock rooms
+
+- [#893](https://github.com/signalwire/signalwire-js/pull/893) [`a66d5a2c`](https://github.com/signalwire/signalwire-js/commit/a66d5a2c521c92a47621b23e48bba7cd7272b0db) Thanks [@edolix](https://github.com/edolix)! - Bump to tap latest to solve semver vulnerability
+
+- [#884](https://github.com/signalwire/signalwire-js/pull/884) [`e5db7cab`](https://github.com/signalwire/signalwire-js/commit/e5db7cabc2e532a19fad45753e47f7d612d6e248) Thanks [@edolix](https://github.com/edolix)! - Split lock/unlock tests
+
+- [#888](https://github.com/signalwire/signalwire-js/pull/888) [`fc2b5b1c`](https://github.com/signalwire/signalwire-js/commit/fc2b5b1c1a944386c297638edb4c6d4af20ad9f8) Thanks [@edolix](https://github.com/edolix)! - Delete the domain app when the test ends
+
 ## 0.1.11
 
 ### Patch Changes

--- a/internal/e2e-realtime-api/package.json
+++ b/internal/e2e-realtime-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sw-internal/e2e-realtime-api",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "private": true,
   "main": "index.js",
   "scripts": {

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.20.0] - 2023-11-07
+
+### Added
+
+- [#884](https://github.com/signalwire/signalwire-js/pull/884) [`e5db7cab`](https://github.com/signalwire/signalwire-js/commit/e5db7cabc2e532a19fad45753e47f7d612d6e248) Thanks [@edolix](https://github.com/edolix)! - Add support for `lock` and `unlock` RoomSessions.
+
+### Fixed
+
+- [#885](https://github.com/signalwire/signalwire-js/pull/885) [`bcced8ae`](https://github.com/signalwire/signalwire-js/commit/bcced8ae774de5483331c4d3146299d5ffffd7e7) Thanks [@edolix](https://github.com/edolix)! - Bugfix: remove video prefix from member.updated events to emit them properly
+
+### Added
+
+- [#901](https://github.com/signalwire/signalwire-js/pull/901) [`2131bb41`](https://github.com/signalwire/signalwire-js/commit/2131bb418afeb75081fb2bfaee3b00a24df4614f) Thanks [@giavac](https://github.com/giavac)! - Add an optional nodeId to call.dial
+
 ## [3.19.0] - 2023-09-14
 
 ### Added

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,7 +3,7 @@
   "description": "Shared code for the SignalWire JS SDK",
   "author": "SignalWire Team <open.source@signalwire.com>",
   "license": "MIT",
-  "version": "3.19.0",
+  "version": "3.20.0",
   "main": "dist/index.node.js",
   "module": "dist/index.esm.js",
   "files": [

--- a/packages/js/CHANGELOG.md
+++ b/packages/js/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.24.0] - 2023-11-07
+
+### Added
+
+- [#884](https://github.com/signalwire/signalwire-js/pull/884) [`e5db7cab`](https://github.com/signalwire/signalwire-js/commit/e5db7cabc2e532a19fad45753e47f7d612d6e248) Thanks [@edolix](https://github.com/edolix)! - Add support for `lock` and `unlock` RoomSessions.
+
+### Dependencies
+
+- Updated dependencies [[`e5db7cab`](https://github.com/signalwire/signalwire-js/commit/e5db7cabc2e532a19fad45753e47f7d612d6e248), [`bcced8ae`](https://github.com/signalwire/signalwire-js/commit/bcced8ae774de5483331c4d3146299d5ffffd7e7), [`2131bb41`](https://github.com/signalwire/signalwire-js/commit/2131bb418afeb75081fb2bfaee3b00a24df4614f)]:
+  - @signalwire/core@3.20.0
+  - @signalwire/webrtc@3.10.4
+
 ## [3.23.4] - 2023-09-14
 
 ### Changed

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -3,7 +3,7 @@
   "description": "SignalWire JS SDK",
   "author": "SignalWire Team <open.source@signalwire.com>",
   "license": "MIT",
-  "version": "3.23.4",
+  "version": "3.24.0",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",
   "unpkg": "dist/index.umd.js",
@@ -39,8 +39,8 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@signalwire/core": "3.19.0",
-    "@signalwire/webrtc": "3.10.3",
+    "@signalwire/core": "3.20.0",
+    "@signalwire/webrtc": "3.10.4",
     "jwt-decode": "^3.1.2"
   },
   "types": "dist/js/src/index.d.ts"

--- a/packages/realtime-api/CHANGELOG.md
+++ b/packages/realtime-api/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.12.0] - 2023-11-07
+
+### Added
+
+- [#884](https://github.com/signalwire/signalwire-js/pull/884) [`e5db7cab`](https://github.com/signalwire/signalwire-js/commit/e5db7cabc2e532a19fad45753e47f7d612d6e248) Thanks [@edolix](https://github.com/edolix)! - Add support for `lock` and `unlock` RoomSessions.
+
+### Added
+
+- [#901](https://github.com/signalwire/signalwire-js/pull/901) [`2131bb41`](https://github.com/signalwire/signalwire-js/commit/2131bb418afeb75081fb2bfaee3b00a24df4614f) Thanks [@giavac](https://github.com/giavac)! - Add an optional nodeId to call.dial
+
+### Dependencies
+
+- Updated dependencies [[`e5db7cab`](https://github.com/signalwire/signalwire-js/commit/e5db7cabc2e532a19fad45753e47f7d612d6e248), [`bcced8ae`](https://github.com/signalwire/signalwire-js/commit/bcced8ae774de5483331c4d3146299d5ffffd7e7), [`2131bb41`](https://github.com/signalwire/signalwire-js/commit/2131bb418afeb75081fb2bfaee3b00a24df4614f)]:
+  - @signalwire/core@3.20.0
+
 ## [3.11.0] - 2023-09-14
 
 ### Added

--- a/packages/realtime-api/package.json
+++ b/packages/realtime-api/package.json
@@ -3,7 +3,7 @@
   "description": "SignalWire RealTime SDK for Node.js",
   "author": "SignalWire Team <open.source@signalwire.com>",
   "license": "MIT",
-  "version": "3.11.0",
+  "version": "3.12.0",
   "main": "dist/index.node.js",
   "exports": {
     "require": "./dist/index.node.js",
@@ -37,7 +37,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@signalwire/core": "3.19.0",
+    "@signalwire/core": "3.20.0",
     "ws": "^8.13.0"
   },
   "devDependencies": {

--- a/packages/web-api/CHANGELOG.md
+++ b/packages/web-api/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.3] - 2023-11-07
+
+### Dependencies
+
+- Updated dependencies [[`e5db7cab`](https://github.com/signalwire/signalwire-js/commit/e5db7cabc2e532a19fad45753e47f7d612d6e248), [`bcced8ae`](https://github.com/signalwire/signalwire-js/commit/bcced8ae774de5483331c4d3146299d5ffffd7e7), [`2131bb41`](https://github.com/signalwire/signalwire-js/commit/2131bb418afeb75081fb2bfaee3b00a24df4614f)]:
+  - @signalwire/core@3.20.0
+
 ## [3.0.2] - 2023-09-14
 
 ### Changed

--- a/packages/web-api/package.json
+++ b/packages/web-api/package.json
@@ -3,7 +3,7 @@
   "description": "SignalWire Web-API SDK for Node.js",
   "author": "SignalWire Team <open.source@signalwire.com>",
   "license": "MIT",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "main": "dist/index.node.js",
   "exports": {
     "require": "./dist/index.node.js",
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@signalwire/compatibility-api": "^3.1.3",
-    "@signalwire/core": "3.19.0",
+    "@signalwire/core": "3.20.0",
     "node-abort-controller": "^2.0.0",
     "node-fetch": "^2.6.1"
   },

--- a/packages/webrtc/CHANGELOG.md
+++ b/packages/webrtc/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.10.4] - 2023-11-07
+
+### Dependencies
+
+- Updated dependencies [[`e5db7cab`](https://github.com/signalwire/signalwire-js/commit/e5db7cabc2e532a19fad45753e47f7d612d6e248), [`bcced8ae`](https://github.com/signalwire/signalwire-js/commit/bcced8ae774de5483331c4d3146299d5ffffd7e7), [`2131bb41`](https://github.com/signalwire/signalwire-js/commit/2131bb418afeb75081fb2bfaee3b00a24df4614f)]:
+  - @signalwire/core@3.20.0
+
 ## [3.10.3] - 2023-09-14
 
 ### Changed

--- a/packages/webrtc/package.json
+++ b/packages/webrtc/package.json
@@ -3,7 +3,7 @@
   "description": "SignalWire WebRTC library",
   "author": "SignalWire Team <open.source@signalwire.com>",
   "license": "MIT",
-  "version": "3.10.3",
+  "version": "3.10.4",
   "main": "dist/cjs/webrtc/src/index.js",
   "module": "dist/mjs/webrtc/src/index.js",
   "files": [
@@ -37,7 +37,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@signalwire/core": "3.19.0",
+    "@signalwire/core": "3.20.0",
     "sdp": "^3.2.0"
   },
   "types": "dist/cjs/webrtc/src/index.d.ts"


### PR DESCRIPTION
# Description

Release including:

- End-to-end test cases for call fabric
- Additional lock/unlock tests
- Optional nodeId to call.dial
- Add support for `lock` and `unlock` RoomSessions

## Type of change

- [x] Release
- [ ] Internal refactoring
- [ ] Bug fix (bugfix - non-breaking)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
