### PR TITLE
Remove pull request trigger for scheduled e2e

### DIFF
--- a/.github/workflows/realtime-api-production-euswcom.yml
+++ b/.github/workflows/realtime-api-production-euswcom.yml
@@ -1,8 +1,6 @@
 name: RealtimeAPI SDK [production euswcom]
 
 on:
-  pull_request:
-    branches: [ main ]
   workflow_call:
   workflow_dispatch:
   schedule:


### PR DESCRIPTION
Follow-up to https://github.com/signalwire/signalwire-js/pull/905, I forgot to remove the pull request trigger.