### PR TITLE
runNodeScript.js, add includeFiles and create a test report

### DIFF
--- a/scripts/sw-test/README.md
+++ b/scripts/sw-test/README.md
@@ -26,6 +26,7 @@ By default we'll use the `SW_TEST_CONFIG` environment variable to load the confi
 | `env`  | :white_check_mark:  | :white_check_mark:  | :white_check_mark:  |
 | `ignoreTests` | :white_check_mark:  | :white_check_mark:  | :white_check_mark:  |
 | `ignoreFiles`  | :x:  | :x:  | :white_check_mark:  |
+| `includeFiles`  | :x:  | :x:  | :white_check_mark:  |
 
 ### `env` (`Object`): Environment Variables
 You can define the environment variables to be used in your tests in a single spot using JS Object notation.
@@ -62,3 +63,13 @@ Example:
 ```
 SW_TEST_CONFIG='{ "ignoreFiles": ["voice.test.ts"] }'
 ```
+
+### `includeFiles` (`string[]`): Include Files by name.
+Any files that match the given name will be used.
+
+Example:
+```
+SW_TEST_CONFIG='{ "includeFiles": ["voiceCollect/withAllListeners.test.ts", "voicePlayback/withPlaybackListeners.test.ts"] }'
+```
+
+This is optional.

--- a/scripts/sw-test/README.md
+++ b/scripts/sw-test/README.md
@@ -72,4 +72,4 @@ Example:
 SW_TEST_CONFIG='{ "includeFiles": ["voiceCollect/withAllListeners.test.ts", "voicePlayback/withPlaybackListeners.test.ts"] }'
 ```
 
-This is optional.
+This is optional. If missing or empty it will be considered as "include all" (unless listed in `ignoredFiles`).

--- a/scripts/sw-test/runNodeScript.js
+++ b/scripts/sw-test/runNodeScript.js
@@ -85,6 +85,7 @@ async function runNodeScript(config) {
   try {
     for await (const test of tests) {
       await new Promise((resolve, reject) => {
+        console.log('Running Test', test.name)
         const child = spawn(...getRunParams(test))
 
         child.stdout.on('data', (data) => {

--- a/scripts/sw-test/runNodeScript.js
+++ b/scripts/sw-test/runNodeScript.js
@@ -11,7 +11,7 @@ const ALLOWED_SCRIPT_EXTENSIONS = ['js', 'ts']
 
 const getScriptOptions = (pathname, config) => {
   const ignoreFiles = config.ignoreFiles || []
-  const includeFiles = config.includeFiles || undefined
+  const includeFiles = config.includeFiles || []
   const ignoreDirectories = config.ignoreDirectories
     ? [...config.ignoreDirectories, 'playwright']
     : ['playwright']
@@ -34,12 +34,11 @@ const getScriptOptions = (pathname, config) => {
       .replace(/\.\.(\/|\\)/g, '')
       .replace(/\\/g, '/')
 
-    if (
-      fs.lstatSync(itemPath).isFile() &&
-      (((includeFiles === undefined) && normalizedPath.includes('.test.')) ||
-       ((includeFiles !== undefined) && includeFiles.includes(normalizedPath))) &&
-      !ignoreFiles.includes(normalizedPath)
-    ) {
+    const isValidFile = fs.lstatSync(itemPath).isFile() && normalizedPath.includes('.test.')
+    const isIncludedFile = (includeFiles.length == 0) || includeFiles.includes(normalizedPath)
+    const isIgnoredFile = ignoreFiles.includes(normalizedPath)
+
+    if (isValidFile && isIncludedFile && !isIgnoredFile) {
       acc.push({
         name: normalizedPath,
         type: getScriptType(itemPath),


### PR DESCRIPTION
# Description

Review sw-test/runNodeScript.js so that it's possible to provide a list of tests to execute inside `SW_TEST_CONFIG` (`includeFiles` array).
Log test results as the run completes.
Don't interrupt the run if a test fails.
Updated README.

## Type of change

- [x] Internal refactoring
- [ ] Bug fix (bugfix - non-breaking)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


