### PR TITLE
Video & CF SDK: Allow user to disable UDP transport

### DIFF
--- a/.changeset/tiny-dancers-rescue.md
+++ b/.changeset/tiny-dancers-rescue.md
@@ -1,0 +1,34 @@
+---
+'@signalwire/webrtc': minor
+'@signalwire/js': minor
+---
+
+Allow users to pass the optional `disableUdpIceServers` boolean flag with a value of `true` to remove the URLs of UDP transport ICE servers.
+
+Default value for `disableUdpIceServers` is `false`
+
+Call Fabric SDK:
+
+```js
+import { SignalWire } from '@signalwire/js'
+
+const client = await SignalWire({
+   host: ...,
+   token: ...,
+   rootElement: ...,
+   disableUdpIceServers: true|false, // default is false
+})
+```
+
+Video SDK:
+
+```js
+import { Video } from '@signalwire/js'
+
+const roomSession = new Video.RoomSession({
+   host: ...,
+   token: ...,
+   rootElement: ...,
+   disableUdpIceServers: true|false, // default is false
+})
+```

--- a/packages/js/src/BaseRoomSession.ts
+++ b/packages/js/src/BaseRoomSession.ts
@@ -31,6 +31,7 @@ import type {
   RoomSessionConnectionContract,
   BaseRoomSessionJoinParams,
   LocalOverlay,
+  AudioElement,
 } from './utils/interfaces'
 import { SCREENSHARE_AUDIO_CONSTRAINTS } from './utils/constants'
 import { audioSetSpeakerAction } from './features/actions'
@@ -65,6 +66,11 @@ export interface BaseRoomSession<T>
   leave(): Promise<void>
 }
 
+interface BaseRoomSessionOptions
+  extends BaseConnection<RoomSessionObjectEvents> {
+  mirrorLocalVideoOverlay: boolean
+}
+
 export class RoomSessionConnection
   extends BaseConnection<RoomSessionObjectEvents>
   implements BaseRoomInterface, RoomSessionConnectionContract
@@ -72,17 +78,9 @@ export class RoomSessionConnection
   private _screenShareList = new Set<RoomSessionScreenShare>()
   private _deviceList = new Set<RoomSessionDevice>()
   private _mirrored: LocalOverlay['mirrored']
-  private _audioEl:
-    | HTMLAudioElement & {
-        sinkId?: string
-        setSinkId?: (id: string) => Promise<void>
-      }
+  private _audioEl: AudioElement
 
-  constructor(
-    options: BaseConnection<RoomSessionObjectEvents> & {
-      mirrorLocalVideoOverlay: boolean
-    }
-  ) {
+  constructor(options: BaseRoomSessionOptions) {
     super(options)
     this._mirrored = options.mirrorLocalVideoOverlay
 

--- a/packages/js/src/RoomSession.ts
+++ b/packages/js/src/RoomSession.ts
@@ -111,6 +111,7 @@ export const RoomSession = function (roomOptions: RoomSessionOptions) {
     localStream,
     watchMediaPackets,
     watchMediaPacketsTimeout,
+    disableUdpIceServers = false,
     ...userOptions
   } = roomOptions
 
@@ -176,6 +177,7 @@ export const RoomSession = function (roomOptions: RoomSessionOptions) {
     watchMediaPackets,
     watchMediaPacketsTimeout,
     prevCallId: reattachManager.getPrevCallId(),
+    disableUdpIceServers,
   })
 
   // WebRTC connection left the room.

--- a/packages/js/src/fabric/SignalWire.ts
+++ b/packages/js/src/fabric/SignalWire.ts
@@ -1,12 +1,10 @@
 import { type UserOptions } from '@signalwire/core'
 import { HTTPClient } from './HTTPClient'
-import { WSClient } from './WSClient'
+import { WSClient, WSClientOptions } from './WSClient'
 
-interface SignalWireOptions extends UserOptions {
-  rootElement?: HTMLElement
-}
+export interface SignalWireOptions extends UserOptions, WSClientOptions {}
 
-interface SignalWireContract {
+export interface SignalWireContract {
   httpHost: HTTPClient['httpHost']
   getAddresses: HTTPClient['getAddresses']
   registerDevice: HTTPClient['registerDevice']

--- a/packages/js/src/fabric/WSClient.ts
+++ b/packages/js/src/fabric/WSClient.ts
@@ -17,8 +17,11 @@ interface PushNotification {
   decrypted: Record<string, any>
 }
 
-interface WSClientOptions extends UserOptions {
+export interface WSClientOptions extends UserOptions {
+  /** HTML element in which to display the video stream */
   rootElement?: HTMLElement
+  /** Disable ICE UDP transport policy */
+  disableUdpIceServers?: boolean
 }
 
 export class WSClient {
@@ -85,6 +88,7 @@ export class WSClient {
           watchMediaPackets: false,
           // watchMediaPacketsTimeout:,
           nodeId: params.nodeId,
+          disableUdpIceServers: this.options.disableUdpIceServers || false,
         })
 
         // WebRTC connection left the room.

--- a/packages/js/src/utils/interfaces.ts
+++ b/packages/js/src/utils/interfaces.ts
@@ -461,3 +461,8 @@ export type PagingCursor =
       before?: never
       after: string
     }
+
+export interface AudioElement extends HTMLAudioElement {
+  sinkId?: string
+  setSinkId?: (id: string) => Promise<void>
+}

--- a/packages/webrtc/src/RTCPeer.ts
+++ b/packages/webrtc/src/RTCPeer.ts
@@ -1,5 +1,9 @@
 import { EventEmitter, getLogger, uuid } from '@signalwire/core'
-import { getUserMedia, getMediaConstraints } from './utils/helpers'
+import {
+  getUserMedia,
+  getMediaConstraints,
+  filterIceServers,
+} from './utils/helpers'
 import {
   sdpStereoHack,
   sdpBitrateHack,
@@ -148,7 +152,9 @@ export default class RTCPeer<EventTypes extends EventEmitter.ValidEventTypes> {
     const { rtcPeerConfig = {} } = this.options
     const config: RTCConfiguration = {
       bundlePolicy: 'max-compat',
-      iceServers: this.call.iceServers,
+      iceServers: filterIceServers(this.call.iceServers, {
+        disableUdpIceServers: this.options.disableUdpIceServers,
+      }),
       // @ts-ignore
       sdpSemantics: 'unified-plan',
       ...rtcPeerConfig,

--- a/packages/webrtc/src/utils/helpers.ts
+++ b/packages/webrtc/src/utils/helpers.ts
@@ -47,3 +47,29 @@ export const getMediaConstraints = async (
 
   return { audio, video }
 }
+
+interface FilterIceServersOptions {
+  disableUdpIceServers?: boolean
+}
+
+export const filterIceServers = (
+  servers: RTCIceServer[],
+  options: FilterIceServersOptions
+) => {
+  const { disableUdpIceServers = false } = options
+
+  const filterOutUdpUrls = (urls: string | string[]) => {
+    const transportParam = 'transport=udp'
+
+    if (Array.isArray(urls)) {
+      return urls.filter((url) => !url.includes(transportParam))
+    }
+
+    return urls.includes(transportParam) ? '' : urls
+  }
+
+  return servers.map((server) => ({
+    ...server,
+    urls: disableUdpIceServers ? filterOutUdpUrls(server.urls) : server.urls,
+  }))
+}

--- a/packages/webrtc/src/utils/interfaces.ts
+++ b/packages/webrtc/src/utils/interfaces.ts
@@ -21,6 +21,8 @@ export interface ConnectionOptions {
   remoteStream?: MediaStream
   /** List of ICE servers. */
   iceServers?: RTCIceServer[]
+  /** Disable ICE UDP transport policy */
+  disableUdpIceServers?: boolean
   /** Audio constraints to use when joining the room. Default: `true`. */
   audio?: MediaStreamConstraints['audio']
   /** Video constraints to use when joining the room. Default: `true`. */


### PR DESCRIPTION
# Description

Allow users to pass the optional `disableUdpIceServers` boolean flag with a value of `true` to remove the URLs of UDP transport ICE servers.

Default value for `disableUdpIceServers` is `false`

ref: https://github.com/signalwire/cloud-support/issues/3245

## Type of change

- [ ] Internal refactoring
- [ ] Bug fix (bugfix - non-breaking)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Code snippets

Call Fabric SDK:
```js
import { SignalWire } from '@signalwire/js'

const client = await SignalWire({
   host: ...,
   token: ...,
   rootElement: ...,
   disableUdpIceServers: true|false, // default is false
})
```

Video SDK:
```js
import { Video } from '@signalwire/js'

const roomSession = new Video.RoomSession({
   host: ...,
   token: ...,
   rootElement: ...,
   disableUdpIceServers: true|false, // default is false
})
```
