### PR TITLE
Voice SDK: Fix tap event typo

### DIFF
--- a/.changeset/red-hairs-work.md
+++ b/.changeset/red-hairs-work.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/realtime-api': patch
+---
+
+Fix tap.started event on Tap instance

--- a/packages/realtime-api/src/voice/workers/voiceCallTapWorker.ts
+++ b/packages/realtime-api/src/voice/workers/voiceCallTapWorker.ts
@@ -54,7 +54,7 @@ export const voiceCallTapWorker: SDKWorker<Client> = function* (
     switch (payload.state) {
       case 'tapping':
         callInstance.emit('tap.started', tapInstance)
-        tapInstance.emit('tap.ended', tapInstance)
+        tapInstance.emit('tap.started', tapInstance)
         return false
       case 'finished':
         callInstance.emit('tap.ended', tapInstance)


### PR DESCRIPTION
# Description

Fix `tap.started` event on Tap instance 

ref: https://github.com/signalwire/cloud-product/issues/8970

## Type of change

- [ ] Internal refactoring
- [x] Bug fix (bugfix - non-breaking)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Code snippets

In case of new feature or breaking changes, please include code snippets.
