### PR TITLE
Add public getConversationHistory

### DIFF
--- a/.changeset/twenty-boats-film.md
+++ b/.changeset/twenty-boats-film.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/js': minor
+---
+
+Add getConversationHistory in the public API

--- a/.gitignore
+++ b/.gitignore
@@ -13,12 +13,14 @@ log.txt
 .vscode/
 .sass-cache/
 .versions/
+.devcontainer/
 node_modules/
 $RECYCLE.BIN/
 
 .DS_Store
 Thumbs.db
 UserInterfaceState.xcuserstate
+.env
 .env.local
 .env.development.local
 .env.test.local

--- a/packages/core/src/types/callfabric.ts
+++ b/packages/core/src/types/callfabric.ts
@@ -1,18 +1,6 @@
-export interface FetchAddressResponse {
+export interface PaginatedResponse<T> {
   data:
-    | Array<{
-        display_name: string
-        name: string
-        preview_url?: string
-        cover_url?: string
-        resource_id: string
-        type: string
-        channels: {
-          audio?: string
-          messaging?: string
-          video?: string
-        }
-      }>
+    | Array<T>
     | []
   links: {
     first: string
@@ -22,7 +10,35 @@ export interface FetchAddressResponse {
   }
 }
 
+export interface Address {
+  display_name: string
+  name: string
+  preview_url?: string
+  cover_url?: string
+  resource_id: string
+  type: string
+  channels: {
+    audio?: string
+    messaging?: string
+    video?: string
+  }
+}
+export interface FetchAddressResponse extends PaginatedResponse<Address>{}
+
 export interface GetAddressesOptions {
   type?: string
   displayName?: string
 }
+
+export interface ConversationHistory {       
+  type: string
+  // FIXME needs to be completed
+}
+
+export interface FetchConversationHistoryResponse extends PaginatedResponse<ConversationHistory>{}
+
+export interface GetConversationHistoriOption {
+  subscriberId: string,
+  addressId: string,
+  limit?: number
+} 

--- a/packages/js/src/fabric/HTTPClient.ts
+++ b/packages/js/src/fabric/HTTPClient.ts
@@ -1,6 +1,11 @@
 import {
+  Address,
+  ConversationHistory,
+  FetchConversationHistoryResponse,
   FetchAddressResponse,
   GetAddressesOptions,
+  GetConversationHistoriOption,
+  PaginatedResponse,
   type UserOptions,
 } from '@signalwire/core'
 import { createHttpClient } from './createHttpClient'
@@ -23,12 +28,51 @@ export class HTTPClient {
     })
   }
 
+  private async _anotherPage<T>(url: string) {
+    const { body } = await this.httpClient<PaginatedResponse<T>>(url)
+    return this._buildPaginatedResult(body)
+  }
+
+  private async _buildPaginatedResult<T>(body: PaginatedResponse<T>) {
+    return {
+      addresses: body.data,
+      nextPage: async () => {
+        const { next } = body.links
+        return next ? this._anotherPage(next) : undefined
+      },
+      prevPage: async () => {
+        const { prev } = body.links
+        return prev ? this._anotherPage(prev) : undefined
+      },
+      firstPage: async () => {
+        const { first } = body.links
+        return first ? this._anotherPage(first) : undefined
+      },
+      hasNext: Boolean(body.links.next),
+      hasPrev: Boolean(body.links.prev),
+    }
+  }
+
   get httpHost() {
     const { host } = this.options
     if (!host) {
       return 'fabric.signalwire.com'
     }
     return `fabric.${host.split('.').splice(1).join('.')}`
+  }
+
+  public async getConversationHistory(options: GetConversationHistoriOption) {
+    const { subscriberId, addressId, limit = 15 } = options
+    const path = '/conversations'
+
+    const queryParams = new URLSearchParams()
+    queryParams.append('subscriber_id', subscriberId)
+    queryParams.append('address_id', addressId)
+    queryParams.append('limit', `${limit}`)
+
+    const { body } = await this.httpClient<FetchConversationHistoryResponse>(`${path}?${queryParams.toString()}`)
+
+    return this._buildPaginatedResult<ConversationHistory>(body)
   }
 
   public async getAddresses(options?: GetAddressesOptions) {
@@ -52,32 +96,7 @@ export class HTTPClient {
 
     const { body } = await this.httpClient<FetchAddressResponse>(path)
 
-    const anotherPage = async (url: string) => {
-      const { body } = await this.httpClient<FetchAddressResponse>(url)
-      return buildResult(body)
-    }
-
-    const buildResult = (body: FetchAddressResponse) => {
-      return {
-        addresses: body.data,
-        nextPage: async () => {
-          const { next } = body.links
-          return next ? anotherPage(next) : undefined
-        },
-        prevPage: async () => {
-          const { prev } = body.links
-          return prev ? anotherPage(prev) : undefined
-        },
-        firstPage: async () => {
-          const { first } = body.links
-          return first ? anotherPage(first) : undefined
-        },
-        hasNext: Boolean(body.links.next),
-        hasPrev: Boolean(body.links.prev),
-      }
-    }
-
-    return buildResult(body)
+    return this._buildPaginatedResult<Address>(body)
   }
 
   public async registerDevice({


### PR DESCRIPTION
# Description

- Adds a new public method to fetch the conversation history.
- small refactor to generalize how to handle paginated responses generically   

Please include a summary of the change and which issue is fixed. 

## Type of change

- [ ] Internal refactoring
- [ ] Bug fix (bugfix - non-breaking)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Code snippets

`const conversations = client.getConversationHistory({subscriberId: 'X', addressId: 'Z', limit: 5})`
