### PR TITLE
build: Update actions to use Node.js 20

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -12,7 +12,7 @@ runs:
   steps:
     - name: Cache dist folders
       id: cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         key: ${{ github.ref }}-${{ github.sha }}
         path: packages/*/dist

--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -11,13 +11,13 @@ runs:
   using: composite
   steps:
     - name: Setup node
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ inputs.NODE_VERSION }}
         cache: npm
     - name: Cache node_modules
       id: cache_node_modules
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         key: ${{ runner.os }}-node-modules-${{ inputs.NODE_VERSION }}-${{ hashFiles('**/package-lock.json') }}
         path: |

--- a/.github/actions/playwright/action.yml
+++ b/.github/actions/playwright/action.yml
@@ -10,7 +10,7 @@ runs:
   using: composite
   steps:
     - name: Cache playwright binaries
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: playwright-cache
       with:
         path: |

--- a/.github/actions/setup-js-app/action.yml
+++ b/.github/actions/setup-js-app/action.yml
@@ -11,7 +11,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup node
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ inputs.NODE_VERSION }}
         cache: 'npm'

--- a/.github/actions/setup-node-app/action.yml
+++ b/.github/actions/setup-node-app/action.yml
@@ -11,7 +11,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup node
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ inputs.NODE_VERSION }}
         cache: 'npm'

--- a/.github/workflows/browser-js-production-eu-region.yml
+++ b/.github/workflows/browser-js-production-eu-region.yml
@@ -15,7 +15,7 @@ jobs:
     name: Run E2E tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install deps
         uses: ./.github/actions/install
         with:

--- a/.github/workflows/browser-js-production.yml
+++ b/.github/workflows/browser-js-production.yml
@@ -19,7 +19,7 @@ jobs:
         node-version: [18.x]
         project: [default, streaming, slow]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install deps
         uses: ./.github/actions/install
         with:

--- a/.github/workflows/browser-js-staging.yml
+++ b/.github/workflows/browser-js-staging.yml
@@ -19,7 +19,7 @@ jobs:
         node-version: [18.x]
         project: [default, streaming, slow]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install deps
         uses: ./.github/actions/install
         with:

--- a/.github/workflows/realtime-api-production-euswcom.yml
+++ b/.github/workflows/realtime-api-production-euswcom.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         node-version: [18.x]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install deps
         uses: ./.github/actions/install
         with:

--- a/.github/workflows/realtime-api-production.yml
+++ b/.github/workflows/realtime-api-production.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         node-version: [18.x]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install deps
         uses: ./.github/actions/install
         with:

--- a/.github/workflows/realtime-api-staging.yml
+++ b/.github/workflows/realtime-api-staging.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         node-version: [18.x]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install deps
         uses: ./.github/actions/install
         with:

--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -22,8 +22,8 @@ jobs:
         node-version: [18.x]
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         node-version: [18.x]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install deps
         uses: ./.github/actions/install
         with:

--- a/.github/workflows/update-playgrounds.yml
+++ b/.github/workflows/update-playgrounds.yml
@@ -15,8 +15,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 18.x
       - name: Build static assets for each branch


### PR DESCRIPTION
# Description

Fixes deprecation warning

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/setup-node@v3, actions/cache@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

## Type of change

- [X] Internal refactoring
- [ ] Bug fix (bugfix - non-breaking)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Code snippets

In case of new feature or breaking changes, please include code snippets.
