### PR TITLE
Collect tests: consider numerical version of detected string and partial results

### DIFF
--- a/.changeset/brave-monkeys-wink.md
+++ b/.changeset/brave-monkeys-wink.md
@@ -1,0 +1,6 @@
+---
+'@sw-internal/e2e-realtime-api': patch
+'@signalwire/realtime-api': patch
+---
+
+Fix collect e2e tests

--- a/internal/e2e-realtime-api/src/voiceCollect/withContinuousFalsePartialFalse.test.ts
+++ b/internal/e2e-realtime-api/src/voiceCollect/withContinuousFalsePartialFalse.test.ts
@@ -8,10 +8,7 @@ import {
 } from '../utils'
 
 const possibleExpectedTexts = [
-  '123456789 10:00 11:00 12:00',
-  'one two three four five six seven eight nine ten',
-  '1 2 3 4 5 6 7 8 9 10',
-  '1112',
+  '12345678910',
 ]
 
 const handler: TestHandler = ({ domainApp }) => {
@@ -89,7 +86,7 @@ const handler: TestHandler = ({ domainApp }) => {
             await waitForPlaybackEnd
 
             const collected = await callCollect.ended()
-            const collected_cleaned = collected.text!.trim().replace(/\s+/g, ' ');
+            const collected_cleaned = collected.text!.trim().replace(/\s+/g, '');
             console.log(">>> collected cleaned: [", collected_cleaned, "]")
 
             tap.ok(
@@ -120,7 +117,7 @@ const handler: TestHandler = ({ domainApp }) => {
       await waitForCollectStart
 
       await call.playAudio({
-        url: 'https://amaswtest.s3-accelerate.amazonaws.com/newrecording2.mp3',
+        url: 'https://files.swire.io/e2e/1-12-counting.mp3',
       })
 
       // Inform callee that speech has completed

--- a/internal/e2e-realtime-api/src/voiceCollect/withContinuousFalsePartialFalse.test.ts
+++ b/internal/e2e-realtime-api/src/voiceCollect/withContinuousFalsePartialFalse.test.ts
@@ -10,6 +10,7 @@ import {
 const possibleExpectedTexts = [
   '123456789 10:00 11:00 12:00',
   'one two three four five six seven eight nine ten',
+  '1 2 3 4 5 6 7 8 9 10',
   '1112',
 ]
 
@@ -88,8 +89,11 @@ const handler: TestHandler = ({ domainApp }) => {
             await waitForPlaybackEnd
 
             const collected = await callCollect.ended()
+            const collected_cleaned = collected.text!.trim().replace(/\s+/g, ' ');
+            console.log(">>> collected cleaned: [", collected_cleaned, "]")
+
             tap.ok(
-              possibleExpectedTexts.includes(collected.text!),
+              possibleExpectedTexts.includes(collected_cleaned!),
               'Received Correct Text'
             )
 

--- a/internal/e2e-realtime-api/src/voiceCollect/withContinuousFalsePartialTrue&EarlyHangup.test.ts
+++ b/internal/e2e-realtime-api/src/voiceCollect/withContinuousFalsePartialTrue&EarlyHangup.test.ts
@@ -8,10 +8,7 @@ import {
 } from '../utils'
 
 const possibleExpectedTexts = [
-  '123456789 10:00 11:00 12:00',
-  'one two three four five six seven eight nine ten',
-  '1 2 3 4 5 6 7 8 9 10',
-  '1112',
+  '12345678910',
 ]
 
 const handler: TestHandler = ({ domainApp }) => {
@@ -88,7 +85,7 @@ const handler: TestHandler = ({ domainApp }) => {
             await waitForPlaybackEnd
 
             const collected = await callCollect.ended()
-            const collected_cleaned = collected.text!.trim().replace(/\s+/g, ' ');
+            const collected_cleaned = collected.text!.trim().replace(/\s+/g, '');
             console.log(">>> collected cleaned: [", collected_cleaned, "]")
 
             tap.ok(
@@ -120,7 +117,7 @@ const handler: TestHandler = ({ domainApp }) => {
 
       // Play an speech but do not let it complete
       call.playAudio({
-        url: 'https://amaswtest.s3-accelerate.amazonaws.com/newrecording2.mp3',
+        url: 'https://files.swire.io/e2e/1-12-counting.mp3',
       })
       await new Promise((resolve) => setTimeout(resolve, 5_000))
 

--- a/internal/e2e-realtime-api/src/voiceCollect/withContinuousFalsePartialTrue&EarlyHangup.test.ts
+++ b/internal/e2e-realtime-api/src/voiceCollect/withContinuousFalsePartialTrue&EarlyHangup.test.ts
@@ -10,6 +10,7 @@ import {
 const possibleExpectedTexts = [
   '123456789 10:00 11:00 12:00',
   'one two three four five six seven eight nine ten',
+  '1 2 3 4 5 6 7 8 9 10',
   '1112',
 ]
 

--- a/internal/e2e-realtime-api/src/voiceCollect/withContinuousFalsePartialTrue&EarlyHangup.test.ts
+++ b/internal/e2e-realtime-api/src/voiceCollect/withContinuousFalsePartialTrue&EarlyHangup.test.ts
@@ -87,8 +87,11 @@ const handler: TestHandler = ({ domainApp }) => {
             await waitForPlaybackEnd
 
             const collected = await callCollect.ended()
+            const collected_cleaned = collected.text!.trim().replace(/\s+/g, ' ');
+            console.log(">>> collected cleaned: [", collected_cleaned, "]")
+
             tap.ok(
-              possibleExpectedTexts.includes(collected.text!),
+              possibleExpectedTexts.includes(collected_cleaned!),
               'Received Correct Text'
             )
 

--- a/internal/e2e-realtime-api/src/voiceCollect/withContinuousFalsePartialTrue.test.ts
+++ b/internal/e2e-realtime-api/src/voiceCollect/withContinuousFalsePartialTrue.test.ts
@@ -8,10 +8,7 @@ import {
 } from '../utils'
 
 const possibleExpectedTexts = [
-  '123456789 10:00 11:00 12:00',
-  'one two three four five six seven eight nine ten',
-  '1 2 3 4 5 6 7 8 9 10',
-  '1112',
+  '12345678910',
 ]
 
 const handler: TestHandler = ({ domainApp }) => {
@@ -86,9 +83,8 @@ const handler: TestHandler = ({ domainApp }) => {
 
             // Wait until the caller ends sending the speech
             await waitForPlaybackEnd
-
             const collected = await callCollect.ended()
-            const collected_cleaned = collected.text!.trim().replace(/\s+/g, ' ');
+            const collected_cleaned = collected.text!.trim().replace(/\s+/g, '');
             console.log(">>> collected cleaned: [", collected_cleaned, "]")
 
             tap.ok(
@@ -119,7 +115,7 @@ const handler: TestHandler = ({ domainApp }) => {
       await waitForCollectStart
 
       await call.playAudio({
-        url: 'https://amaswtest.s3-accelerate.amazonaws.com/newrecording2.mp3',
+        url: 'https://files.swire.io/e2e/1-12-counting.mp3',
       })
 
       // Inform callee that speech has completed

--- a/internal/e2e-realtime-api/src/voiceCollect/withContinuousFalsePartialTrue.test.ts
+++ b/internal/e2e-realtime-api/src/voiceCollect/withContinuousFalsePartialTrue.test.ts
@@ -10,6 +10,7 @@ import {
 const possibleExpectedTexts = [
   '123456789 10:00 11:00 12:00',
   'one two three four five six seven eight nine ten',
+  '1 2 3 4 5 6 7 8 9 10',
   '1112',
 ]
 

--- a/internal/e2e-realtime-api/src/voiceCollect/withContinuousFalsePartialTrue.test.ts
+++ b/internal/e2e-realtime-api/src/voiceCollect/withContinuousFalsePartialTrue.test.ts
@@ -87,8 +87,11 @@ const handler: TestHandler = ({ domainApp }) => {
             await waitForPlaybackEnd
 
             const collected = await callCollect.ended()
+            const collected_cleaned = collected.text!.trim().replace(/\s+/g, ' ');
+            console.log(">>> collected cleaned: [", collected_cleaned, "]")
+
             tap.ok(
-              possibleExpectedTexts.includes(collected.text!),
+              possibleExpectedTexts.includes(collected_cleaned!),
               'Received Correct Text'
             )
 

--- a/internal/e2e-realtime-api/src/voiceCollect/withContinuousTruePartialFalse.test.ts
+++ b/internal/e2e-realtime-api/src/voiceCollect/withContinuousTruePartialFalse.test.ts
@@ -8,10 +8,7 @@ import {
 } from '../utils'
 
 const possibleExpectedTexts = [
-  '123456789 10:00 11:00 12:00',
-  'one two three four five six seven eight nine ten',
-  '1 2 3 4 5 6 7 8 9 10',
-  '1112',
+  '12345678910',
 ]
 
 const handler: TestHandler = ({ domainApp }) => {
@@ -95,7 +92,7 @@ const handler: TestHandler = ({ domainApp }) => {
             setTimeout(() => call.hangup(), 100)
 
             const collected = await callCollect.ended()
-            const collected_cleaned = collected.text!.trim().replace(/\s+/g, ' ');
+            const collected_cleaned = collected.text!.trim().replace(/\s+/g, '');
             console.log(">>> collected cleaned: [", collected_cleaned, "]")
 
             tap.ok(
@@ -126,7 +123,7 @@ const handler: TestHandler = ({ domainApp }) => {
       await waitForCollectStart
 
       await call.playAudio({
-        url: 'https://amaswtest.s3-accelerate.amazonaws.com/newrecording2.mp3',
+        url: 'https://files.swire.io/e2e/1-12-counting.mp3',
       })
 
       // Inform callee that speech has completed

--- a/internal/e2e-realtime-api/src/voiceCollect/withContinuousTruePartialFalse.test.ts
+++ b/internal/e2e-realtime-api/src/voiceCollect/withContinuousTruePartialFalse.test.ts
@@ -10,6 +10,7 @@ import {
 const possibleExpectedTexts = [
   '123456789 10:00 11:00 12:00',
   'one two three four five six seven eight nine ten',
+  '1 2 3 4 5 6 7 8 9 10',
   '1112',
 ]
 

--- a/internal/e2e-realtime-api/src/voiceCollect/withContinuousTruePartialFalse.test.ts
+++ b/internal/e2e-realtime-api/src/voiceCollect/withContinuousTruePartialFalse.test.ts
@@ -94,8 +94,11 @@ const handler: TestHandler = ({ domainApp }) => {
             setTimeout(() => call.hangup(), 100)
 
             const collected = await callCollect.ended()
+            const collected_cleaned = collected.text!.trim().replace(/\s+/g, ' ');
+            console.log(">>> collected cleaned: [", collected_cleaned, "]")
+
             tap.ok(
-              possibleExpectedTexts.includes(collected.text!),
+              possibleExpectedTexts.includes(collected_cleaned!),
               'Received Correct Text'
             )
 

--- a/internal/e2e-realtime-api/src/voiceCollect/withContinuousTruePartialTrue.test.ts
+++ b/internal/e2e-realtime-api/src/voiceCollect/withContinuousTruePartialTrue.test.ts
@@ -8,11 +8,7 @@ import {
 } from '../utils'
 
 const possibleExpectedTexts = [
-  '123456789 10:00 11:00 12:00',
-  'one two three four five six seven eight nine ten',
-  '1 2 3 4 5 6 7 8 9 10',
-  '1 1 1 2',
-  '11 12',
+  '1112',
 ]
 
 const handler: TestHandler = ({ domainApp }) => {
@@ -78,7 +74,7 @@ const handler: TestHandler = ({ domainApp }) => {
                      * overall collect has not ended yet.
                      */
                     if (_collect.final === true) {
-                      const collected_cleaned = _collect.text!.trim().replace(/\s+/g, ' ');
+                      const collected_cleaned = _collect.text!.trim().replace(/\s+/g, '');
                       console.log(">>> collected update cleaned: [", collected_cleaned, "]")
 
                       tap.ok(
@@ -110,7 +106,7 @@ const handler: TestHandler = ({ domainApp }) => {
             setTimeout(() => call.hangup(), 100)
 
             const collected = await callCollect.ended()
-            const collected_cleaned = collected.text!.trim().replace(/\s+/g, ' ');
+            const collected_cleaned = collected.text!.trim().replace(/\s+/g, '');
             console.log(">>> collected cleaned: [", collected_cleaned, "]")
 
             tap.ok(

--- a/internal/e2e-realtime-api/src/voiceCollect/withContinuousTruePartialTrue.test.ts
+++ b/internal/e2e-realtime-api/src/voiceCollect/withContinuousTruePartialTrue.test.ts
@@ -11,8 +11,8 @@ const possibleExpectedTexts = [
   '123456789 10:00 11:00 12:00',
   'one two three four five six seven eight nine ten',
   '1 2 3 4 5 6 7 8 9 10',
-  '1112',
-  'yes',
+  '1 1 1 2',
+  '11 12',
 ]
 
 const handler: TestHandler = ({ domainApp }) => {
@@ -70,7 +70,22 @@ const handler: TestHandler = ({ domainApp }) => {
                     console.log('>>> collect.started')
                   },
                   onUpdated: (_collect) => {
-                    console.log('>>> collect.updated', _collect.text)
+                    console.log('>>> collect.updated: [', _collect.text, ']')
+
+                    /* With 'continuous' true, we may have 'final' true to indicate
+                     * a portion of speech has been correctly collected and this
+                     * part of collection has completed. We want to check even if the
+                     * overall collect has not ended yet.
+                     */
+                    if (_collect.final === true) {
+                      const collected_cleaned = _collect.text!.trim().replace(/\s+/g, ' ');
+                      console.log(">>> collected update cleaned: [", collected_cleaned, "]")
+
+                      tap.ok(
+                        possibleExpectedTexts.includes(collected_cleaned!),
+                        'Received Correct Updated Text'
+                      )
+                    }
                   },
                   onEnded: (_collect) => {
                     console.log('>>> collect.ended', _collect.text)
@@ -126,7 +141,7 @@ const handler: TestHandler = ({ domainApp }) => {
       await waitForCollectStart
 
       await call.playAudio({
-        url: 'https://amaswtest.s3-accelerate.amazonaws.com/newrecording2.mp3',
+        url: 'https://files.swire.io/e2e/1-12-counting.mp3',
       })
 
       // Inform callee that speech has completed

--- a/internal/e2e-realtime-api/src/voiceCollect/withContinuousTruePartialTrue.test.ts
+++ b/internal/e2e-realtime-api/src/voiceCollect/withContinuousTruePartialTrue.test.ts
@@ -8,6 +8,7 @@ import {
 } from '../utils'
 
 const possibleExpectedTexts = [
+  '12345678910',
   '1112',
 ]
 

--- a/internal/e2e-realtime-api/src/voiceCollect/withContinuousTruePartialTrue.test.ts
+++ b/internal/e2e-realtime-api/src/voiceCollect/withContinuousTruePartialTrue.test.ts
@@ -10,6 +10,7 @@ import {
 const possibleExpectedTexts = [
   '123456789 10:00 11:00 12:00',
   'one two three four five six seven eight nine ten',
+  '1 2 3 4 5 6 7 8 9 10',
   '1112',
   'yes',
 ]
@@ -94,8 +95,11 @@ const handler: TestHandler = ({ domainApp }) => {
             setTimeout(() => call.hangup(), 100)
 
             const collected = await callCollect.ended()
+            const collected_cleaned = collected.text!.trim().replace(/\s+/g, ' ');
+            console.log(">>> collected cleaned: [", collected_cleaned, "]")
+
             tap.ok(
-              possibleExpectedTexts.includes(collected.text!),
+              possibleExpectedTexts.includes(collected_cleaned!),
               'Received Correct Text'
             )
 

--- a/packages/realtime-api/src/voice/workers/voiceCallCollectWorker.ts
+++ b/packages/realtime-api/src/voice/workers/voiceCallCollectWorker.ts
@@ -68,9 +68,14 @@ export const voiceCallCollectWorker: SDKWorker<Client> = function* (
       }
       return false
     } else if (payload.final === true && payload.state == "collecting") {
-      /* final true with state collecting means we want partial results */
-      callInstance.emit('collect.updated', collectInstance)
-      collectInstance.emit('collect.updated', collectInstance)
+      // Even if final is true but we are still collecting, we want an update
+      if (eventPrefix === 'prompt') {
+        callInstance.emit('prompt.updated', promptInstance)
+        promptInstance.emit('prompt.updated', promptInstance)
+      } else {
+        callInstance.emit('collect.updated', collectInstance)
+        collectInstance.emit('collect.updated', collectInstance)
+      }
     }
 
     switch (payload.result.type) {

--- a/packages/realtime-api/src/voice/workers/voiceCallCollectWorker.ts
+++ b/packages/realtime-api/src/voice/workers/voiceCallCollectWorker.ts
@@ -67,6 +67,10 @@ export const voiceCallCollectWorker: SDKWorker<Client> = function* (
         collectInstance.emit('collect.updated', collectInstance)
       }
       return false
+    } else if (payload.final === true && payload.state == "collecting") {
+      /* final true with state collecting means we want partial results */
+      callInstance.emit('collect.updated', collectInstance)
+      collectInstance.emit('collect.updated', collectInstance)
     }
 
     switch (payload.result.type) {


### PR DESCRIPTION
# Description

Before this change:

```
>>> collect.ended  1 2  3 4 5 6 7 8 9 10

...

not ok 4 - Received Correct Text

  ---

  at:

    fileName: src/voiceCollect/withContinuousFalsePartialFalse.test.ts

    lineNumber: 91

    columnNumber: 17
    typeName: EventEmitter

    functionName: EventEmitter.onCallReceived

  stack: >
    EventEmitter.onCallReceived
    (src/voiceCollect/withContinuousFalsePartialFalse.test.ts:91:17)

  source: |2
  

                const collected = await callCollect.ended()

                tap.ok(
    ----------------^
```

because the expected string is one of:
```
const possibleExpectedTexts = [
  '123456789 10:00 11:00 12:00',
  'one two three four five six seven eight nine ten',
  '1112',

```

These changes adapt the expectations to what's currently (correctly) detected.

## Type of change

- [ ] Internal refactoring
- [x] Bug fix (bugfix - non-breaking)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Code snippets

In case of new feature or breaking changes, please include code snippets.
