### PR TITLE
Page size for Address API

### DIFF
--- a/.changeset/twenty-planets-work.md
+++ b/.changeset/twenty-planets-work.md
@@ -1,0 +1,6 @@
+---
+'@signalwire/core': patch
+'@signalwire/js': patch
+---
+
+Page size for Address API

--- a/packages/core/src/types/callfabric.ts
+++ b/packages/core/src/types/callfabric.ts
@@ -1,7 +1,5 @@
 export interface PaginatedResponse<T> {
-  data:
-    | Array<T>
-    | []
+  data: Array<T> | []
   links: {
     first: string
     self: string
@@ -23,22 +21,24 @@ export interface Address {
     video?: string
   }
 }
-export interface FetchAddressResponse extends PaginatedResponse<Address>{}
+export interface FetchAddressResponse extends PaginatedResponse<Address> {}
 
 export interface GetAddressesOptions {
   type?: string
   displayName?: string
+  pageSize?: number
 }
 
-export interface ConversationHistory {       
+export interface ConversationHistory {
   type: string
   // FIXME needs to be completed
 }
 
-export interface FetchConversationHistoryResponse extends PaginatedResponse<ConversationHistory>{}
+export interface FetchConversationHistoryResponse
+  extends PaginatedResponse<ConversationHistory> {}
 
 export interface GetConversationHistoriOption {
-  subscriberId: string,
-  addressId: string,
+  subscriberId: string
+  addressId: string
   limit?: number
-} 
+}

--- a/packages/js/src/fabric/HTTPClient.ts
+++ b/packages/js/src/fabric/HTTPClient.ts
@@ -92,11 +92,11 @@ export class HTTPClient {
   }
 
   public async getAddresses(options?: GetAddressesOptions) {
-    const { type, displayName } = options || {}
+    const { type, displayName, pageSize } = options || {}
 
     let path = '/addresses' as const
 
-    if (type || displayName) {
+    if (type || displayName || pageSize) {
       const queryParams = new URLSearchParams()
 
       if (type) {
@@ -105,6 +105,10 @@ export class HTTPClient {
 
       if (displayName) {
         queryParams.append('display_name', displayName)
+      }
+
+      if (pageSize) {
+        queryParams.append('page_size', pageSize.toString())
       }
 
       path += `?${queryParams.toString()}`


### PR DESCRIPTION
# Description

Allow user to pass the page size for Address API 

## Type of change

- [ ] Internal refactoring
- [ ] Bug fix (bugfix - non-breaking)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Code snippets

```js
const addressData = await client.getAddresses({
   type: 'room',
   displayName: 'john doe',
   pageSize: 10
})
```

All parameters are optional.