### PR TITLE
Emits all "selves" updates using the "original self" id

### DIFF
--- a/.changeset/new-buses-pull.md
+++ b/.changeset/new-buses-pull.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/js': patch
+---
+
+Only emits self member updates with the original self.member_id. That is to prevent the application to be exposed to internal self member versions on each call segment.

--- a/package-lock.json
+++ b/package-lock.json
@@ -13506,14 +13506,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/object-path": {
-      "version": "0.11.8",
-      "resolved": "https://registry.npmjs.org/object-path/-/object-path-0.11.8.tgz",
-      "integrity": "sha512-YJjNZrlXJFM42wTBn6zgOJVar9KFJvzx6sTWDte8sWZF//cnjl0BxHNpfZx+ZffXX63A9q0b1zsFiBX4g4X5KA==",
-      "engines": {
-        "node": ">= 10.12.0"
-      }
-    },
     "node_modules/object.assign": {
       "version": "4.1.4",
       "license": "MIT",
@@ -17650,8 +17642,7 @@
       "dependencies": {
         "@signalwire/core": "4.0.0-beta.0",
         "@signalwire/webrtc": "3.11.0",
-        "jwt-decode": "^3.1.2",
-        "object-path": "^0.11.8"
+        "jwt-decode": "^3.1.2"
       },
       "devDependencies": {
         "@types/object-path": "^0.11.4"

--- a/packages/js/src/UnifiedJWTSession.ts
+++ b/packages/js/src/UnifiedJWTSession.ts
@@ -26,8 +26,8 @@ export class UnifiedJWTSession extends JWTSession {
   }
 
   popCallInstanceRef(): InternalUnifiedMethodTarget | undefined {
-    this.logger.debug('Poping target from stack', this.callInstancesStack[this.callInstancesStack.length-1]?.callId)
     const target = this.callInstancesStack.pop()
+    this.logger.debug('Poping target from stack', target.callId)
     return target
   }
 

--- a/packages/js/src/UnifiedJWTSession.ts
+++ b/packages/js/src/UnifiedJWTSession.ts
@@ -27,7 +27,7 @@ export class UnifiedJWTSession extends JWTSession {
 
   popCallInstanceRef(): InternalUnifiedMethodTarget | undefined {
     const target = this.callInstancesStack.pop()
-    this.logger.debug('Poping target from stack', target.callId)
+    this.logger.debug('Poping target from stack', target?.callId)
     return target
   }
 

--- a/packages/js/src/UnifiedJWTSession.ts
+++ b/packages/js/src/UnifiedJWTSession.ts
@@ -21,11 +21,14 @@ export class UnifiedJWTSession extends JWTSession {
   }
 
   pushCallInstanceRef(target: InternalUnifiedMethodTarget) {
+    this.logger.debug('Pushing new target to stack', target)
     this.callInstancesStack.push(target)
   }
 
   popCallInstanceRef(): InternalUnifiedMethodTarget | undefined {
-    return this.callInstancesStack.pop()
+    this.logger.debug('Poping target from stack', this.callInstancesStack[this.callInstancesStack.length-1]?.callId)
+    const target = this.callInstancesStack.pop()
+    return target
   }
 
   getExcuteSelf() {

--- a/packages/js/src/UnifiedJWTSession.ts
+++ b/packages/js/src/UnifiedJWTSession.ts
@@ -52,7 +52,7 @@ export class UnifiedJWTSession extends JWTSession {
       // when we make the target the current self
       
       //@ts-ignore
-      const defaultTarget = getCurrentSelf()
+      const defaultTarget = this.getCurrentSelf()
       return !!defaultTarget ? [defaultTarget] : []
     }
 
@@ -61,7 +61,7 @@ export class UnifiedJWTSession extends JWTSession {
     const targetMember = memberId && callId && nodeId ? {memberId, callId, nodeId} : undefined
 
     //@ts-ignore
-    const defaultTarget = targetMember ?? getCurrentSelf()
+    const defaultTarget = targetMember ?? this.getCurrentSelf()
     return !!defaultTarget ? [defaultTarget] : []
   }
 

--- a/packages/js/src/UnifiedJWTSession.ts
+++ b/packages/js/src/UnifiedJWTSession.ts
@@ -40,7 +40,7 @@ export class UnifiedJWTSession extends JWTSession {
   }
 
   isASelfInstance(id: string) {
-    return !!this.callInstancesStack.find((item)=>item.memberId === id)
+    return this.callInstancesStack.some((item)=>item.memberId === id)
   }
 
   //@ts-ignore

--- a/packages/js/src/fabric/unified/workers/unifiedEventsWatcher.ts
+++ b/packages/js/src/fabric/unified/workers/unifiedEventsWatcher.ts
@@ -44,7 +44,7 @@ function* debugEmitter({
 }) {
   const { type, payload } = action
   // @ts-expect-error
-  yield instance.emit(type, payload)
+  yield instance.emit(`__debug.${type}`, payload)
 }
 
 export const unifiedEventsWatcher: SDKWorker<RoomSessionConnection> =

--- a/packages/js/src/video/videoMemberWorker.ts
+++ b/packages/js/src/video/videoMemberWorker.ts
@@ -36,7 +36,8 @@ export const videoMemberWorker = function* (
 
   // For now, we are not storing the RoomSession object in the instance map
 
-  let memberInstance = get<RoomSessionMember>(payload.member.id)
+  //@ts-ignore in unified context id => member_id
+  let memberInstance = get<RoomSessionMember>(payload.member.member_id)
   if (!memberInstance) {
     memberInstance = Rooms.createRoomSessionMemberObject({
       store: roomSession.store,
@@ -45,13 +46,14 @@ export const videoMemberWorker = function* (
   } else {
     memberInstance.setPayload(payload as Rooms.RoomSessionMemberEventParams)
   }
-  set<RoomSessionMember>(payload.member.id, memberInstance)
+  //@ts-ignore in unified context id => member_id
+  set<RoomSessionMember>(payload.member.member_id, memberInstance)
 
   const event = stripNamespacePrefix(type) as VideoMemberEventNames
 
   if (type.startsWith('video.member.updated.')) {
     const clientType = fromSnakeToCamelCase(event)
-    // @ts-expect-error
+    //@ts-expect-error
     roomSession.emit(clientType, memberInstance)
   }
 

--- a/packages/js/src/video/videoRoomWorker.ts
+++ b/packages/js/src/video/videoRoomWorker.ts
@@ -30,7 +30,7 @@ export const videoRoomWorker = function* (
 
   // Upsert member in the instance map
   if ((payload.room_session?.members?.length || 0) > 0) {
-    ;(payload.room_session.members || []).forEach((member) => {
+    (payload.room_session.members || []).forEach((member) => {
       let memberInstance = get<RoomSessionMember>(member.id)
       if (!memberInstance) {
         memberInstance = Rooms.createRoomSessionMemberObject({

--- a/packages/js/src/video/videoRoomWorker.ts
+++ b/packages/js/src/video/videoRoomWorker.ts
@@ -24,8 +24,6 @@ export const videoRoomWorker = function* (
     instanceMap: { get, set },
   } = options
 
-  console.log('action', type, payload, payload.room_session.members)
-
   // For now, we are not storing the RoomSession object in the instance map
 
   // Upsert member in the instance map

--- a/packages/js/src/video/videoRoomWorker.ts
+++ b/packages/js/src/video/videoRoomWorker.ts
@@ -29,7 +29,7 @@ export const videoRoomWorker = function* (
   // For now, we are not storing the RoomSession object in the instance map
 
   // Upsert member in the instance map
-  if ((payload.room_session.members?.length || 0) > 0) {
+  if ((payload.room_session?.members?.length || 0) > 0) {
     ;(payload.room_session.members || []).forEach((member) => {
       let memberInstance = get<RoomSessionMember>(member.id)
       if (!memberInstance) {


### PR DESCRIPTION
# Description

The nested behavior of the CF calls introduces a new "self" member on each segment it joins.

Since we need to emit all updates, but at the same time the developer should not be exposed to this internal complexity, we always emit all updates related to the "selves" member with the same ID (the self-target/first-self). 

This prevents the "selves" from being included in the application members list more than once.

Also if the developer is trying to execute a method with a member parameter equal to the self-target, that means it trying to send a method targeting "self" on the last segment, so we need to intercept and update the parameter to the "self" on top of the target stack.   

## Type of change

- [ ] Internal refactoring
- [x] Bug fix (bugfix - non-breaking)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Code snippets

In case of new feature or breaking changes, please include code snippets.
