### PR TITLE
Consistent `member.joined` events

### DIFF
--- a/.changeset/thin-bananas-heal.md
+++ b/.changeset/thin-bananas-heal.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/js': minor
+---
+
+NEW emits `member.joined` events for all members in a `call.joined` event

--- a/packages/js/src/video/videoRoomWorker.ts
+++ b/packages/js/src/video/videoRoomWorker.ts
@@ -82,6 +82,13 @@ export const videoRoomWorker = function* (
           })
         },
       })
+      for(const memberPayload of payload.room_session.members) {
+        //@ts-expect-error
+        yield sagaEffects.fork(videoMemberWorker, {
+          ...options,
+          action: {type: 'video.member.joined', payload: {member: memberPayload}},
+        })
+      }
       roomSession.emit('room.subscribed', payload)
       break
     }


### PR DESCRIPTION
# Description

In the CF nested calls the backend won't send `member.joined` for all members.

The list of *all* members is a combination of emitted `member.joined` and existing members in `call.joined`.

To abstract for the final developers, this will  internally emit `member.joined` events for all existing members in a `call.joined` event.

PS: This PR is not considering `member.left` events
 
## Type of change

- [x] Internal refactoring
- [ ] Bug fix (bugfix - non-breaking)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Code snippets

In case of new feature or breaking changes, please include code snippets.
