### PR TITLE
Full Width Videos

### DIFF
--- a/.changeset/four-badgers-wash.md
+++ b/.changeset/four-badgers-wash.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/js': minor
+---
+
+NEW - by default the SDK will use the full width for the video call in both orientations.

--- a/packages/js/src/features/mediaElements/mediaElementsSagas.ts
+++ b/packages/js/src/features/mediaElements/mediaElementsSagas.ts
@@ -382,7 +382,7 @@ function* videoElementSetupWorker({
     aspectRatioListener({
       videoElement: element, 
       paddingWrapper, 
-      fixInLandscapeOrientation: rootElement.classList.contains('landscape-ony') });
+      fixInLandscapeOrientation: rootElement.classList.contains('landscape-only') });
 
     const layersWrapper = document.createElement('div')
     layersWrapper.classList.add('mcuLayers')

--- a/packages/js/src/utils/aspectRatioListener.ts
+++ b/packages/js/src/utils/aspectRatioListener.ts
@@ -8,7 +8,10 @@ export function aspectRatioListener({videoElement, paddingWrapper, fixInLandscap
         containerElement.appendChild(pEl);
     }
 
-    const debugElement = document.getElementById(debugDivElementId);
+    let debugElement: HTMLElement|null;
+    try {
+        debugElement = document.getElementById(debugDivElementId);
+    } catch {}
     
     VIDEO_SIZING_EVENTS.forEach(event => videoElement.addEventListener(event, () => {
             const paddingBottom = fixInLandscapeOrientation ? '56.25' : 

--- a/packages/js/src/utils/aspectRatioListener.ts
+++ b/packages/js/src/utils/aspectRatioListener.ts
@@ -1,0 +1,37 @@
+const VIDEO_SIZING_EVENTS = ['loadedmetadata', 'resize']
+
+export function aspectRatioListener({videoElement, paddingWrapper, fixInLandscapeOrientation = false, debugDivElementId = 'videoDimensionsDebug', samplingInterval = 0}: {videoElement: HTMLVideoElement, paddingWrapper: HTMLDivElement, fixInLandscapeOrientation: boolean, debugDivElementId?: string, samplingInterval?: number}) {
+    const buildHtmlContent = (event:string, width: number, height: number) => `Video dimensions on <strong>${event} event</strong>:</strong> ${width}x${height}px - fixInLandscapeOrientation: ${fixInLandscapeOrientation}`
+    const appendDebugInfo = (containerElement: HTMLElement, event:string) => {
+        const pEl = document.createElement('p')
+        pEl.innerHTML = buildHtmlContent(event, videoElement.videoWidth, videoElement.videoHeight);    
+        containerElement.appendChild(pEl);
+    }
+
+    const debugElement = document.getElementById(debugDivElementId);
+    
+    VIDEO_SIZING_EVENTS.forEach(event => videoElement.addEventListener(event, () => {
+            const paddingBottom = fixInLandscapeOrientation ? '56.25' : 
+                (videoElement.videoHeight / videoElement.videoWidth) * 100
+            paddingWrapper.style.paddingBottom = `${paddingBottom}%`
+            if(debugElement) {
+                appendDebugInfo(debugElement, event)
+            }
+        }));
+
+        if(samplingInterval > 0) {
+            setInterval(() => {
+                const paddingBottom = (videoElement.videoHeight / videoElement.videoWidth) * 100
+                paddingWrapper.style.paddingBottom = `${paddingBottom}%`
+                if(debugElement) {
+                    let statsElement = debugElement.querySelector('.timer-values')
+                    if(!statsElement) {
+                        statsElement = document.createElement('div');
+                        statsElement.className = 'timer-values'
+                        debugElement.appendChild(statsElement);
+                    }
+                    appendDebugInfo(debugElement, 'timer')
+                }
+            });            
+        }   
+}

--- a/packages/js/src/utils/videoElement.ts
+++ b/packages/js/src/utils/videoElement.ts
@@ -183,6 +183,10 @@ const setVideoMediaTrack = ({
   })
 }
 
+/**
+ * @deprecated
+ * FIXME remove this in the future
+ */
 const createRootElementResizeObserver = ({
   video,
   rootElement,

--- a/packages/webrtc/src/RTCPeer.ts
+++ b/packages/webrtc/src/RTCPeer.ts
@@ -832,41 +832,7 @@ export default class RTCPeer<EventTypes extends EventEmitter.ValidEventTypes> {
       '\n\n',
       remoteDescription.sdp
     )
-    const debugElement = document.getElementById('videoDebug');
-            if(debugElement) {
-              let statsElement = debugElement.querySelector('.rtc-stats')
-              if(!statsElement) {
-                statsElement = document.createElement('div');
-                statsElement.className = 'rtc-stats'
-                debugElement.appendChild(statsElement);
-              }
-              setInterval(()=> {
-                this.instance.getStats(null).then((reports) => {
-                  let statsString = '';
-                  reports.forEach((report) => {
-                    if(["outbound-rtp", "remote-inbound-rtp", "media-source"].includes(report.type)) {
-                      statsString += '<h3>Report type=';
-                      statsString += report.type;
-                      statsString += '</h3>\n';
-                      statsString += `id ${report.id}<br>`;
-                      statsString += `time ${report.timestamp}<br>`;
-                      Object.keys(report).forEach(k => {
-                        if (k !== 'timestamp' && k !== 'type' && k !== 'id') {
-                            if (typeof report[k] === 'object') {
-                              statsString += `${k}: ${JSON.stringify(report[k])}<br>`;
-                            } else {
-                              statsString += `${k}: ${report[k]}<br>`;
-                            }
-                        }
-                      });
-                    }
-                  });
-                  statsElement!.innerHTML = statsString;
-                });
-                
 
-              }, 1000)
-            }  
     return this.instance.setRemoteDescription(sessionDescr)
   }
 


### PR DESCRIPTION
# Description

By default, now the video stream will get the full width of the `rootElement` container.
This will continue to present videos with the correct aspect ratio, but allow for videos on portrait to use all the available space.

Before we were always getting videos in landscape. 
Now the video orientation is dynamic based on the number of participants and the camera orientation.

So the orientation can change during the call. The implementation monitors video-size events and makes sure the video takes the full width.

If the application wants it can disable this using the CSS class `landscape-only` in the `rootElement`
   

## Type of change

- [ ] Internal refactoring
- [ ] Bug fix (bugfix - non-breaking)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Code snippets

In case of new feature or breaking changes, please include code snippets.

### To disable the full-width behavior and allways get a video container in landscape orientation
```
<div id="rootElement" class="landscape-only">
```
