### PR TITLE
Specify pageSize param to conversation APIs

### DIFF
--- a/.changeset/kind-keys-compete.md
+++ b/.changeset/kind-keys-compete.md
@@ -1,0 +1,6 @@
+---
+'@signalwire/core': patch
+'@signalwire/js': patch
+---
+
+Introduce pageSize param for Conversation APIs

--- a/internal/playground-js/src/fabric-http/index.js
+++ b/internal/playground-js/src/fabric-http/index.js
@@ -197,6 +197,7 @@ async function fetchAddresses() {
     const addressData = await client.address.getAddresses({
       type: selectedType === 'all' ? undefined : selectedType,
       displayName: !searchText.length ? undefined : searchText,
+      pageSize: 10,
     })
     window.__addressData = addressData
     updateAddressUI()
@@ -301,7 +302,9 @@ function updateHistoryUI() {
 async function fetchHistories() {
   if (!client) return
   try {
-    const historyData = await client.conversation.getConversations()
+    const historyData = await client.conversation.getConversations({
+      pageSize: 10,
+    })
     window.__historyData = historyData
     updateHistoryUI()
     subscribeToNewMessages()

--- a/packages/core/src/types/callfabric.ts
+++ b/packages/core/src/types/callfabric.ts
@@ -37,10 +37,7 @@ export interface FetchAddressResponse extends PaginatedResponse<Address> {}
  * Conversations
  */
 export interface GetConversationsOptions {
-  limit?: number
-  since?: number
-  until?: number
-  cursor?: string
+  pageSize?: number
 }
 
 export interface Conversation {
@@ -59,10 +56,7 @@ export interface FetchConversationsResponse
  */
 
 export interface GetMessagesOptions {
-  limit?: number
-  since?: number
-  until?: number
-  cursor?: string
+  pageSize?: number
 }
 
 export interface ConversationMessage {
@@ -81,10 +75,7 @@ export interface FetchConversationMessagesResponse
 
 export interface GetConversationMessagesOptions {
   addressId: string
-  limit?: number
-  since?: number
-  until?: number
-  cursor?: string
+  pageSize?: number
 }
 
 export interface SubscriberInfoResponse {

--- a/packages/js/src/fabric/Conversation.ts
+++ b/packages/js/src/fabric/Conversation.ts
@@ -41,21 +41,12 @@ export class Conversation {
 
   public async getConversations(options?: GetConversationsOptions) {
     try {
-      const { limit, since, until, cursor } = options || {}
+      const { pageSize } = options || {}
 
       const path = '/api/fabric/conversations'
       const queryParams = new URLSearchParams()
-      if (limit) {
-        queryParams.append('limit', limit.toString())
-      }
-      if (since) {
-        queryParams.append('since', since.toString())
-      }
-      if (until) {
-        queryParams.append('until', until.toString())
-      }
-      if (cursor) {
-        queryParams.append('cursor', cursor)
+      if (pageSize) {
+        queryParams.append('page_size', pageSize.toString())
       }
 
       const { body } = await this.httpClient.fetch<FetchConversationsResponse>(
@@ -70,21 +61,12 @@ export class Conversation {
 
   public async getMessages(options?: GetMessagesOptions) {
     try {
-      const { limit, since, until, cursor } = options || {}
+      const { pageSize } = options || {}
 
       const path = '/api/fabric/messages'
       const queryParams = new URLSearchParams()
-      if (limit) {
-        queryParams.append('limit', limit.toString())
-      }
-      if (since) {
-        queryParams.append('since', since.toString())
-      }
-      if (until) {
-        queryParams.append('until', until.toString())
-      }
-      if (cursor) {
-        queryParams.append('cursor', cursor)
+      if (pageSize) {
+        queryParams.append('page_size', pageSize.toString())
       }
 
       const { body } =
@@ -105,21 +87,12 @@ export class Conversation {
     options: GetConversationMessagesOptions
   ) {
     try {
-      const { addressId, limit, since, until, cursor } = options || {}
+      const { addressId, pageSize } = options || {}
 
       const path = `/api/fabric/conversations/${addressId}/messages`
       const queryParams = new URLSearchParams()
-      if (limit) {
-        queryParams.append('limit', limit.toString())
-      }
-      if (since) {
-        queryParams.append('since', since.toString())
-      }
-      if (until) {
-        queryParams.append('until', until.toString())
-      }
-      if (cursor) {
-        queryParams.append('cursor', cursor)
+      if (pageSize) {
+        queryParams.append('page_size', pageSize.toString())
       }
 
       const { body } =

--- a/packages/js/src/fabric/HTTPClient.ts
+++ b/packages/js/src/fabric/HTTPClient.ts
@@ -8,6 +8,7 @@ import {
 } from '@signalwire/core'
 import { CreateHttpClient, createHttpClient } from './createHttpClient'
 import { buildPaginatedResult } from '../utils/paginatedResult'
+import { makeQueryParamsUrls } from '../utils/makeQueryParamsUrl'
 
 type JWTHeader = { ch?: string; typ?: string }
 
@@ -56,25 +57,20 @@ export class HTTPClient {
 
     let path = '/api/fabric/addresses'
 
-    if (type || displayName || pageSize) {
-      const queryParams = new URLSearchParams()
-
-      if (type) {
-        queryParams.append('type', type)
-      }
-
-      if (displayName) {
-        queryParams.append('display_name', displayName)
-      }
-
-      if (pageSize) {
-        queryParams.append('page_size', pageSize.toString())
-      }
-
-      path += `?${queryParams.toString()}`
+    const queryParams = new URLSearchParams()
+    if (type) {
+      queryParams.append('type', type)
+    }
+    if (displayName) {
+      queryParams.append('display_name', displayName)
+    }
+    if (pageSize) {
+      queryParams.append('page_size', pageSize.toString())
     }
 
-    const { body } = await this.httpClient<FetchAddressResponse>(path)
+    const { body } = await this.httpClient<FetchAddressResponse>(
+      makeQueryParamsUrls(path, queryParams)
+    )
 
     return buildPaginatedResult<Address>(body, this.httpClient)
   }


### PR DESCRIPTION
# Description

Allow the user to pass the pageSize param to limit the data length.

## Type of change

- [ ] Internal refactoring
- [ ] Bug fix (bugfix - non-breaking)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Code snippets

```js
await client.conversation.getConversations({ pageSize: 10 });

await client.conversation.getMessages({ pageSize: 10 });

await client.conversation.getConversationMessages({ pageSize: 10 });
```
