### PR TITLE
Unify Incoming Invites over WebSocket and Push Notifications

### DIFF
--- a/.changeset/long-fishes-cry.md
+++ b/.changeset/long-fishes-cry.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/js': minor
+---
+
+Changed API for handling incoming call over WebSocket and PushNotification

--- a/.changeset/rich-fans-tickle.md
+++ b/.changeset/rich-fans-tickle.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/js': minor
+---
+
+Changed dial() and accept() functions now can receive a rootElement to render the call video

--- a/packages/js/src/fabric/IncomingCallManager.test.ts
+++ b/packages/js/src/fabric/IncomingCallManager.test.ts
@@ -1,0 +1,245 @@
+import { IncomingCallManager, IncomingCallNotification } from './IncomingCallManager'
+
+describe('IncomingCallManager', () => {
+    const answer = jest.fn()
+    const buildCall = () => ({ answer })
+    const rejectCall = jest.fn().mockResolvedValue(null)
+
+  beforeAll(() => {
+    jest.resetAllMocks()
+  })
+
+  test('It should invoke the proper listeners', () => {
+    //@ts-ignore
+    const manager = new IncomingCallManager(buildCall, rejectCall)
+    const allNotificationListerner = jest.fn()
+    const pnNotificationListerner = jest.fn()
+    const wsNotificationListerner = jest.fn()
+
+    manager.setNotificationHandlers({
+      all: allNotificationListerner,
+      websocket: wsNotificationListerner,
+      pushNotification: pnNotificationListerner,
+    })
+
+    manager.handleIncomingInvite({
+      source: 'websocket',
+      callID: 'foo1',
+      callee_id_name: 'foo',
+      callee_id_number: 'foo',
+      caller_id_name: 'foo',
+      caller_id_number: 'foo',
+      sdp: 'foo',
+      display_direction: 'foo',
+      nodeId: 'foo'
+    })
+
+    expect(allNotificationListerner).toHaveBeenCalledTimes(1)
+    expect(wsNotificationListerner).toHaveBeenCalledTimes(1)
+    expect(pnNotificationListerner).toHaveBeenCalledTimes(0)
+
+    manager.handleIncomingInvite({
+        source: 'pushNotification',
+        callID: 'foo2',
+        callee_id_name: 'foo',
+        callee_id_number: 'foo',
+        caller_id_name: 'foo',
+        caller_id_number: 'foo',
+        sdp: 'foo',
+        display_direction: 'foo',
+        nodeId: 'foo'
+      })
+      
+      expect(allNotificationListerner).toHaveBeenCalledTimes(2)
+      expect(wsNotificationListerner).toHaveBeenCalledTimes(1)
+      expect(pnNotificationListerner).toHaveBeenCalledTimes(1)
+  
+  })
+
+  test('It should not answer the call when the invite is rejected', () => {
+    //@ts-ignore
+    const manager = new IncomingCallManager(buildCall, rejectCall)
+    const allNotificationListerner = jest.fn((notification: IncomingCallNotification) => {notification.invite.reject()})
+
+    manager.setNotificationHandlers({
+        //@ts-ignore
+      all: allNotificationListerner,
+    })
+
+    manager.handleIncomingInvite({
+      source: 'websocket',
+      callID: 'foo1',
+      callee_id_name: 'foo',
+      callee_id_number: 'foo',
+      caller_id_name: 'foo',
+      caller_id_number: 'foo',
+      sdp: 'foo',
+      display_direction: 'foo',
+      nodeId: 'foo'
+    })
+
+    expect(allNotificationListerner).toHaveBeenCalledTimes(1)
+    expect(answer).toBeCalledTimes(0)
+  })
+
+  test('It should answer the call when the invite is accepted', () => {
+    //@ts-ignore
+    const manager = new IncomingCallManager(buildCall, rejectCall)
+    //@ts-ignore
+    const allNotificationListerner = jest.fn((notification: IncomingCallNotification) => {notification.invite.accept({})})
+
+    manager.setNotificationHandlers({
+        //@ts-ignore
+      all: allNotificationListerner,
+    })
+
+    manager.handleIncomingInvite({
+      source: 'websocket',
+      callID: 'foo1',
+      callee_id_name: 'foo',
+      callee_id_number: 'foo',
+      caller_id_name: 'foo',
+      caller_id_number: 'foo',
+      sdp: 'foo',
+      display_direction: 'foo',
+      nodeId: 'foo'
+    })
+
+    expect(allNotificationListerner).toHaveBeenCalledTimes(1)
+    expect(answer).toBeCalledTimes(1)
+  })
+
+  test('It should dedupe overlaping listeners', () => {
+    //@ts-ignore
+    const manager = new IncomingCallManager(buildCall, rejectCall)
+    const notificationListerner = jest.fn()
+    manager.setNotificationHandlers({
+      all: notificationListerner,
+      websocket: notificationListerner,
+      pushNotification: notificationListerner,
+    })
+
+    manager.handleIncomingInvite({
+      source: 'websocket',
+      callID: 'foo',
+      callee_id_name: 'foo',
+      callee_id_number: 'foo',
+      caller_id_name: 'foo',
+      caller_id_number: 'foo',
+      sdp: 'foo',
+      display_direction: 'foo',
+      nodeId: 'foo'
+    })
+
+    expect(notificationListerner).toHaveBeenCalledTimes(1)
+  })
+
+  test('It should dedupe invites', () => {
+    //@ts-ignore
+    const manager = new IncomingCallManager(buildCall, rejectCall)
+    const notificationListerner = jest.fn()
+    manager.setNotificationHandlers({
+      all: notificationListerner,
+    })
+
+    manager.handleIncomingInvite({
+      source: 'websocket',
+      callID: 'same-id',
+      callee_id_name: 'foo',
+      callee_id_number: 'foo',
+      caller_id_name: 'foo',
+      caller_id_number: 'foo',
+      sdp: 'foo',
+      display_direction: 'foo',
+      nodeId: 'foo'
+    })
+
+    manager.handleIncomingInvite({
+        source: 'websocket',
+        callID: 'same-id',
+        callee_id_name: 'foo',
+        callee_id_number: 'foo',
+        caller_id_name: 'foo',
+        caller_id_number: 'foo',
+        sdp: 'foo',
+        display_direction: 'foo',
+        nodeId: 'foo'
+      })
+
+    expect(notificationListerner).toHaveBeenCalledTimes(1)
+  })
+
+  test('It should clean up invites after reject', () => {
+    //@ts-ignore
+    const manager = new IncomingCallManager(buildCall, rejectCall)
+    const notificationListerner = jest.fn((notification: IncomingCallNotification) => {notification.invite.reject()})
+    manager.setNotificationHandlers({
+    //@ts-ignore
+      all: notificationListerner,
+    })
+
+    manager.handleIncomingInvite({
+      source: 'websocket',
+      callID: 'same-id',
+      callee_id_name: 'foo',
+      callee_id_number: 'foo',
+      caller_id_name: 'foo',
+      caller_id_number: 'foo',
+      sdp: 'foo',
+      display_direction: 'foo',
+      nodeId: 'foo'
+    })
+
+    manager.handleIncomingInvite({
+        source: 'websocket',
+        callID: 'same-id',
+        callee_id_name: 'foo',
+        callee_id_number: 'foo',
+        caller_id_name: 'foo',
+        caller_id_number: 'foo',
+        sdp: 'foo',
+        display_direction: 'foo',
+        nodeId: 'foo'
+      })
+
+    expect(notificationListerner).toHaveBeenCalledTimes(2)
+  })
+
+  test('It should clean up invites after accept', () => {
+    //@ts-ignore
+    const manager = new IncomingCallManager(buildCall, rejectCall)
+    //@ts-ignore
+    const notificationListerner = jest.fn((notification: IncomingCallNotification) => {notification.invite.accept({})})
+    manager.setNotificationHandlers({
+    //@ts-ignore
+      all: notificationListerner,
+    })
+
+    manager.handleIncomingInvite({
+      source: 'websocket',
+      callID: 'same-id',
+      callee_id_name: 'foo',
+      callee_id_number: 'foo',
+      caller_id_name: 'foo',
+      caller_id_number: 'foo',
+      sdp: 'foo',
+      display_direction: 'foo',
+      nodeId: 'foo'
+    })
+
+    manager.handleIncomingInvite({
+        source: 'websocket',
+        callID: 'same-id',
+        callee_id_name: 'foo',
+        callee_id_number: 'foo',
+        caller_id_name: 'foo',
+        caller_id_number: 'foo',
+        sdp: 'foo',
+        display_direction: 'foo',
+        nodeId: 'foo'
+      })
+
+    expect(notificationListerner).toHaveBeenCalledTimes(2)
+  })
+
+})

--- a/packages/js/src/fabric/IncomingCallManager.ts
+++ b/packages/js/src/fabric/IncomingCallManager.ts
@@ -15,14 +15,16 @@ export interface IncomingInvite {
   nodeId: string
  }
 
+export interface AcceptInviteParams {
+  rootElement: HTMLElement | undefined
+}
+
 export interface IncomingCallNotification {
     invite: {
       details: IncomingInvite
       accept: ({
         rootElement,
-      }: {
-        rootElement: HTMLElement | undefined
-      }) => Promise<BaseRoomSession<RoomSession>>
+      }: AcceptInviteParams) => Promise<BaseRoomSession<RoomSession>>
       reject: () => Promise<void>
     }
   }

--- a/packages/js/src/fabric/IncomingCallManager.ts
+++ b/packages/js/src/fabric/IncomingCallManager.ts
@@ -1,0 +1,110 @@
+import { BaseRoomSession } from "../BaseRoomSession"
+import { RoomSession } from "../RoomSession"
+
+export type InboundCallSource = 'websocket' | 'pushNotification'
+
+export interface IncomingInvite {
+  source: InboundCallSource
+  callID: string
+  sdp: string
+  caller_id_name: string
+  caller_id_number: string
+  callee_id_name: string
+  callee_id_number: string
+  display_direction: string
+  nodeId: string
+ }
+
+export interface IncomingCallNotification {
+    invite: {
+      details: IncomingInvite
+      accept: ({
+        rootElement,
+      }: {
+        rootElement: HTMLElement | undefined
+      }) => Promise<BaseRoomSession<RoomSession>>
+      reject: () => Promise<void>
+    }
+  }
+export type IncomingCallHandler = (notification: IncomingCallNotification) => Promise<void>
+
+export  interface IncomingCallHandlers {
+    all?: IncomingCallHandler
+    pushNotification?: IncomingCallHandler
+    websocket?: IncomingCallHandler
+  }
+
+export class IncomingCallManager {
+
+  private _pendingInvites: Record<string, IncomingInvite> = {}
+  private _handlers: IncomingCallHandlers = {};
+  
+  constructor(private _buildCallObject: (invite: IncomingInvite,
+    rootElement: HTMLElement | undefined) => BaseRoomSession<RoomSession>, private _executeReject: (callId: string, nodeId: string) => Promise<void>) {}
+  
+  private _buildNotification(invite: IncomingInvite): IncomingCallNotification {
+
+    const accept = async (
+      rootElement: HTMLElement | undefined
+    ): Promise<BaseRoomSession<RoomSession>> => {
+      return new Promise((resolve, reject) => {
+        delete this._pendingInvites[invite.callID]
+        try {
+          const call = this._buildCallObject(invite, rootElement)
+          //@ts-expect-error
+          call.answer()
+
+          resolve(call)
+        } catch (e) {
+          reject(e)
+        }
+      })
+    }
+
+    const reject = () => {
+      delete this._pendingInvites[invite.callID]
+      return this._executeReject(
+        invite.callID,
+        invite.nodeId
+      )
+    }
+
+      return {
+        invite: {
+          details: invite,
+          accept: ({ rootElement }: { rootElement: HTMLElement | undefined }) =>
+            accept(rootElement),
+          reject: () => reject(),
+        },
+      }
+    }
+
+  setNotificationHandlers(handlers: IncomingCallHandlers) {
+    this._handlers.all = handlers.all
+    if((handlers.pushNotification && (this._handlers.all != handlers.pushNotification)) || !handlers.pushNotification) {
+      this._handlers.pushNotification = handlers.pushNotification
+    }
+    if((handlers.websocket && (this._handlers.all != handlers.websocket)) || !handlers.websocket) {
+      this._handlers.websocket = handlers.websocket
+    }
+  }
+
+  handleIncomingInvite(incomingInvite: IncomingInvite) {
+    if(incomingInvite.callID in this._pendingInvites) {
+      console.log(`skiping nottification for pending invite to callID: ${incomingInvite.callID}`)
+      return
+    }
+    this._pendingInvites[incomingInvite.callID] = incomingInvite
+
+    if(!(this._handlers.all || this._handlers[incomingInvite.source])) {
+      console.log('skiping nottification no listeners:')
+      return 
+    }
+
+    const notification = this._buildNotification(incomingInvite)
+    
+    this._handlers.all?.(notification)
+    const handler = this._handlers[incomingInvite.source]
+    handler?.(notification)
+  }
+}

--- a/packages/js/src/fabric/WSClient.ts
+++ b/packages/js/src/fabric/WSClient.ts
@@ -273,6 +273,8 @@ export class WSClient {
       remoteSdp: sdp,
       prevCallId: callID,
       nodeId,
+      eventsWatcher: unifiedEventsWatcher,
+      disableUdpIceServers: this.options.disableUdpIceServers || false,
     })
 
     // WebRTC connection left the room.

--- a/packages/js/src/fabric/WSClient.ts
+++ b/packages/js/src/fabric/WSClient.ts
@@ -49,7 +49,9 @@ export class WSClient {
       logLevel: 'debug',
       unifiedEventing: true,
     })
-    this._incomingCallManager = new IncomingCallManager(this.buildInboundCall, this.executeVertoBye)
+    this._incomingCallManager = new IncomingCallManager(
+      (payload: IncomingInvite,rootElement: HTMLElement | undefined) => this.buildInboundCall(payload, rootElement), 
+      (callId: string, nodeId: string) => this.executeVertoBye(callId, nodeId))
   }
 
   /** @internal */

--- a/packages/js/src/fabric/WSClient.ts
+++ b/packages/js/src/fabric/WSClient.ts
@@ -10,6 +10,9 @@ import { createClient } from '../createClient'
 import { wsClientWorker, unifiedEventsWatcher } from './workers'
 import { InboundCallSource, IncomingCallHandlers, IncomingCallManager, IncomingInvite } from './IncomingCallManager'
 
+export interface OnlineParams {
+  incomingCallHandlers: IncomingCallHandlers
+}
 interface PushNotification {
   encryption_type: 'aes_256_gcm'
   notification_uuid: string
@@ -310,7 +313,7 @@ export class WSClient {
   /**
    * Mark the client as 'online' to receive calls over WebSocket
    */
-  online(incomingCallHandlers: IncomingCallHandlers) {
+  online({incomingCallHandlers}: OnlineParams) {
     this._incomingCallManager.setNotificationHandlers(incomingCallHandlers)
     // @ts-expect-error
     return this.wsClient.execute({

--- a/packages/js/src/fabric/index.ts
+++ b/packages/js/src/fabric/index.ts
@@ -2,9 +2,3 @@ export * from './Client'
 export * from './SWClient'
 export * from './WSClient'
 export * from './SignalWire'
-export {
-    IncomingCallHandler,
-    IncomingCallHandlers,
-    InboundCallSource,
-    IncomingCallNotification
-} from './IncomingCallManager'

--- a/packages/js/src/fabric/index.ts
+++ b/packages/js/src/fabric/index.ts
@@ -2,3 +2,9 @@ export * from './Client'
 export * from './SWClient'
 export * from './WSClient'
 export * from './SignalWire'
+export {
+    IncomingCallHandler,
+    IncomingCallHandlers,
+    InboundCallSource,
+    IncomingCallNotification
+} from './IncomingCallManager'

--- a/packages/js/src/index.ts
+++ b/packages/js/src/index.ts
@@ -124,5 +124,6 @@ export {
   IncomingCallHandler,
   IncomingCallHandlers,
   InboundCallSource,
-  IncomingCallNotification
+  IncomingCallNotification,
+  AcceptInviteParams
 } from './fabric/IncomingCallManager'

--- a/packages/js/src/index.ts
+++ b/packages/js/src/index.ts
@@ -119,3 +119,10 @@ export type {
   RoomSessionObjectEvents as RoomObjectEvents,
   RoomEventNames,
 } from './utils/interfaces'
+
+export {
+  IncomingCallHandler,
+  IncomingCallHandlers,
+  InboundCallSource,
+  IncomingCallNotification
+} from './fabric/IncomingCallManager'

--- a/packages/webrtc/src/RTCPeer.ts
+++ b/packages/webrtc/src/RTCPeer.ts
@@ -509,11 +509,11 @@ export default class RTCPeer<EventTypes extends EventEmitter.ValidEventTypes> {
   }
 
   private _remoteSdpHasVideo(): boolean {
-    return hasMediaSection(this.remoteSdp ?? '', 'video')
+    return hasMediaSection(this.remoteSdp ?? this.options.remoteSdp ?? '', 'video')
   }
 
   private _remoteSdpHasAudio(): boolean {
-    return hasMediaSection(this.remoteSdp ?? '', 'audio')
+    return hasMediaSection(this.remoteSdp ?? this.options.remoteSdp ?? '', 'audio')
   }
 
   async start() {


### PR DESCRIPTION
# Description

This unifies the notification of incoming calls for both cases Push and WS.
Changes:
* Now the developer should provide incoming invites callbacks in the `online` method.
* `handlePushNotification` doesn't return a `call` object anymore.
* Push notification invites, are published via incoming invite callbacks too.
* The `call` object is only created after `accept` is called
* added got a `rootElement` param to `dial()` and `accept()`. This allows developers to set the rootElement after initializing de client
 
## Type of change

- [x] Internal refactoring
- [ ] Bug fix (bugfix - non-breaking)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Code snippets

```js
// register invites callback for push notification only
client.online({pushNotification: __incomingCallNotification})

// register invites callback for both push notification and websocket
window.__client.online({all: __incomingCallNotification})

//accept call unsing the invite notification
const call = await window.__invite.accept(document.getElementById('rootElement'))

```

In case of new feature or breaking changes, please include code snippets.
