### PR TITLE
e2e tests, browser v2, add scenarios with conference

### DIFF
--- a/.changeset/sour-jars-mix.md
+++ b/.changeset/sour-jars-mix.md
@@ -1,0 +1,5 @@
+---
+'@sw-internal/e2e-js': patch
+---
+
+Review and add e2e tests for v2 webrtc

--- a/internal/e2e-js/tests/v2Webrtc/v2WebrtcFromRest.spec.ts
+++ b/internal/e2e-js/tests/v2Webrtc/v2WebrtcFromRest.spec.ts
@@ -7,9 +7,96 @@ import {
   expectInjectRelayHost,
   expectRelayConnected,
   expectv2HasReceivedAudio,
+  expectv2HasReceivedSilence,
   getDialConferenceLaml,
   randomizeResourceName
 } from '../../utils'
+
+test.describe('v2WebrtcFromRest', () => {
+  test('should handle a call from REST API to v2 client, playing silence at answer', async ({
+    createCustomVanillaPage,
+  }) => {
+    console.info('START: should handle a call from REST API to v2 client, playing silence at answer')
+
+    const expectCallActive = async (page: Page) => {
+      // Hangup call button locator
+      const hangupCall = page.locator('#hangupCall')
+      expect(hangupCall).not.toBe(null)
+
+      // Expect the Hangup button to be enabled (call active)
+      await expect(hangupCall).toBeEnabled()
+    }
+
+    const expectCallHangup = async (page: Page) => {
+      // Hangup call button locator
+      const hangupCall = page.locator('#hangupCall')
+      expect(hangupCall).not.toBe(null)
+
+      // Wait for call to be hung up
+      await expect(hangupCall).toBeDisabled()
+    }
+
+    const pageCallee = await createCustomVanillaPage({ name: '[callee]' })
+    await pageCallee.goto(SERVER_URL + '/v2vanilla.html')
+
+    const relayHost = process.env.RELAY_HOST ?? ''
+    await expectInjectRelayHost(pageCallee, relayHost)
+
+    const envRelayProject = process.env.RELAY_PROJECT ?? ''
+    expect(envRelayProject).not.toBe(null)
+
+    const resource = randomizeResourceName()
+    const jwtCallee = await createTestJWTToken({ resource: resource })
+    expect(jwtCallee).not.toBe(null)
+
+    await expectRelayConnected(pageCallee, envRelayProject, jwtCallee)
+
+    const inlineLaml = `<?xml version="1.0" encoding="UTF-8"?>
+      <Response>
+      <Say>
+        <prosody volume="silent">Words to speak Words to speak Words to speak Words to speak Words to speak Words to speak Words to speak Words to speak Words to speak Words to speak Words to speak Words to speak Words to speak Words to speak Words to speak Words to speak Words to speak Words to speak Words to speak Words to speak Words to speak Words to speak Words to speak Words to speak Words to speak Words to speak Words to speak Words to speak</prosody>
+      </Say>
+    </Response>`
+
+    console.log('inline Laml: ', inlineLaml)
+    const createResult = await createCallWithCompatibilityApi(
+      resource,
+      inlineLaml
+    )
+    expect(createResult).toBe(201)
+    console.log('REST API returned 201 at ', new Date())
+
+    const callStatusCallee = pageCallee.locator('#callStatus')
+    expect(callStatusCallee).not.toBe(null)
+    await expect(callStatusCallee).toContainText('-> active')
+
+    console.log('The call is active at ', new Date())
+
+    const callDurationMs = 20000
+    // Call duration
+    await pageCallee.waitForTimeout(callDurationMs)
+
+    console.log('Time to check the audio energy at ', new Date())
+
+    // We expect silence...
+    const maxAudioEnergy = 0.01
+
+    // ... but the packets must be received anyway
+    const minPackets = (callDurationMs * 0.9) * 50 / 1000
+
+    // Check the audio energy level is above threshold
+    console.log('Expected max audio energy: ', maxAudioEnergy)
+
+    await expectv2HasReceivedSilence(pageCallee, maxAudioEnergy, minPackets)
+
+    await expectCallActive(pageCallee)
+    console.log('Hanging up the call at ', new Date())
+    await pageCallee.click('#hangupCall')
+    await expectCallHangup(pageCallee)
+
+    console.info('END: should handle a call from REST API to v2 client, playing silence at answer')
+  })
+})
 
 test.describe('v2WebrtcFromRest', () => {
   test('should handle a call from REST API to v2 client, dialing into a Conference at answer', async ({

--- a/internal/e2e-js/tests/v2Webrtc/v2WebrtcFromRest.spec.ts
+++ b/internal/e2e-js/tests/v2Webrtc/v2WebrtcFromRest.spec.ts
@@ -69,7 +69,8 @@ test.describe('v2WebrtcFromRest', () => {
     console.log('inline Laml: ', inlineLaml)
     const createResult = await createCallWithCompatibilityApi(
       resource,
-      inlineLaml
+      inlineLaml,
+      'PCMU,PCMA'
     )
     expect(createResult).toBe(201)
     console.log('REST API returned 201 at ', new Date())
@@ -99,5 +100,250 @@ test.describe('v2WebrtcFromRest', () => {
     await expectCallHangup(pageCallee)
 
     console.info('END: should handle a call from LaML bin')
+  })
+})
+
+test.describe('v2WebrtcFromRestTwoJoinAudioVideo', () => {
+  test('should handle a call from LaML bin and make 2 users join a room, audio/video', async ({
+    createCustomVanillaPage,
+  }) => {
+    console.info('START: should handle a call from LaML bin and make 2 users join a room, audio/video')
+
+    const expectCallActive = async (page: Page) => {
+      // Hangup call button locator
+      const hangupCall = page.locator('#hangupCall')
+      expect(hangupCall).not.toBe(null)
+
+      // Expect the Hangup button to be enabled (call active)
+      await expect(hangupCall).toBeEnabled()
+    }
+
+    const expectCallHangup = async (page: Page) => {
+      // Hangup call button locator
+      const hangupCall = page.locator('#hangupCall')
+      expect(hangupCall).not.toBe(null)
+
+      // Wait for call to be hung up
+      await expect(hangupCall).toBeDisabled()
+    }
+
+    const pageCallee = await createCustomVanillaPage({ name: '[callee]' })
+    await pageCallee.goto(SERVER_URL + '/v2vanilla.html')
+
+    const pageCallee2 = await createCustomVanillaPage({ name: '[callee2]' })
+    await pageCallee2.goto(SERVER_URL + '/v2vanilla.html')
+
+    const relayHost = process.env.RELAY_HOST ?? ''
+    await expectInjectRelayHost(pageCallee, relayHost)
+    await expectInjectRelayHost(pageCallee2, relayHost)
+
+    const envRelayProject = process.env.RELAY_PROJECT ?? ''
+    expect(envRelayProject).not.toBe(null)
+
+    const resource = randomizeResourceName()
+    const jwtCallee = await createTestJWTToken({ resource: resource })
+    expect(jwtCallee).not.toBe(null)
+
+    const resource2 = randomizeResourceName()
+    const jwtCallee2 = await createTestJWTToken({ resource: resource2 })
+    expect(jwtCallee2).not.toBe(null)
+
+    await expectRelayConnected(pageCallee, envRelayProject, jwtCallee)
+    await expectRelayConnected(pageCallee2, envRelayProject, jwtCallee2)
+
+    const conferenceName = randomizeRoomName('v2rest')
+    const conferenceRegion = process.env.LAML_CONFERENCE_REGION ?? ''
+    const inlineLaml = `<?xml version="1.0" encoding="UTF-8"?>
+      <Response>
+        <Dial>
+          <Conference
+            endConferenceOnExit="false"
+            startConferenceOnEnter="true"
+            waitUrl="https://cdn.signalwire.com/default-music/welcome.mp3"
+            waitMethod="GET"
+            ${conferenceRegion}>
+            ${conferenceName}
+          </Conference>
+        </Dial>
+      </Response>`
+
+    console.log('inline Laml: ', inlineLaml)
+    const createResult = await createCallWithCompatibilityApi(
+      resource,
+      inlineLaml,
+      'PCMU,PCMA'
+    )
+    expect(createResult).toBe(201)
+    console.log('REST API returned 201 at ', new Date())
+
+    const callStatusCallee = pageCallee.locator('#callStatus')
+    expect(callStatusCallee).not.toBe(null)
+    await expect(callStatusCallee).toContainText('-> active')
+
+    console.log('The call is active at ', new Date())
+
+    const createResult2 = await createCallWithCompatibilityApi(
+      resource2,
+      inlineLaml,
+      ''
+    )
+    expect(createResult2).toBe(201)
+    console.log('REST API returned 201 at ', new Date())
+
+    const callStatusCallee2 = pageCallee2.locator('#callStatus')
+    expect(callStatusCallee2).not.toBe(null)
+    await expect(callStatusCallee2).toContainText('-> active')
+
+    console.log('The call is active at ', new Date())
+
+    const callDurationMs = 20000
+    // Call duration
+    await pageCallee.waitForTimeout(callDurationMs)
+
+    console.log('Time to check the audio energy at ', new Date())
+
+    // Empirical value; it depends on the call scenario
+    const minAudioEnergy = callDurationMs / 50000
+
+    // Check the audio energy level is above threshold
+    console.log('Expected min audio energy: ', minAudioEnergy)
+    await expectv2TotalAudioEnergyToBeGreaterThan(pageCallee, minAudioEnergy)
+    await expectv2TotalAudioEnergyToBeGreaterThan(pageCallee2, minAudioEnergy)
+
+    await expectCallActive(pageCallee)
+    await expectCallActive(pageCallee2)
+
+    console.log('Hanging up the call2 at ', new Date())
+
+    await pageCallee.click('#hangupCall')
+    await expectCallHangup(pageCallee)
+
+    await pageCallee2.click('#hangupCall')
+    await expectCallHangup(pageCallee2)
+
+    console.info('END: should handle a call from LaML bin and make 2 users join a room, audio/video')
+  })
+})
+
+
+test.describe('v2WebrtcFromRestTwoJoinAudio', () => {
+  test('should handle a call from LaML bin and make 2 users join a room, audio G711', async ({
+    createCustomVanillaPage,
+  }) => {
+    console.info('START: should handle a call from LaML bin and make 2 users join a room, audio G711')
+
+    const expectCallActive = async (page: Page) => {
+      // Hangup call button locator
+      const hangupCall = page.locator('#hangupCall')
+      expect(hangupCall).not.toBe(null)
+
+      // Expect the Hangup button to be enabled (call active)
+      await expect(hangupCall).toBeEnabled()
+    }
+
+    const expectCallHangup = async (page: Page) => {
+      // Hangup call button locator
+      const hangupCall = page.locator('#hangupCall')
+      expect(hangupCall).not.toBe(null)
+
+      // Wait for call to be hung up
+      await expect(hangupCall).toBeDisabled()
+    }
+
+    const pageCallee = await createCustomVanillaPage({ name: '[callee]' })
+    await pageCallee.goto(SERVER_URL + '/v2vanilla.html')
+
+    const pageCallee2 = await createCustomVanillaPage({ name: '[callee2]' })
+    await pageCallee2.goto(SERVER_URL + '/v2vanilla.html')
+
+    const relayHost = process.env.RELAY_HOST ?? ''
+    await expectInjectRelayHost(pageCallee, relayHost)
+    await expectInjectRelayHost(pageCallee2, relayHost)
+
+    const envRelayProject = process.env.RELAY_PROJECT ?? ''
+    expect(envRelayProject).not.toBe(null)
+
+    const resource = randomizeResourceName()
+    const jwtCallee = await createTestJWTToken({ resource: resource })
+    expect(jwtCallee).not.toBe(null)
+
+    const resource2 = randomizeResourceName()
+    const jwtCallee2 = await createTestJWTToken({ resource: resource2 })
+    expect(jwtCallee2).not.toBe(null)
+
+    await expectRelayConnected(pageCallee, envRelayProject, jwtCallee)
+    await expectRelayConnected(pageCallee2, envRelayProject, jwtCallee2)
+
+    const conferenceName = randomizeRoomName('v2rest')
+    const conferenceRegion = process.env.LAML_CONFERENCE_REGION ?? ''
+    const inlineLaml = `<?xml version="1.0" encoding="UTF-8"?>
+      <Response>
+        <Dial>
+          <Conference
+            endConferenceOnExit="false"
+            startConferenceOnEnter="true"
+            waitUrl="https://cdn.signalwire.com/default-music/welcome.mp3"
+            waitMethod="GET"
+            ${conferenceRegion}>
+            ${conferenceName}
+          </Conference>
+        </Dial>
+      </Response>`
+
+    console.log('inline Laml: ', inlineLaml)
+    const createResult = await createCallWithCompatibilityApi(
+      resource,
+      inlineLaml,
+      'PCMU,PCMA'
+    )
+    expect(createResult).toBe(201)
+    console.log('REST API returned 201 at ', new Date())
+
+    const callStatusCallee = pageCallee.locator('#callStatus')
+    expect(callStatusCallee).not.toBe(null)
+    await expect(callStatusCallee).toContainText('-> active')
+
+    console.log('The call is active at ', new Date())
+
+    const createResult2 = await createCallWithCompatibilityApi(
+      resource2,
+      inlineLaml,
+      'PCMU,PCMA'
+    )
+    expect(createResult2).toBe(201)
+    console.log('REST API returned 201 at ', new Date())
+
+    const callStatusCallee2 = pageCallee2.locator('#callStatus')
+    expect(callStatusCallee2).not.toBe(null)
+    await expect(callStatusCallee2).toContainText('-> active')
+
+    console.log('The call is active at ', new Date())
+
+    const callDurationMs = 20000
+    // Call duration
+    await pageCallee.waitForTimeout(callDurationMs)
+
+    console.log('Time to check the audio energy at ', new Date())
+
+    // Empirical value; it depends on the call scenario
+    const minAudioEnergy = callDurationMs / 50000
+
+    // Check the audio energy level is above threshold
+    console.log('Expected min audio energy: ', minAudioEnergy)
+    await expectv2TotalAudioEnergyToBeGreaterThan(pageCallee, minAudioEnergy)
+    await expectv2TotalAudioEnergyToBeGreaterThan(pageCallee2, minAudioEnergy)
+
+    await expectCallActive(pageCallee)
+    await expectCallActive(pageCallee2)
+
+    console.log('Hanging up the call2 at ', new Date())
+
+    await pageCallee.click('#hangupCall')
+    await expectCallHangup(pageCallee)
+
+    await pageCallee2.click('#hangupCall')
+    await expectCallHangup(pageCallee2)
+
+    console.info('END: should handle a call from LaML bin and make 2 users join a room, audio G711')
   })
 })

--- a/internal/e2e-js/tests/v2Webrtc/v2WebrtcFromRest.spec.ts
+++ b/internal/e2e-js/tests/v2Webrtc/v2WebrtcFromRest.spec.ts
@@ -7,15 +7,15 @@ import {
   expectInjectRelayHost,
   expectRelayConnected,
   expectv2HasReceivedAudio,
-  randomizeResourceName,
-  randomizeRoomName,
+  getDialConferenceLaml,
+  randomizeResourceName
 } from '../../utils'
 
 test.describe('v2WebrtcFromRest', () => {
-  test('should handle a call from LaML bin', async ({
+  test('should handle a call from REST API to v2 client, dialing into a Conference at answer', async ({
     createCustomVanillaPage,
   }) => {
-    console.info('START: should handle a call from LaML bin')
+    console.info('START: should handle a call from REST API to v2 client, dialing into a Conference at answer')
 
     const expectCallActive = async (page: Page) => {
       // Hangup call button locator
@@ -50,21 +50,7 @@ test.describe('v2WebrtcFromRest', () => {
 
     await expectRelayConnected(pageCallee, envRelayProject, jwtCallee)
 
-    const conferenceName = randomizeRoomName('v2rest')
-    const conferenceRegion = process.env.LAML_CONFERENCE_REGION ?? ''
-    const inlineLaml = `<?xml version="1.0" encoding="UTF-8"?>
-      <Response>
-        <Dial>
-          <Conference
-            endConferenceOnExit="false"
-            startConferenceOnEnter="true"
-            waitUrl="https://cdn.signalwire.com/default-music/welcome.mp3"
-            waitMethod="GET"
-            ${conferenceRegion}>
-            ${conferenceName}
-          </Conference>
-        </Dial>
-      </Response>`
+    const inlineLaml = getDialConferenceLaml('v2rest0')
 
     console.log('inline Laml: ', inlineLaml)
     const createResult = await createCallWithCompatibilityApi(
@@ -103,15 +89,15 @@ test.describe('v2WebrtcFromRest', () => {
     await pageCallee.click('#hangupCall')
     await expectCallHangup(pageCallee)
 
-    console.info('END: should handle a call from LaML bin')
+    console.info('END: should handle a call from REST API to v2 client, dialing into a Conference at answer')
   })
 })
 
 test.describe('v2WebrtcFromRestTwoJoinAudioVideo', () => {
-  test('should handle a call from LaML bin and make 2 users join a room, audio/video', async ({
+  test('should handle a call from REST API to v2 clients, dialing both into a Conference at answer, audio/video', async ({
     createCustomVanillaPage,
   }) => {
-    console.info('START: should handle a call from LaML bin and make 2 users join a room, audio/video')
+    console.info('START: should handle a call from REST API to v2 clients, dialing both into a Conference at answer, audio/video')
 
     const expectCallActive = async (page: Page) => {
       // Hangup call button locator
@@ -155,21 +141,7 @@ test.describe('v2WebrtcFromRestTwoJoinAudioVideo', () => {
     await expectRelayConnected(pageCallee, envRelayProject, jwtCallee)
     await expectRelayConnected(pageCallee2, envRelayProject, jwtCallee2)
 
-    const conferenceName = randomizeRoomName('v2rest')
-    const conferenceRegion = process.env.LAML_CONFERENCE_REGION ?? ''
-    const inlineLaml = `<?xml version="1.0" encoding="UTF-8"?>
-      <Response>
-        <Dial>
-          <Conference
-            endConferenceOnExit="false"
-            startConferenceOnEnter="true"
-            waitUrl="https://cdn.signalwire.com/default-music/welcome.mp3"
-            waitMethod="GET"
-            ${conferenceRegion}>
-            ${conferenceName}
-          </Conference>
-        </Dial>
-      </Response>`
+    const inlineLaml = getDialConferenceLaml('v2rest1')
 
     console.log('inline Laml: ', inlineLaml)
     const createResult = await createCallWithCompatibilityApi(
@@ -227,15 +199,15 @@ test.describe('v2WebrtcFromRestTwoJoinAudioVideo', () => {
     await pageCallee2.click('#hangupCall')
     await expectCallHangup(pageCallee2)
 
-    console.info('END: should handle a call from LaML bin and make 2 users join a room, audio/video')
+    console.info('END: should handle a call from REST API to v2 clients, dialing both into a Conference at answer, audio/video')
   })
 })
 
 test.describe('v2WebrtcFromRestTwoJoinAudio', () => {
-  test('should handle a call from LaML bin and make 2 users join a room, audio G711', async ({
+  test('should handle a call from REST API to v2 clients, dialing both into a Conference at answer, audio G711', async ({
     createCustomVanillaPage,
   }) => {
-    console.info('START: should handle a call from LaML bin and make 2 users join a room, audio G711')
+    console.info('START: should handle a call from REST API to v2 clients, dialing both into a Conference at answer, audio G711')
 
     const expectCallActive = async (page: Page) => {
       // Hangup call button locator
@@ -279,21 +251,7 @@ test.describe('v2WebrtcFromRestTwoJoinAudio', () => {
     await expectRelayConnected(pageCallee, envRelayProject, jwtCallee)
     await expectRelayConnected(pageCallee2, envRelayProject, jwtCallee2)
 
-    const conferenceName = randomizeRoomName('v2rest')
-    const conferenceRegion = process.env.LAML_CONFERENCE_REGION ?? ''
-    const inlineLaml = `<?xml version="1.0" encoding="UTF-8"?>
-      <Response>
-        <Dial>
-          <Conference
-            endConferenceOnExit="false"
-            startConferenceOnEnter="true"
-            waitUrl="https://cdn.signalwire.com/default-music/welcome.mp3"
-            waitMethod="GET"
-            ${conferenceRegion}>
-            ${conferenceName}
-          </Conference>
-        </Dial>
-      </Response>`
+    const inlineLaml = getDialConferenceLaml('v2rest2')
 
     console.log('inline Laml: ', inlineLaml)
     const createResult = await createCallWithCompatibilityApi(
@@ -353,6 +311,6 @@ test.describe('v2WebrtcFromRestTwoJoinAudio', () => {
     await pageCallee2.click('#hangupCall')
     await expectCallHangup(pageCallee2)
 
-    console.info('END: should handle a call from LaML bin and make 2 users join a room, audio G711')
+    console.info('END: should handle a call from REST API to v2 clients, dialing both into a Conference at answer, audio G711')
   })
 })

--- a/internal/e2e-js/tests/v2Webrtc/v2WebrtcFromRest.spec.ts
+++ b/internal/e2e-js/tests/v2Webrtc/v2WebrtcFromRest.spec.ts
@@ -6,7 +6,7 @@ import {
   createTestJWTToken,
   expectInjectRelayHost,
   expectRelayConnected,
-  expectv2TotalAudioEnergyToBeGreaterThan,
+  expectv2HasReceivedAudio,
   randomizeResourceName,
   randomizeRoomName,
 } from '../../utils'
@@ -92,7 +92,11 @@ test.describe('v2WebrtcFromRest', () => {
 
     // Check the audio energy level is above threshold
     console.log('Expected min audio energy: ', minAudioEnergy)
-    await expectv2TotalAudioEnergyToBeGreaterThan(pageCallee, minAudioEnergy)
+
+    // Considers 50 pps with max 10% packet loss
+    const minPackets = (callDurationMs * 0.9) * 50 / 1000
+
+    await expectv2HasReceivedAudio(pageCallee, minAudioEnergy, minPackets)
 
     await expectCallActive(pageCallee)
     console.log('Hanging up the call at ', new Date())
@@ -201,12 +205,16 @@ test.describe('v2WebrtcFromRestTwoJoinAudioVideo', () => {
     console.log('Time to check the audio energy at ', new Date())
 
     // Empirical value; it depends on the call scenario
-    const minAudioEnergy = callDurationMs / 50000
+    const minAudioEnergy = callDurationMs / 8000
 
     // Check the audio energy level is above threshold
     console.log('Expected min audio energy: ', minAudioEnergy)
-    await expectv2TotalAudioEnergyToBeGreaterThan(pageCallee, minAudioEnergy)
-    await expectv2TotalAudioEnergyToBeGreaterThan(pageCallee2, minAudioEnergy)
+
+    // Considers 50 pps with max 10% packet loss
+    const minPackets = (callDurationMs * 0.9) * 50 / 1000
+
+    await expectv2HasReceivedAudio(pageCallee, minAudioEnergy, minPackets)
+    await expectv2HasReceivedAudio(pageCallee2, minAudioEnergy, minPackets)
 
     await expectCallActive(pageCallee)
     await expectCallActive(pageCallee2)
@@ -323,12 +331,16 @@ test.describe('v2WebrtcFromRestTwoJoinAudio', () => {
     console.log('Time to check the audio energy at ', new Date())
 
     // Empirical value; it depends on the call scenario
-    const minAudioEnergy = callDurationMs / 50000
+    const minAudioEnergy = callDurationMs / 8000
 
     // Check the audio energy level is above threshold
     console.log('Expected min audio energy: ', minAudioEnergy)
-    await expectv2TotalAudioEnergyToBeGreaterThan(pageCallee, minAudioEnergy)
-    await expectv2TotalAudioEnergyToBeGreaterThan(pageCallee2, minAudioEnergy)
+
+    // Considers 50 pps with max 10% packet loss
+    const minPackets = (callDurationMs * 0.9) * 50 / 1000
+
+    await expectv2HasReceivedAudio(pageCallee, minAudioEnergy, minPackets)
+    await expectv2HasReceivedAudio(pageCallee2, minAudioEnergy, minPackets)
 
     await expectCallActive(pageCallee)
     await expectCallActive(pageCallee2)

--- a/internal/e2e-js/tests/v2Webrtc/v2WebrtcFromRest.spec.ts
+++ b/internal/e2e-js/tests/v2Webrtc/v2WebrtcFromRest.spec.ts
@@ -170,8 +170,7 @@ test.describe('v2WebrtcFromRestTwoJoinAudioVideo', () => {
     console.log('inline Laml: ', inlineLaml)
     const createResult = await createCallWithCompatibilityApi(
       resource,
-      inlineLaml,
-      'PCMU,PCMA'
+      inlineLaml
     )
     expect(createResult).toBe(201)
     console.log('REST API returned 201 at ', new Date())
@@ -184,8 +183,7 @@ test.describe('v2WebrtcFromRestTwoJoinAudioVideo', () => {
 
     const createResult2 = await createCallWithCompatibilityApi(
       resource2,
-      inlineLaml,
-      ''
+      inlineLaml
     )
     expect(createResult2).toBe(201)
     console.log('REST API returned 201 at ', new Date())
@@ -224,7 +222,6 @@ test.describe('v2WebrtcFromRestTwoJoinAudioVideo', () => {
     console.info('END: should handle a call from LaML bin and make 2 users join a room, audio/video')
   })
 })
-
 
 test.describe('v2WebrtcFromRestTwoJoinAudio', () => {
   test('should handle a call from LaML bin and make 2 users join a room, audio G711', async ({

--- a/internal/e2e-js/tests/v2Webrtc/webrtcCalling.spec.ts
+++ b/internal/e2e-js/tests/v2Webrtc/webrtcCalling.spec.ts
@@ -116,10 +116,10 @@ test.describe('v2WebrtcCalling', () => {
     console.info('END: should handle one to one calling')
   })
 
-  test('should receive a call from LaML and expect an audio', async ({
+  test('should receive a call from LaML and expect to receive audio', async ({
     createCustomVanillaPage,
   }) => {
-    console.info('START: should receive a call from LaML and expect an audio')
+    console.info('START: should receive a call from LaML and expect to receive audio')
 
     const RESOURCE = 'vanilla-laml-callee'
     const pageCallee = await createCustomVanillaPage({ name: '[callee]' })
@@ -144,9 +144,11 @@ test.describe('v2WebrtcCalling', () => {
       <Response>
         <Play loop="0">https://cdn.signalwire.com/default-music/welcome.mp3</Play>
       </Response>`
+
     const createResult = await createCallWithCompatibilityApi(
       RESOURCE,
-      inlineLaml
+      inlineLaml,
+      ''
     )
     expect(createResult).toBe(201)
 
@@ -166,6 +168,6 @@ test.describe('v2WebrtcCalling', () => {
     // Wait for callee to hangup
     await expectCallHangup(pageCallee)
 
-    console.info('END: should receive a call from LaML and expect an audio')
+    console.info('END: should receive a call from LaML and expect to receive audio')
   })
 })

--- a/internal/e2e-js/tests/v2Webrtc/webrtcCalling.spec.ts
+++ b/internal/e2e-js/tests/v2Webrtc/webrtcCalling.spec.ts
@@ -147,8 +147,7 @@ test.describe('v2WebrtcCalling', () => {
 
     const createResult = await createCallWithCompatibilityApi(
       RESOURCE,
-      inlineLaml,
-      ''
+      inlineLaml
     )
     expect(createResult).toBe(201)
 

--- a/internal/e2e-js/utils.ts
+++ b/internal/e2e-js/utils.ts
@@ -717,7 +717,7 @@ export const expectPageReceiveMedia = async (page: Page, delay = 5_000) => {
 export const createCallWithCompatibilityApi = async (
   resource: string,
   inlineLaml: string,
-  codecs: string
+  codecs?: string|undefined
 ) => {
   const data = new URLSearchParams()
 

--- a/internal/e2e-js/utils.ts
+++ b/internal/e2e-js/utils.ts
@@ -716,7 +716,8 @@ export const expectPageReceiveMedia = async (page: Page, delay = 5_000) => {
 
 export const createCallWithCompatibilityApi = async (
   resource: string,
-  inlineLaml: string
+  inlineLaml: string,
+  codecs: string
 ) => {
   const data = new URLSearchParams()
 
@@ -728,7 +729,11 @@ export const createCallWithCompatibilityApi = async (
   const vertoDomain = process.env.VERTO_DOMAIN
   expect(vertoDomain).toBeDefined()
 
-  data.append('To', `verto:${resource}@${vertoDomain}`)
+  let to = `verto:${resource}@${vertoDomain}`
+  if (codecs) {
+    to += `;codecs=${codecs}`
+  }
+  data.append('To', to)
 
   console.log(
     'REST API URL: ',

--- a/internal/e2e-js/utils.ts
+++ b/internal/e2e-js/utils.ts
@@ -822,6 +822,28 @@ export const expectv2TotalAudioEnergyToBeGreaterThan = async (
   expect(audioStats['inbound-rtp']['totalAudioEnergy']).toBeGreaterThan(value)
 }
 
+export const getDialConferenceLaml = (
+  conferenceNameBase: string
+) => {
+  const conferenceName = randomizeRoomName(conferenceNameBase)
+  const conferenceRegion = process.env.LAML_CONFERENCE_REGION ?? ''
+  const inlineLaml = `<?xml version="1.0" encoding="UTF-8"?>
+    <Response>
+      <Dial>
+        <Conference
+          endConferenceOnExit="false"
+          startConferenceOnEnter="true"
+          waitUrl="https://cdn.signalwire.com/default-music/welcome.mp3"
+          waitMethod="GET"
+          ${conferenceRegion}>
+          ${conferenceName}
+        </Conference>
+      </Dial>
+    </Response>`
+
+    return inlineLaml
+}
+
 export const expectv2HasReceivedAudio = async (
   page: Page,
   minTotalAudioEnergy: number,
@@ -894,8 +916,6 @@ export const expectv2HasReceivedAudio = async (
   }
 
 }
-
-
 
 export const randomizeResourceName = (prefix: string = 'e2e') => {
   return `res-${prefix}${uuid()}`

--- a/internal/e2e-js/utils.ts
+++ b/internal/e2e-js/utils.ts
@@ -917,6 +917,100 @@ export const expectv2HasReceivedAudio = async (
 
 }
 
+export const expectv2HasReceivedSilence = async (
+  page: Page,
+  maxTotalAudioEnergy: number,
+  minPacketsReceived: number
+) => {
+  const audioStats = await page.evaluate(async () => {
+    // @ts-expect-error
+    const currentCall = window.__currentCall
+    const audioReceiver = currentCall.peer.instance
+      .getReceivers()
+      .find((r: any) => r.track.kind === 'audio')
+
+    const audioTrackId = audioReceiver.track.id
+
+    const stats = await currentCall.peer.instance.getStats(null)
+    const filter = {
+      'inbound-rtp': [
+        'audioLevel',
+        'totalAudioEnergy',
+        'totalSamplesDuration',
+        'totalSamplesReceived',
+        'packetsDiscarded',
+        'lastPacketReceivedTimestamp',
+        'bytesReceived',
+        'packetsReceived',
+        'packetsLost',
+        'packetsRetransmitted',
+      ],
+    }
+    const result: any = {}
+    Object.keys(filter).forEach((entry) => {
+      result[entry] = {}
+    })
+
+    stats.forEach((report: any) => {
+      for (const [key, value] of Object.entries(filter)) {
+        if (
+          report.type == key &&
+          report['mediaType'] === 'audio' &&
+          report['trackIdentifier'] === audioTrackId
+        ) {
+          value.forEach((entry) => {
+            if (report[entry]) {
+              result[key][entry] = report[entry]
+            }
+          })
+        }
+      }
+    }, {})
+
+    return result
+  })
+  console.log('audioStats: ', audioStats)
+
+  /* This is a workaround what we think is a bug in Playwright
+   * There are cases where totalAudioEnergy is not present in the report
+   * even though we see audio and it's not silence.
+   * In that case we rely on the number of packetsReceived.
+   * If there is genuine silence, then totalAudioEnergy must be present,
+   * albeit being a small number.
+   */
+  console.log(`Evaluating audio energy (max energy: ${maxTotalAudioEnergy}, min packets: ${minPacketsReceived})`)
+  const totalAudioEnergy = audioStats['inbound-rtp']['totalAudioEnergy']
+  const packetsReceived = audioStats['inbound-rtp']['packetsReceived']
+  if (totalAudioEnergy) {
+    expect(totalAudioEnergy).toBeLessThan(maxTotalAudioEnergy)
+  } else {
+    console.log("Warning: totalAudioEnergy was missing from the report!")
+    // We still want the right amount of packets
+    expect(packetsReceived).toBeGreaterThan(minPacketsReceived)
+  }
+}
+
+
+
+// export const startMediaRecording = async (
+//   page: Page
+// ) => {
+//   await page.evaluate(async () => {
+//     // @ts-expect-error
+//     const currentCall = window.__currentCall
+//     const stream = currentCall.peer.instance
+
+//     const options = {};
+//     const mediaRecorder = new MediaRecorder(stream, options);
+//     mediaRecorder.start();
+//   })
+// }
+
+
+
+
+
+
 export const randomizeResourceName = (prefix: string = 'e2e') => {
   return `res-${prefix}${uuid()}`
 }


### PR DESCRIPTION
# Description

Add e2e test scenarios for v2 Webrtc calls, dialling into a conference after answer (audio/video or only G.711).

Change the approach for checking the `totalAudioEnergy` to take into account what I consider a bug in playwright/Chromium.

Add a test that expects silence, to double check the role of `totalAudioEnergy`.

## Type of change

- [x] Internal refactoring
- [x] Bug fix (bugfix - non-breaking)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Code snippets

In case of new feature or breaking changes, please include code snippets.
