### PR TITLE
CF SDK: OAuth refresh token

### DIFF
--- a/.changeset/heavy-moose-retire.md
+++ b/.changeset/heavy-moose-retire.md
@@ -1,0 +1,6 @@
+---
+'@signalwire/core': patch
+'@signalwire/js': patch
+---
+
+CF SDK: OAuth refresh token

--- a/packages/core/src/BaseJWTSession.ts
+++ b/packages/core/src/BaseJWTSession.ts
@@ -6,7 +6,7 @@ import {
 } from './RPCMessages'
 import { SessionOptions } from './utils/interfaces'
 import { BaseSession } from './BaseSession'
-import { authExpiringAction } from './redux/actions'
+import { authExpiringAction, reauthAction } from './redux/actions'
 import { type SWCloseEvent, isSATAuth } from './utils'
 
 export class BaseJWTSession extends BaseSession {
@@ -150,14 +150,14 @@ export class BaseJWTSession extends BaseSession {
     if (!this.expiresAt) {
       return
     }
-    const refreshTokenFn =
-      this.options._onRefreshToken || this.options.onRefreshToken
+    const refreshTokenFn = this.options.onRefreshToken
     if (this.expiresIn <= this._refreshTokenNotificationDiff) {
       this.dispatch(authExpiringAction())
 
       if (typeof refreshTokenFn === 'function') {
         try {
-          await refreshTokenFn()
+          const token = await refreshTokenFn()
+          this.dispatch(reauthAction({ token }))
         } catch (error) {
           this.logger.error(error)
         }

--- a/packages/core/src/redux/interfaces.ts
+++ b/packages/core/src/redux/interfaces.ts
@@ -56,7 +56,7 @@ export type ReduxComponent = WebRTCCall | Message
 export interface ComponentState {
   byId: {
     [key: string]: ReduxComponent
-  },
+  }
 }
 
 export interface SessionState {
@@ -120,6 +120,7 @@ export type SessionChannelAction =
   | PayloadAction<void, 'auth/success'>
   | PayloadAction<void, 'auth/expiring'>
   | PayloadAction<{ error: SessionAuthError }>
+  | PayloadAction<{ token: string }>
   | PayloadAction<SessionAuthStatus>
 
 export type SwEventChannel = MulticastChannel<MapToPubSubShape<SwEventParams>>

--- a/packages/core/src/utils/interfaces.ts
+++ b/packages/core/src/utils/interfaces.ts
@@ -110,15 +110,8 @@ export interface SessionOptions {
   // From `LogLevelDesc` of loglevel to simplify our docs
   /** logging level */
   logLevel?: 'trace' | 'debug' | 'info' | 'warn' | 'error' | 'silent'
-  /** To refresh the auth token */
-  onRefreshToken?(): Promise<void>
-  /**
-   * The SDK invokes this method and uses the new token to re-auth.
-   * TODO: rename it: getNewToken, getRefreshedToken, fetchToken (?)
-   *
-   * @internal
-   * */
-  _onRefreshToken?(): Promise<void>
+  /** The SDK invokes this method and uses the new token to re-auth. */
+  onRefreshToken?(): Promise<string>
   sessionChannel?: SessionChannel
   /** Unified eventing is required only with Call Fabric SDK */
   unifiedEventing?: boolean

--- a/packages/js/src/fabric/WSClient.ts
+++ b/packages/js/src/fabric/WSClient.ts
@@ -46,12 +46,7 @@ export class WSClient {
 
   constructor(public options: WSClientOptions) {
     this.wsClient = createClient<RoomSession>({
-      host: this.options.host,
-      token: this.options.token,
-      debug: {
-        logWsTraffic: true,
-      },
-      logLevel: 'debug',
+      ...this.options,
       unifiedEventing: true,
     })
   }


### PR DESCRIPTION
# Description

Reauthenticate the user when the token expires.

## Type of change

- [ ] Internal refactoring
- [ ] Bug fix (bugfix - non-breaking)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Code snippets

```js
// Implicitly refresh token
const client = await SignalWire({
      host: "...",
      token: ".......",
      rootElement: ".....",
      onRefreshToken: () => {
        const newToken = 'eyJh.....'
        return newToken
      },

// Explicitly refresh token
await client.updateToken(newToken)
```
