### PR TITLE
Expose more CF SDK types

### DIFF
--- a/.changeset/silly-grapes-shout.md
+++ b/.changeset/silly-grapes-shout.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/js': patch
+---
+
+Expsose Call Fabric types

--- a/packages/core/src/types/callfabric.ts
+++ b/packages/core/src/types/callfabric.ts
@@ -52,7 +52,7 @@ export interface FetchConversationsResponse
   extends PaginatedResponse<Conversation> {}
 
 /**
- * Messages
+ * Conversation Messages
  */
 
 export interface GetMessagesOptions {
@@ -78,6 +78,10 @@ export interface GetConversationMessagesOptions {
   pageSize?: number
 }
 
+/**
+ * Subsriber info
+ */
+
 export interface SubscriberInfoResponse {
   app_settings?: string
   company_name?: string
@@ -91,4 +95,27 @@ export interface SubscriberInfoResponse {
   push_notification_key: string
   region?: string
   time_zone?: number
+}
+
+/**
+ * Device registration
+ */
+export type RegisterDeviceType = 'iOS' | 'Android' | 'Desktop'
+
+export interface RegisterDeviceParams {
+  deviceType: RegisterDeviceType
+  deviceToken: string
+}
+
+export interface UnregisterDeviceParams {
+  id: string
+}
+
+export interface RegisterDeviceResponse {
+  date_registered: Date
+  device_name?: string
+  device_token: string
+  device_type: RegisterDeviceType
+  id: string
+  push_notification_key: string
 }

--- a/packages/js/src/fabric/HTTPClient.ts
+++ b/packages/js/src/fabric/HTTPClient.ts
@@ -5,9 +5,9 @@ import {
   type FetchAddressResponse,
   type GetAddressesOptions,
   type UserOptions,
-  RegisterDeviceParams,
-  UnregisterDeviceParams,
-  RegisterDeviceResponse,
+  type RegisterDeviceParams,
+  type UnregisterDeviceParams,
+  type RegisterDeviceResponse,
 } from '@signalwire/core'
 import { CreateHttpClient, createHttpClient } from './createHttpClient'
 import { buildPaginatedResult } from '../utils/paginatedResult'

--- a/packages/js/src/fabric/HTTPClient.ts
+++ b/packages/js/src/fabric/HTTPClient.ts
@@ -12,9 +12,13 @@ import { makeQueryParamsUrls } from '../utils/makeQueryParamsUrl'
 
 type JWTHeader = { ch?: string; typ?: string }
 
-interface RegisterDeviceParams {
+export interface RegisterDeviceParams {
   deviceType: 'iOS' | 'Android' | 'Desktop'
   deviceToken: string
+}
+
+export interface UnregisterDeviceParams {
+  id: string
 }
 
 // TODO: extends from a Base class to share from core
@@ -91,7 +95,7 @@ export class HTTPClient {
     return body
   }
 
-  public async unregisterDevice({ id }: { id: string }) {
+  public async unregisterDevice({ id }: UnregisterDeviceParams) {
     const path = `/subscriber/devices/${id}` as const
     return await this.httpClient<any>(path, {
       method: 'DELETE',

--- a/packages/js/src/fabric/HTTPClient.ts
+++ b/packages/js/src/fabric/HTTPClient.ts
@@ -5,21 +5,15 @@ import {
   type FetchAddressResponse,
   type GetAddressesOptions,
   type UserOptions,
+  RegisterDeviceParams,
+  UnregisterDeviceParams,
+  RegisterDeviceResponse,
 } from '@signalwire/core'
 import { CreateHttpClient, createHttpClient } from './createHttpClient'
 import { buildPaginatedResult } from '../utils/paginatedResult'
 import { makeQueryParamsUrls } from '../utils/makeQueryParamsUrl'
 
 type JWTHeader = { ch?: string; typ?: string }
-
-export interface RegisterDeviceParams {
-  deviceType: 'iOS' | 'Android' | 'Desktop'
-  deviceToken: string
-}
-
-export interface UnregisterDeviceParams {
-  id: string
-}
 
 // TODO: extends from a Base class to share from core
 export class HTTPClient {
@@ -84,7 +78,7 @@ export class HTTPClient {
     deviceToken,
   }: RegisterDeviceParams) {
     const path = '/subscriber/devices' as const
-    const { body } = await this.httpClient<any>(path, {
+    const { body } = await this.httpClient<RegisterDeviceResponse>(path, {
       method: 'POST',
       body: {
         device_type: deviceType,
@@ -97,7 +91,7 @@ export class HTTPClient {
 
   public async unregisterDevice({ id }: UnregisterDeviceParams) {
     const path = `/subscriber/devices/${id}` as const
-    return await this.httpClient<any>(path, {
+    return await this.httpClient<void>(path, {
       method: 'DELETE',
     })
   }

--- a/packages/js/src/fabric/index.ts
+++ b/packages/js/src/fabric/index.ts
@@ -1,4 +1,6 @@
 export * from './Client'
 export * from './SWClient'
 export * from './WSClient'
+export * from './HTTPClient'
 export * from './SignalWire'
+export * from './IncomingCallManager'

--- a/packages/js/src/index.ts
+++ b/packages/js/src/index.ts
@@ -68,8 +68,6 @@ export type {
   InboundCallSource,
   IncomingCallNotification,
   AcceptInviteParams,
-  RegisterDeviceParams,
-  UnregisterDeviceParams,
 } from './fabric'
 
 /**
@@ -124,6 +122,9 @@ export type {
   ConversationMessageEventName,
   ConversationMessageEvent,
   ConversationEvent,
+  RegisterDeviceParams,
+  UnregisterDeviceParams,
+  RegisterDeviceResponse,
 } from '@signalwire/core'
 
 export type {

--- a/packages/js/src/index.ts
+++ b/packages/js/src/index.ts
@@ -60,7 +60,17 @@ export * as PubSub from './pubSub'
  */
 export * as Fabric from './fabric'
 export { SWClient, SignalWire } from './fabric'
-export type { SignalWireContract, SignalWireOptions } from './fabric'
+export type {
+  SignalWireContract,
+  SignalWireOptions,
+  IncomingCallHandler,
+  IncomingCallHandlers,
+  InboundCallSource,
+  IncomingCallNotification,
+  AcceptInviteParams,
+  RegisterDeviceParams,
+  UnregisterDeviceParams,
+} from './fabric'
 
 /**
  * The Video namespace contains the classes and functions that you need to
@@ -97,13 +107,23 @@ export type {
   InternalVideoMemberEntity,
   VideoPosition,
   VideoPositions,
+  /**
+   * Call Fabric types
+   */
   GetAddressesOptions,
   Address,
+  FetchAddressResponse,
   GetConversationsOptions,
   Conversation,
+  FetchConversationsResponse,
   GetMessagesOptions,
   ConversationMessage,
+  FetchConversationMessagesResponse,
   GetConversationMessagesOptions,
+  SubscriberInfoResponse,
+  ConversationMessageEventName,
+  ConversationMessageEvent,
+  ConversationEvent,
 } from '@signalwire/core'
 
 export type {
@@ -119,11 +139,3 @@ export type {
   RoomSessionObjectEvents as RoomObjectEvents,
   RoomEventNames,
 } from './utils/interfaces'
-
-export {
-  IncomingCallHandler,
-  IncomingCallHandlers,
-  InboundCallSource,
-  IncomingCallNotification,
-  AcceptInviteParams
-} from './fabric/IncomingCallManager'


### PR DESCRIPTION
# Description

New exposed types include:

- RegisterDeviceParams,
- UnregisterDeviceParams,
- FetchAddressResponse,
- FetchConversationsResponse,
- FetchConversationMessagesResponse,
- SubscriberInfoResponse,
- ConversationMessageEventName,
- ConversationMessageEvent,
- ConversationEvent

## Type of change

- [x] Internal refactoring
- [ ] Bug fix (bugfix - non-breaking)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Code snippets

In case of new feature or breaking changes, please include code snippets.
