### PR TITLE
Connects before sending the online request

### DIFF
--- a/.changeset/pretty-dancers-add.md
+++ b/.changeset/pretty-dancers-add.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/js': patch
+---
+
+FIXED connects to before sending the online request

--- a/packages/js/src/fabric/WSClient.ts
+++ b/packages/js/src/fabric/WSClient.ts
@@ -59,13 +59,16 @@ export class WSClient {
 
   async connect() {
     // @ts-ignore
-    this.wsClient.runWorker('wsClientWorker', {
-      worker: wsClientWorker,
-      initialState: {
-        buildInboundCall: (incomingInvite: Omit<IncomingInvite, 'source'>) => this.notifyIncomingInvite('websocket', incomingInvite), 
-      },
+    if(!this.wsClient.connected) {
+        // @ts-ignore
+        this.wsClient.runWorker('wsClientWorker', {
+        worker: wsClientWorker,
+        initialState: {
+          buildInboundCall: (incomingInvite: Omit<IncomingInvite, 'source'>) => this.notifyIncomingInvite('websocket', incomingInvite), 
+        },
     })
     await this.wsClient.connect()
+    }
   }
 
   disconnect() {
@@ -306,8 +309,11 @@ export class WSClient {
   /**
    * Mark the client as 'online' to receive calls over WebSocket
    */
-  online({incomingCallHandlers}: OnlineParams) {
+  async online({incomingCallHandlers}: OnlineParams) {
     this._incomingCallManager.setNotificationHandlers(incomingCallHandlers)
+
+    await this.connect()
+    
     // @ts-expect-error
     return this.wsClient.execute({
       method: 'subscriber.online',


### PR DESCRIPTION
# Description

To avoid errors if the developer calls the `online()` method before calling `connect()` this transparently calls `connect()` before sending the online request. Since the `connect()` is async the `online()` now needs to be async too. 

## Type of change

- [x] Internal refactoring
- [ ] Bug fix (bugfix - non-breaking)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Code snippets

In case of new feature or breaking changes, please include code snippets.
