### PR TITLE
Use Ice Candidates Pool

### DIFF
--- a/.changeset/metal-dancers-type.md
+++ b/.changeset/metal-dancers-type.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/webrtc': patch
+---
+
+CHANGE use Ice Candidates Pool by default

--- a/packages/webrtc/src/BaseConnection.ts
+++ b/packages/webrtc/src/BaseConnection.ts
@@ -68,7 +68,7 @@ const DEFAULT_CALL_OPTIONS: ConnectionOptions = {
   userVariables: {},
   requestTimeout: 10 * 1000,
   autoApplyMediaParams: true,
-  iceGatheringTimeout: 2 * 1000,
+  iceGatheringTimeout: 15,
   maxIceGatheringTimeout: 5 * 1000,
   maxConnectionStateTimeout: 3 * 1000,
   watchMediaPackets: true,

--- a/packages/webrtc/src/BaseConnection.ts
+++ b/packages/webrtc/src/BaseConnection.ts
@@ -68,7 +68,7 @@ const DEFAULT_CALL_OPTIONS: ConnectionOptions = {
   userVariables: {},
   requestTimeout: 10 * 1000,
   autoApplyMediaParams: true,
-  iceGatheringTimeout: 15,
+  iceGatheringTimeout: 1000,
   maxIceGatheringTimeout: 5 * 1000,
   maxConnectionStateTimeout: 3 * 1000,
   watchMediaPackets: true,

--- a/packages/webrtc/src/RTCPeer.ts
+++ b/packages/webrtc/src/RTCPeer.ts
@@ -22,6 +22,7 @@ import { watchRTCPeerMediaPackets } from './utils/watchRTCPeerMediaPackets'
 
 const RESUME_TIMEOUT = 12_000
 const DEFAULT_ICE_CANDIDATE_POOL_SIZE = 3
+const ICE_POOL_GATHERING_TIMEOUT = 15
 
 export default class RTCPeer<EventTypes extends EventEmitter.ValidEventTypes> {
   public uuid = uuid()
@@ -774,8 +775,12 @@ export default class RTCPeer<EventTypes extends EventEmitter.ValidEventTypes> {
       this._iceTimeout = setTimeout(() => {
         this.instance.removeEventListener('icecandidate', this._onIce)
         this._sdpReady()
-      }, this.options.iceGatheringTimeout)
+      }, this._iceGatheringTimeout())
     }
+  }
+
+  private _iceGatheringTimeout(): number | undefined {
+    return DEFAULT_ICE_CANDIDATE_POOL_SIZE > 0 ? ICE_POOL_GATHERING_TIMEOUT : this.options.iceGatheringTimeout
   }
 
   private _setLocalDescription(localDescription: RTCSessionDescriptionInit) {

--- a/packages/webrtc/src/RTCPeer.ts
+++ b/packages/webrtc/src/RTCPeer.ts
@@ -520,6 +520,8 @@ export default class RTCPeer<EventTypes extends EventEmitter.ValidEventTypes> {
 
   async start() {
     return new Promise(async (resolve, reject) => {
+      this._setupRTCPeerConnection()
+
       this._resolveStartMethod = resolve
       this._rejectStartMethod = reject
 
@@ -529,15 +531,6 @@ export default class RTCPeer<EventTypes extends EventEmitter.ValidEventTypes> {
         this._rejectStartMethod(error)
         return this.call.setState('hangup')
       }
-
-      /**
-       * We need to defer the creation of RTCPeerConnection
-       * until we gain gUM access otherwise it will have
-       * private IP addresses in ICE host candidates
-       * replaced by an mDNS hostname
-       * @see https://groups.google.com/g/discuss-webrtc/c/6stQXi72BEU?pli=1
-       */
-      this._setupRTCPeerConnection()
 
       let hasLocalTracks = false
       if (this._localStream && streamIsValid(this._localStream)) {

--- a/packages/webrtc/src/RTCPeer.ts
+++ b/packages/webrtc/src/RTCPeer.ts
@@ -21,6 +21,7 @@ import {
 import { watchRTCPeerMediaPackets } from './utils/watchRTCPeerMediaPackets'
 
 const RESUME_TIMEOUT = 12_000
+const DEFAULT_ICE_CANDIDATE_POOL_SIZE = 3
 
 export default class RTCPeer<EventTypes extends EventEmitter.ValidEventTypes> {
   public uuid = uuid()
@@ -156,6 +157,7 @@ export default class RTCPeer<EventTypes extends EventEmitter.ValidEventTypes> {
       iceServers: filterIceServers(this.call.iceServers, {
         disableUdpIceServers: this.options.disableUdpIceServers,
       }),
+      iceCandidatePoolSize: DEFAULT_ICE_CANDIDATE_POOL_SIZE,
       // @ts-ignore
       sdpSemantics: 'unified-plan',
       ...rtcPeerConfig,


### PR DESCRIPTION
# Description

The changes will enable the pre-gathering of ice candidates as soon as we instantiate the `RTCPeerConnection`.
To create some room for the pre-gathering the `RTCPeerConnection` instantiation was moved to the top of the `RTCPeer.start()` method. introducing one side effect.
 

## Side Effect 

In the very first use of an Application the `RTCPeerConnection` will be instantiated with no  User Media permission, making all `typ host` candidates with` mDNS` addresses instead of IP addresses.  Since we filter all `mDNS` candidates from the SDP before sending it to the server the SDP will have no `typ host` candidates. 

```
a=candidate:441981974 1 udp 1677729536 189.71.169.171 57645 typ srflx raddr 0.0.0.0 rport 0 generation 0 network-cost 999
a=candidate:3969930897 1 udp 33562880 104.131.13.246 38342 typ relay raddr 189.71.169.171 rport 57645 generation 0 network-cost 999
a=candidate:302678533 1 udp 16785152 104.131.13.246 28363 typ relay raddr 189.71.169.171 rport 64803 generation 0 network-cost 999
a=candidate:302678533 1 udp 16785152 104.131.13.246 28362 typ relay raddr 189.71.169.171 rport 64806 generation 0 network-cost 999
```

Tests show no impact on the connectivity or setup time for that **very** first call.

#### Call Setup with `host` candidates
```
2024-04-11T12:36:43.444Z - SEND: (Invite)
2024-04-11T12:36:43.986Z - RECV: (Conversation Event - Call Started)
2024-04-11T12:36:44.804Z - RECV:  (CALL CREATED)

Total 1360ms
```

#### Call Setup with no `host` candidates
```
2024-04-11T12:54:43.866Z - SEND: (Invite)
2024-04-11T12:54:44.449Z - RECV (Conversation Event - Call Started)
2024-04-11T12:54:45.172Z - RECV (CALL CREATED)

Total 1306ms
```

Next calls the SDP will have all the candidates
```
a=candidate:2669029645 1 udp 2122194688 192.168.3.52 62285 typ host generation 0 network-id 3
a=candidate:2652265259 1 udp 1685987072 189.71.169.171 62285 typ srflx raddr 192.168.3.52 rport 62285 generation 0 network-id 3
a=candidate:1047017511 1 udp 2122063616 192.168.3.75 51546 typ host generation 0 network-id 1 network-cost 10
a=candidate:1063799297 1 udp 1685856000 189.71.169.171 51546 typ srflx raddr 192.168.3.75 rport 51546 generation 0 network-id 1 network-cost 10
a=candidate:4234943797 1 udp 2122265344 fdf8:af05:cef:5100:c39:d3c9:957b:a1c 63754 typ host generation 0 network-id 4
a=candidate:4003022956 1 udp 2122134272 fdf8:af05:cef:5100:474:2f54:c6e0:c543 59553 typ host generation 0 network-id 2 network-cost 10
a=candidate:1639775641 1 tcp 1518214912 192.168.3.52 9 typ host tcptype active generation 0 network-id 3
a=candidate:3234000051 1 tcp 1518083840 192.168.3.75 9 typ host tcptype active generation 0 network-id 1 network-cost 10
a=candidate:46582177 1 tcp 1518285568 fdf8:af05:cef:5100:c39:d3c9:957b:a1c 9 typ host tcptype active generation 0 network-id 4
a=candidate:271817976 1 tcp 1518154496 fdf8:af05:cef:5100:474:2f54:c6e0:c543 9 typ host tcptype active generation 0 network-id 2 network-cost 10
a=candidate:1867389088 1 udp 41820415 104.131.13.246 47935 typ relay raddr 189.71.169.171 rport 62285 generation 0 network-id 3
a=candidate:1867389088 1 udp 41689343 104.131.13.246 47524 typ relay raddr 189.71.169.171 rport 51546 generation 0 network-id 1 network-cost 10
```

## Type of change

- [x] Internal refactoring
- [ ] Bug fix (bugfix - non-breaking)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Code snippets

In case of new feature or breaking changes, please include code snippets.
