### PR TITLE
Realtime-api SDK: Fix types export for module NodeNext

### DIFF
--- a/.changeset/metal-seahorses-pull.md
+++ b/.changeset/metal-seahorses-pull.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/realtime-api': patch
+---
+
+Fix types export for module NodeNext

--- a/packages/realtime-api/package.json
+++ b/packages/realtime-api/package.json
@@ -7,6 +7,7 @@
   "main": "dist/index.node.js",
   "beta": true,
   "exports": {
+    "types": "./dist/realtime-api/src/index.d.ts",
     "require": "./dist/index.node.js",
     "default": "./dist/index.node.mjs"
   },


### PR DESCRIPTION
# Description

Based on this thread on the TypeScript repo: https://github.com/microsoft/TypeScript/issues/52363

This PR explicitly mentions the types path in the `package.json` which allows developers to build their Node project using the `NodeNext` module in the tsconfig.

ref: https://github.com/signalwire/signalwire-js/issues/964

## Type of change

- [ ] Internal refactoring
- [x] Bug fix (bugfix - non-breaking)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Code snippets

In case of new feature or breaking changes, please include code snippets.
