### PR TITLE
WIP override _getRPCMethod

### DIFF
--- a/packages/js/src/fabric/CallFabricBaseRoomSession.ts
+++ b/packages/js/src/fabric/CallFabricBaseRoomSession.ts
@@ -43,14 +43,8 @@ export class CallFabricRoomSessionConnection extends RoomSessionConnection {
     })
   }
 
-  override _getRPCMethod(): WebRTCMethod {
-    const authState = this.select(selectors.getAuthState)
-    if (authState) {
-      return 'webrtc.verto'
-    }
-    return 'video.message'
-  }
-
+  override _getRPCMethod(): WebRTCMethod { return 'webrtc.verto' }
+    
   get selfMember() {
     return this.callSegments[0]?.member
   }

--- a/packages/js/src/fabric/CallFabricBaseRoomSession.ts
+++ b/packages/js/src/fabric/CallFabricBaseRoomSession.ts
@@ -7,6 +7,8 @@ import {
   RoomSessionMember,
   VideoMemberEntity,
   Rooms,
+  WebRTCMethod,
+  selectors,
 } from '@signalwire/core'
 import {
   BaseRoomSession,
@@ -39,6 +41,14 @@ export class CallFabricRoomSessionConnection extends RoomSessionConnection {
     this.runWorker('callFabricWorker', {
       worker: callFabricWorker,
     })
+  }
+
+  override _getRPCMethod(): WebRTCMethod {
+    const authState = this.select(selectors.getAuthState)
+    if (authState) {
+      return 'webrtc.verto'
+    }
+    return 'video.message'
   }
 
   get selfMember() {


### PR DESCRIPTION
# Description

We shouldn't use the authorization data as a source for the authentication type.
Since all CF connections are going to use SAT tokens we can just override the `_getRPCMethod` in the `CallFabricRoomSessionConnection`  

## Type of change

- [x] Internal refactoring
- [x] Bug fix (bugfix - non-breaking)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Code snippets

In case of new feature or breaking changes, please include code snippets.
