### PR TITLE
e2e-js Call Fabric VideoRoom, relax expectation on room name

### DIFF
--- a/.changeset/mighty-pillows-protect.md
+++ b/.changeset/mighty-pillows-protect.md
@@ -1,0 +1,5 @@
+---
+'@sw-internal/e2e-js': patch
+---
+
+e2e tests for Call Fabric, relax expectation on Room Name

--- a/internal/e2e-js/tests/callfabric/videoRoom.spec.ts
+++ b/internal/e2e-js/tests/callfabric/videoRoom.spec.ts
@@ -50,8 +50,9 @@ test.describe('CallFabric VideoRoom', () => {
         (member: any) => member.id === roomSession.member_id
       )
     ).toBeTruthy()
-    expect(roomSession.room_session.name).toBe(roomName)
-    expect(roomSession.room.name).toBe(roomName)
+    expect(roomSession.room_session.name.startsWith(roomName)).toBeTruthy()
+    expect(roomSession.room.name.startsWith(roomName)).toBeTruthy()
+    expect(roomSession.room_session.display_name).toBe(roomName)
 
     await expectMCUVisible(page)
 


### PR DESCRIPTION
# Description

When creating a new room with the same name, `display_name` is correctly set to the room name, while `name` keeps the original name but can have a random suffix.
These changes accommodate for that case.

## Type of change

- [ ] Internal refactoring
- [x] Bug fix (bugfix - non-breaking)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Code snippets

In case of new feature or breaking changes, please include code snippets.
