### PR TITLE
Enable dev branch publish to npm @signalwire/js@dev

### DIFF
--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -3,7 +3,7 @@ name: Release dev tag to NPM
 on:
   workflow_run:
     workflows: [Unit and stack tests]
-    branches: [main]
+    branches: [dev]
     types:
       - completed
 


### PR DESCRIPTION
# Description

While we are developing the CF SFK in the `dev` branch we should publish every merge on `dev` to  npm  `@signalwire/js@dev` to allow faster integrations/tests on staging.

## Type of change

- [ ] Internal refactoring
- [ ] Bug fix (bugfix - non-breaking)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Code snippets

In case of new feature or breaking changes, please include code snippets.
