### PR TITLE
Revert "Add region to tests"

### DIFF
--- a/.github/workflows/v2-webrtc-calling-production-ch.yml
+++ b/.github/workflows/v2-webrtc-calling-production-ch.yml
@@ -33,7 +33,6 @@ jobs:
         run: npm run -w=@sw-internal/e2e-js dev -- v2WebrtcFromRest.spec.ts webrtcCalling.spec.ts
         env:
           SW_TEST_CONFIG: ${{ secrets.PRODUCTION_E2E_JS_CHREGION_SW_TEST_CONFIG }}
-          LAML_CONFERENCE_REGION: ${{ vars.PRODUCTION_E2E_JS_EUREGION_LAML_CONFERENCE_REGION }}
       - name: Report Result
         if: success() || failure()
         uses: ./.github/actions/report-test-result


### PR DESCRIPTION
Reverts signalwire/signalwire-js#1038

Currently failing, will need to fix on the backend before re-applying.
