### PR TITLE
Fix local audio and video mute

### DIFF
--- a/packages/js/src/fabric/workers/callFabricWorker.ts
+++ b/packages/js/src/fabric/workers/callFabricWorker.ts
@@ -74,6 +74,13 @@ export const callFabricWorker: SDKWorker<CallFabricRoomSessionConnection> =
             action: updatedAction,
             ...options,
           })
+
+          
+          yield sagaEffects.put(swEventChannel, {
+            ...action,
+            // @ts-expect-error
+            type: `video.${action.type}`
+          })
           return
         }
         case 'layout.changed': {
@@ -117,5 +124,4 @@ export const callFabricWorker: SDKWorker<CallFabricRoomSessionConnection> =
       yield sagaEffects.fork(worker, action)
     }
 
-    getLogger().trace('callFabricWorker ended')
   }

--- a/packages/js/src/fabric/workers/callFabricWorker.ts
+++ b/packages/js/src/fabric/workers/callFabricWorker.ts
@@ -75,12 +75,8 @@ export const callFabricWorker: SDKWorker<CallFabricRoomSessionConnection> =
             ...options,
           })
 
-          
-          yield sagaEffects.put(swEventChannel, {
-            ...action,
-            // @ts-expect-error
-            type: `video.${action.type}`
-          })
+          // @ts-expect-error
+          yield sagaEffects.put(swEventChannel, updatedAction)
           return
         }
         case 'layout.changed': {


### PR DESCRIPTION
# Description

When we removed the unified events mapper we stopped putting in the swEventChannel the `video.*` events required to handle both the local track mute and the localVideoOverlay.

## Type of change

- [] Internal refactoring
- [V] Bug fix (bugfix - non-breaking)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Code snippets

In case of new feature or breaking changes, please include code snippets.
