### PR TITLE
v2 webrtc e2e tests, relax expectation on packets received

### DIFF
--- a/.changeset/tame-avocados-search.md
+++ b/.changeset/tame-avocados-search.md
@@ -1,0 +1,5 @@
+---
+'@sw-internal/e2e-js': patch
+---
+
+Relax condition on expected packets, refactor that logic

--- a/internal/e2e-js/tests/v2Webrtc/v2WebrtcFromRest.spec.ts
+++ b/internal/e2e-js/tests/v2Webrtc/v2WebrtcFromRest.spec.ts
@@ -4,6 +4,7 @@ import {
   SERVER_URL,
   createCallWithCompatibilityApi,
   createTestJWTToken,
+  expectedMinPackets,
   expectInjectRelayHost,
   expectRelayConnected,
   expectv2HasReceivedAudio,
@@ -81,12 +82,11 @@ test.describe('v2WebrtcFromRestSilence', () => {
     // We expect silence...
     const maxAudioEnergy = 0.01
 
-    // ... but the packets must be received anyway
-    const minPackets = (callDurationMs * 0.9) * 50 / 1000
-
     // Check the audio energy level is above threshold
     console.log('Expected max audio energy: ', maxAudioEnergy)
 
+    // Expect at least 70 % packets at 50 pps
+    const minPackets = expectedMinPackets(50, callDurationMs, 0.3)
     await expectv2HasReceivedSilence(pageCallee, maxAudioEnergy, minPackets)
 
     await expectCallActive(pageCallee)
@@ -166,8 +166,8 @@ test.describe('v2WebrtcFromRest', () => {
     // Check the audio energy level is above threshold
     console.log('Expected min audio energy: ', minAudioEnergy)
 
-    // Considers 50 pps with max 10% packet loss
-    const minPackets = (callDurationMs * 0.9) * 50 / 1000
+    // Expect at least 70 % packets at 50 pps
+    const minPackets = expectedMinPackets(50, callDurationMs, 0.3)
 
     await expectv2HasReceivedAudio(pageCallee, minAudioEnergy, minPackets)
 
@@ -269,8 +269,8 @@ test.describe('v2WebrtcFromRestTwoJoinAudioVideo', () => {
     // Check the audio energy level is above threshold
     console.log('Expected min audio energy: ', minAudioEnergy)
 
-    // Considers 50 pps with max 10% packet loss
-    const minPackets = (callDurationMs * 0.9) * 50 / 1000
+    // Expect at least 70 % packets at 50 pps
+    const minPackets = expectedMinPackets(50, callDurationMs, 0.3)
 
     await expectv2HasReceivedAudio(pageCallee, minAudioEnergy, minPackets)
     await expectv2HasReceivedAudio(pageCallee2, minAudioEnergy, minPackets)
@@ -381,8 +381,8 @@ test.describe('v2WebrtcFromRestTwoJoinAudio', () => {
     // Check the audio energy level is above threshold
     console.log('Expected min audio energy: ', minAudioEnergy)
 
-    // Considers 50 pps with max 10% packet loss
-    const minPackets = (callDurationMs * 0.9) * 50 / 1000
+    // Expect at least 70 % packets at 50 pps
+    const minPackets = expectedMinPackets(50, callDurationMs, 0.3)
 
     await expectv2HasReceivedAudio(pageCallee, minAudioEnergy, minPackets)
     await expectv2HasReceivedAudio(pageCallee2, minAudioEnergy, minPackets)

--- a/internal/e2e-js/tests/v2Webrtc/webrtcCalling.spec.ts
+++ b/internal/e2e-js/tests/v2Webrtc/webrtcCalling.spec.ts
@@ -4,6 +4,7 @@ import {
   SERVER_URL,
   createCallWithCompatibilityApi,
   createTestJWTToken,
+  expectedMinPackets,
   expectInjectRelayHost,
   expectRelayConnected,
   expectv2HasReceivedAudio,
@@ -164,8 +165,8 @@ test.describe('v2WebrtcCalling', () => {
     // Empirical value
     const minAudioEnergy = callDurationMs / 50000
 
-    // Considers 50 pps with max 10% packet loss
-    const minPackets = (callDurationMs * 0.9) * 50 / 1000
+    // Expect at least 70 % packets at 50 pps
+    const minPackets = expectedMinPackets(50, callDurationMs, 0.3)
 
     await expectv2HasReceivedAudio(pageCallee, minAudioEnergy, minPackets)
 

--- a/internal/e2e-js/utils.ts
+++ b/internal/e2e-js/utils.ts
@@ -1087,6 +1087,23 @@ export const expectv2HasReceivedSilence = async (
   }
 }
 
+export const expectedMinPackets = (
+  packetRate: number,
+  callDurationMs: number,
+  maxMissingPacketsTolerance: number // 0 to 1.0
+) => {
+  if (maxMissingPacketsTolerance < 0) {
+    maxMissingPacketsTolerance = 0
+  }
+  if (maxMissingPacketsTolerance > 1) {
+    maxMissingPacketsTolerance = 1
+  }
+
+  const minPackets = (callDurationMs * (1 - maxMissingPacketsTolerance)) * packetRate / 1000
+
+  return minPackets
+}
+
 export const randomizeResourceName = (prefix: string = 'e2e') => {
   return `res-${prefix}${uuid()}`
 }


### PR DESCRIPTION
# Description

e2e v2 webrtc tests. Relax expectation in terms of packets received during a call.
Refactor that logic so that it can be reused.

## Type of change

- [x] Internal refactoring
- [ ] Bug fix (bugfix - non-breaking)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Code snippets

In case of new feature or breaking changes, please include code snippets.
