### PR TITLE
Expose userVariables param

### DIFF
--- a/.changeset/ten-weeks-marry.md
+++ b/.changeset/ten-weeks-marry.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/js': minor
+---
+
+ADDED userVariables param to DialOption and WSClientOtions

--- a/packages/js/src/fabric/WSClient.ts
+++ b/packages/js/src/fabric/WSClient.ts
@@ -82,6 +82,7 @@ export class WSClient {
           // watchMediaPacketsTimeout:,
           nodeId: params.nodeId,
           disableUdpIceServers: params.disableUdpIceServers || false,
+          userVariables: params.userVariables || this.options.userVariables
         })
 
         // WebRTC connection left the room.
@@ -222,6 +223,7 @@ export class WSClient {
       prevCallId: callID,
       nodeId,
       disableUdpIceServers: params.disableUdpIceServers || false,
+      userVariables: params.userVariables || this.options.userVariables
     })
 
     // WebRTC connection left the room.

--- a/packages/js/src/fabric/types.ts
+++ b/packages/js/src/fabric/types.ts
@@ -60,7 +60,7 @@ export interface CallOptions {
   /** Video constraints to use when joining the room. Default: `true`. */
   video?: MediaStreamConstraints['video']
   /** User & UserAgent metadata */
-  userVariables?: { [key: string]: any }
+  userVariables?: WSClientOptions['userVariables']
 }
 
 export interface DialParams extends CallOptions {

--- a/packages/js/src/fabric/types.ts
+++ b/packages/js/src/fabric/types.ts
@@ -59,6 +59,8 @@ export interface CallOptions {
   audio?: MediaStreamConstraints['audio']
   /** Video constraints to use when joining the room. Default: `true`. */
   video?: MediaStreamConstraints['video']
+  /** User & UserAgent metadata */
+  userVariables?: { [key: string]: any }
 }
 
 export interface DialParams extends CallOptions {
@@ -71,6 +73,8 @@ export interface WSClientOptions extends UserOptions {
   rootElement?: HTMLElement
   /** Call back function to receive the incoming call */
   incomingCallHandlers?: IncomingCallHandlers
+  /** User & UserAgent metadata */
+  userVariables?: { [key: string]: any }
 }
 
 export type InboundCallSource = 'websocket' | 'pushNotification'

--- a/packages/js/src/fabric/types.ts
+++ b/packages/js/src/fabric/types.ts
@@ -74,7 +74,7 @@ export interface WSClientOptions extends UserOptions {
   /** Call back function to receive the incoming call */
   incomingCallHandlers?: IncomingCallHandlers
   /** User & UserAgent metadata */
-  userVariables?: { [key: string]: any }
+  userVariables?: Record<string, any>
 }
 
 export type InboundCallSource = 'websocket' | 'pushNotification'


### PR DESCRIPTION
# Description

Applications can set the `userVariables` param to share with the backend user and userAgent metadata.

## Type of change

- [ ] Internal refactoring
- [ ] Bug fix (bugfix - non-breaking)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Code snippets

```javascript
const call = await client.dial({
      ...params,
      rootElement: document.getElementById('rootElement'),
      userVariables: {
                "name": "João Santos",
                "email": "joao.santos@signalwire.com",
                "company": "",
                "isMobile": false,
                "isTablet": false,
                "isAndroid": false,
                "isWinPhone": false,
                "isIOS": false,
                "isChrome": true,
                "isFirefox": false,
                "isSafari": false,
                "isOpera": false,
                "isIE": false,
                "isEdge": false,
                "isYandex": false,
                "isChromium": false,
                "osVersion": "10.15.7",
                "osName": "Mac OS",
                "fullBrowserVersion": "125.0.0.0",
                "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36",
                "timezone": "America/Sao_Paulo",
                "gmtOffset": -3,
                "tzString": "GMT-0300 (Brasilia Standard Time)",
                "hostname": "hq.sw.work",
                "microphoneLabel": "Default - MacBook Pro Microphone (Built-in)",
                "cameraLabel": "Immersed Camera"
            }
    })
```
In case of new feature or breaking changes, please include code snippets.
