### PR TITLE
WIP: Allow user to sort conversations

### DIFF
--- a/.changeset/nasty-feet-warn.md
+++ b/.changeset/nasty-feet-warn.md
@@ -1,0 +1,6 @@
+---
+'@signalwire/core': minor
+'@signalwire/js': minor
+---
+
+Allow user to sort conversations in ASC or DESC order. Default is DESC.

--- a/internal/playground-js/src/fabric-http/index.js
+++ b/internal/playground-js/src/fabric-http/index.js
@@ -2,7 +2,9 @@ import { SignalWire } from '@signalwire/js'
 
 const searchInput = document.getElementById('searchInput')
 const searchType = document.getElementById('searchType')
-const conversationMessageInput = document.getElementById('new-conversation-message')
+const conversationMessageInput = document.getElementById(
+  'new-conversation-message'
+)
 const sendMessageBtn = document.getElementById('send-message')
 
 let client = null
@@ -162,7 +164,6 @@ const createAddressListItem = (address) => {
     if (channelName != 'messaging') {
       button.addEventListener('click', () => dialAddress(channelValue))
     } else {
-
       button.addEventListener('click', () => {
         subscribeToNewMessages()
         openMessageModal(address)
@@ -198,7 +199,7 @@ function updateAddressUI() {
   addresses
     .map(createAddressListItem)
     .forEach((item) => addressUl.appendChild(item))
-  subscribeToNewMessages();
+  subscribeToNewMessages()
 }
 
 async function fetchAddresses() {
@@ -327,6 +328,7 @@ async function fetchHistories() {
   try {
     const historyData = await client.conversation.getConversations({
       pageSize: 10,
+      sortOrder: 'ASC',
     })
     window.__historyData = historyData
     updateHistoryUI()

--- a/packages/core/src/types/callfabric.ts
+++ b/packages/core/src/types/callfabric.ts
@@ -68,6 +68,8 @@ export interface FetchAddressResponse extends PaginatedResponse<Address> {}
 /**
  * Conversations
  */
+export type SortOrder = 'ASC' | 'DESC'
+
 export interface SendConversationMessageOptions {
   text: string
   addressId: string
@@ -76,6 +78,7 @@ export interface SendConversationMessageOptions {
 }
 export interface GetConversationsOptions {
   pageSize?: number
+  sortOrder?: SortOrder
 }
 
 export interface Conversation {
@@ -126,6 +129,7 @@ export interface FetchConversationMessagesResponse
 export interface GetConversationMessagesOptions {
   addressId: string
   pageSize?: number
+  sortOrder?: SortOrder
 }
 
 /**

--- a/packages/js/src/fabric/Conversation.ts
+++ b/packages/js/src/fabric/Conversation.ts
@@ -60,12 +60,15 @@ export class Conversation {
 
   public async getConversations(options?: GetConversationsOptions) {
     try {
-      const { pageSize } = options || {}
+      const { pageSize, sortOrder } = options || {}
 
       const path = '/api/fabric/conversations'
       const queryParams = new URLSearchParams()
       if (pageSize) {
         queryParams.append('page_size', pageSize.toString())
+      }
+      if (sortOrder) {
+        queryParams.append('sortOrder', sortOrder.toString())
       }
 
       const { body } = await this.httpClient.fetch<FetchConversationsResponse>(
@@ -109,12 +112,15 @@ export class Conversation {
     options: GetConversationMessagesOptions
   ) {
     try {
-      const { addressId, pageSize } = options || {}
+      const { addressId, pageSize, sortOrder } = options || {}
 
       const path = `/api/fabric/conversations/${addressId}/messages`
       const queryParams = new URLSearchParams()
       if (pageSize) {
         queryParams.append('page_size', pageSize.toString())
+      }
+      if (sortOrder) {
+        queryParams.append('sort_order', sortOrder.toString())
       }
 
       const { body } =


### PR DESCRIPTION
# Description

The conversation APIs now accepts `sortOrder` param to sort the conversation result.

## Type of change

- [ ] Internal refactoring
- [ ] Bug fix (bugfix - non-breaking)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Code snippets

```js
const data = await client.conversation.getConversations({
      pageSize: 10,
      sortOrder: 'ASC', // Default is 'DESC'
    })
```
