### PR TITLE
Add CHAT convenience methods

### DIFF
--- a/.changeset/hungry-wombats-help.md
+++ b/.changeset/hungry-wombats-help.md
@@ -1,0 +1,6 @@
+---
+'@signalwire/js': minor
+'@signalwire/core': patch
+---
+
+Added chat namespace with convenience methods to to handle chat messages

--- a/packages/core/src/types/callfabric.ts
+++ b/packages/core/src/types/callfabric.ts
@@ -117,8 +117,11 @@ export interface ConversationMessage {
   details: Record<string, any>
   type: string
   subtype: string
-  kind: string
+  kind?: string
+  text?: string
 }
+
+export type ConversationChatMessage = Omit<ConversationMessage, 'kind'> & {text: string}
 
 export interface FetchConversationMessagesResponse
   extends PaginatedResponse<ConversationMessage> {}

--- a/packages/js/src/fabric/Conversation.test.ts
+++ b/packages/js/src/fabric/Conversation.test.ts
@@ -300,7 +300,33 @@ describe('Conversation', () => {
       ).toBe(true)
     })
 
-    it('Should return 5(default page) adresss chat messages only', async () => {
+    it('Should return 5 adresss chat messages only', async () => {
+      ;(httpClient.fetch as jest.Mock).mockResolvedValue({
+        body: {
+          data: [
+            { subtype: 'log', conversation_id: 'abc' },
+            { subtype: 'chat', conversation_id: 'abc' },
+            { subtype: 'chat', conversation_id: 'abc' },
+            { subtype: 'chat', conversation_id: 'xyz' },
+          ],
+          links: {
+            next: 'http://next.url',
+            prev: 'http://prev.url',
+          },
+        },
+      })
+
+      const addressId = 'abc'
+      const messages = await conversation.getChatMessages({ addressId, pageSize:3 })
+
+      expect(messages.data).toHaveLength(4)
+      expect(messages.data.every((item) => item.subtype === 'chat')).toBe(true)
+      expect(
+        messages.data.every((item) => item.conversation_id === addressId)
+      ).toBe(true)
+    })
+
+    it('Should return 3 adresss chat messages only', async () => {
       let count = 0
       ;(httpClient.fetch as jest.Mock).mockImplementation(() => {
         ++count

--- a/packages/js/src/fabric/Conversation.ts
+++ b/packages/js/src/fabric/Conversation.ts
@@ -31,7 +31,6 @@ export class Conversation {
   private wsClient: WSClient
   private callbacks: Callback[] = [
     (event: ConversationEventParams) => {
-      console.log(event)
       if(event.subtype !== 'chat') return
       const conversationSubscription = this.chatSubscriptions[event.conversation_id];
       if(!!conversationSubscription) {
@@ -196,7 +195,6 @@ export class Conversation {
   public handleEvent(event: ConversationEventParams) {
     if (this.callbacks.length) {
       this.callbacks.forEach((callback) => {
-        console.log(event)
         callback(event)
       })
     }

--- a/packages/js/src/fabric/Conversation.ts
+++ b/packages/js/src/fabric/Conversation.ts
@@ -10,11 +10,14 @@ import {
   ConversationMessage,
   SendConversationMessageOptions,
   SendConversationMessageResponse,
+  ConversationChatMessage,
 } from '@signalwire/core'
 import { conversationWorker } from './workers'
 import { buildPaginatedResult } from '../utils/paginatedResult'
 import { makeQueryParamsUrls } from '../utils/makeQueryParamsUrl'
 import { ConversationAPI } from './ConversationAPI'
+
+const DEFAULT_CHAT_MESSAGES_PAGE_SIZE = 10
 
 type Callback = (event: ConversationEventParams) => unknown
 
@@ -26,7 +29,16 @@ interface ConversationOptions {
 export class Conversation {
   private httpClient: HTTPClient
   private wsClient: WSClient
-  private callbacks: Callback[] = []
+  private callbacks: Callback[] = [
+    (event: ConversationEventParams) => {
+      if(event.subtype !== 'chat') return
+      const conversationSubscription = this.chatSubscriptions[event.conversation_id];
+      if(!!conversationSubscription) {
+          conversationSubscription.forEach((cb) => cb(event))
+      }
+    }
+  ]
+  private chatSubscriptions: Record<string, Callback[]> = {}
 
   constructor(options: ConversationOptions) {
     this.httpClient = options.httpClient
@@ -131,11 +143,50 @@ export class Conversation {
     }
   }
 
+
+
+  public async getChatMessages({addressId, pageSize = DEFAULT_CHAT_MESSAGES_PAGE_SIZE}: GetConversationMessagesOptions) {
+    const chatMessages = []
+    let conversationMessages: Awaited<ReturnType<typeof this.getConversationMessages>> | undefined
+    conversationMessages = await this.getConversationMessages({addressId, pageSize});
+     chatMessages.push(...conversationMessages.data.filter((item)=>item.conversation_id == addressId))
+     while(chatMessages.length <= pageSize && conversationMessages?.hasNext) {
+      //@ts-expect-error
+      conversationMessages = await conversationMessages?.nextPage() 
+      if(!!conversationMessages) {
+        chatMessages.push(...conversationMessages.data.filter((item)=>(item as ConversationMessage).conversation_id == addressId))
+      }
+     }
+    
+    return { 
+      data: chatMessages as ConversationChatMessage[],
+      hasNext: conversationMessages?.hasNext,
+      hasPrev: conversationMessages?.hasPrev,
+      nextPage: () => conversationMessages?.nextPage(),
+      prevPage: () => conversationMessages?.prevPage()
+    }
+  }
+
   public async subscribe(callback: Callback) {
     // Connect the websocket client first
     this.wsClient.connect()
 
     this.callbacks.push(callback)
+  }
+
+  public async subscribeChatMessages({addressId, onMessage}: {addressId: string, onMessage: Callback}) {
+    // Connect the websocket client first
+    this.wsClient.connect()
+
+    if(!(addressId in this.chatSubscriptions)) {
+      this.chatSubscriptions[addressId] = []
+    }
+
+    this.chatSubscriptions[addressId].push(onMessage);
+    const subscriptionIndex = this.chatSubscriptions[addressId].length - 1
+    return {
+      cancel: () => this.chatSubscriptions[addressId].splice(subscriptionIndex, 1)
+    }
   }
 
   /** @internal */

--- a/packages/js/src/fabric/SignalWire.ts
+++ b/packages/js/src/fabric/SignalWire.ts
@@ -37,6 +37,12 @@ export const SignalWire = (
           subscribe: conversation.subscribe.bind(conversation),
           sendMessage: conversation.sendMessage.bind(conversation),
         },
+        chat: {
+          getMessages:
+            conversation.getChatMessages.bind(conversation),
+          subscribe: conversation.subscribeChatMessages.bind(conversation),
+          sendMessage: conversation.sendMessage.bind(conversation),
+        },
         // @ts-expect-error
         __httpClient: httpClient,
         __wsClient: wsClient,

--- a/packages/js/src/fabric/types.ts
+++ b/packages/js/src/fabric/types.ts
@@ -28,6 +28,11 @@ export interface SignalWireContract {
     getConversationMessages: Conversation['getConversationMessages']
     subscribe: Conversation['subscribe']
     sendMessage: Conversation['sendMessage']
+  },
+  chat: {
+    getMessages: Conversation['getChatMessages']
+    subscribe: Conversation['subscribeChatMessages']
+    sendMessage: Conversation['sendMessage']
   }
 }
 


### PR DESCRIPTION
# Description

Adding

- Signalwire.chat.getMessages({addressId: string, pageSize: number}): Promise<ConversationChatMessage[]>
- Signalwire.chat.subscribe({addressId: string, onMessage: (msg:ConversationChatMessage) => void):Promise<void>
- Signalwire.chat.sendMessage({addressId: string, text: string}): Promise<void>

## Type of change

- [ ] Internal refactoring
- [ ] Bug fix (bugfix - non-breaking)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Code snippets

In case of new feature or breaking changes, please include code snippets.

```typescript
const messages = await client.chat.getMessages({addressId: 'id'})

const sub = await client..chat.subscribe({addressId: 'id', onMessage: console.log})

await client.chat.sendMessage({addressId: 'id', text: 'hello'})
```
