### PR TITLE
v2 webrtc e2e tests - allow passing iceTransportPolicy and refactoring

### DIFF
--- a/.changeset/clean-chairs-yawn.md
+++ b/.changeset/clean-chairs-yawn.md
@@ -1,0 +1,5 @@
+---
+'@sw-internal/e2e-js': patch
+---
+
+Improve v2 webrtc e2e tests to detected media timeouts

--- a/internal/e2e-js/templates/blank/v2vanilla.html
+++ b/internal/e2e-js/templates/blank/v2vanilla.html
@@ -249,9 +249,12 @@
         window.__currentCall = currentCall;
         let ccallState = JSON.parse(JSON.stringify(call,getCircularReplacer()));
         console.log(currentCall.state,currentCall.cause,currentCall.causeCode);
-        console.log("Call State: " ,ccallState);
+
+        console.log("Call update - State: ", ccallState);
+
         let msg =  currentCall.causeCode ? `Code:${currentCall.causeCode} Reason: ${currentCall.cause}` : `Early Media:${currentCall.gotEarly} Answered: ${currentCall.gotAnswer}`;
         callStatus.innerHTML = `${currentCall.prevState} -> ${currentCall.state} </br> ${msg}`;
+
         console.log('State:', call.state)
 
         switch (call.state) {
@@ -272,14 +275,20 @@
           break;
         case 'ringing': // Someone is calling you
           //if (confirm('Pick up the call?')) {
-            console.log("Answering: ", ccallState)
 
-            if (window.__iceTransportPolicy) {
-              console.log("____setting relay only____")
-              currentCall.options.iceTransportPolicy = iceTransportPolicy;
+            console.log("________ current call options: ", currentCall.options)
+
+            answerParams = {}
+            itp = window.__iceTransportPolicy
+
+            if (itp === 'relay' || itp === 'all') {
+              answerParams.iceTransportPolicy = itp;
             }
 
-            currentCall.answer();
+            console.log("Answer params:", answerParams)
+            console.log("Answering: ", ccallState)
+            currentCall.answer(answerParams);
+            console.log("Answered.")
           //} else {
           //  currentCall.hangup();
           //}

--- a/internal/e2e-js/templates/blank/v2vanilla.html
+++ b/internal/e2e-js/templates/blank/v2vanilla.html
@@ -276,8 +276,6 @@
         case 'ringing': // Someone is calling you
           //if (confirm('Pick up the call?')) {
 
-            console.log("________ current call options: ", currentCall.options)
-
             answerParams = {}
             itp = window.__iceTransportPolicy
 

--- a/internal/e2e-js/templates/blank/v2vanilla.html
+++ b/internal/e2e-js/templates/blank/v2vanilla.html
@@ -216,6 +216,8 @@
         client.on('signalwire.notification', handleNotification);
 
         connectStatus.innerHTML = 'Connecting...';
+        console.log("Connecting now...");
+
         client.connect();
       }
 
@@ -271,6 +273,12 @@
         case 'ringing': // Someone is calling you
           //if (confirm('Pick up the call?')) {
             console.log("Answering: ", ccallState)
+
+            if (window.__iceTransportPolicy) {
+              console.log("____setting relay only____")
+              currentCall.options.iceTransportPolicy = iceTransportPolicy;
+            }
+
             currentCall.answer();
           //} else {
           //  currentCall.hangup();
@@ -299,14 +307,14 @@
     */
       function makeCall() {
         const params = {
-        destinationNumber: document.getElementById('number').value, // required!
-        callerNumber: document.getElementById('numberFrom').value, // required!
-        audio: document.getElementById('audio').checked,
-        video: document.getElementById('video').checked ? { aspectRatio: 16/9 } : false,
-      };
+          destinationNumber: document.getElementById('number').value, // required!
+          callerNumber: document.getElementById('numberFrom').value, // required!
+          audio: document.getElementById('audio').checked,
+          video: document.getElementById('video').checked ? { aspectRatio: 16/9 } : false,
+        };
 
-      currentCall = client.newCall(params);
-    }
+        currentCall = client.newCall(params);
+      }
 
     /**
      * Send a DTMF to currentCall if present

--- a/internal/e2e-js/tests/v2Webrtc/v2WebrtcFromRest.spec.ts
+++ b/internal/e2e-js/tests/v2Webrtc/v2WebrtcFromRest.spec.ts
@@ -14,11 +14,12 @@ import {
   randomizeResourceName
 } from '../../utils'
 
+const v2WebrtcFromRestSilenceDescription = 'should handle a call from REST API to v2 client, playing silence at answer'
 test.describe('v2WebrtcFromRestSilence', () => {
-  test('should handle a call from REST API to v2 client, playing silence at answer', async ({
+  test(v2WebrtcFromRestSilenceDescription, async ({
     createCustomVanillaPage,
   }) => {
-    console.info('START: should handle a call from REST API to v2 client, playing silence at answer')
+    console.info('START: ', v2WebrtcFromRestSilenceDescription)
 
     const expectCallActive = async (page: Page) => {
       // Hangup call button locator
@@ -74,9 +75,12 @@ test.describe('v2WebrtcFromRestSilence', () => {
 
     console.log('The call is active at ', new Date())
 
-    const callDurationMs = 20000
-    // Call duration
+    // With 40 seconds we can catch a media timeout
+    const callDurationMs = 40000
     await pageCallee.waitForTimeout(callDurationMs)
+
+    // We want to ensure at this point the call hasn't timed out
+    await expectCallActive(pageCallee)
 
     console.log('Time to check the audio energy at ', new Date())
 
@@ -95,15 +99,16 @@ test.describe('v2WebrtcFromRestSilence', () => {
     await pageCallee.click('#hangupCall')
     await expectCallHangup(pageCallee)
 
-    console.info('END: should handle a call from REST API to v2 client, playing silence at answer')
+    console.info('END: ', v2WebrtcFromRestSilenceDescription)
   })
 })
 
+const v2WebrtcFromRestDescription = 'should handle a call from REST API to v2 client, dialing into a Conference at answer'
 test.describe('v2WebrtcFromRest', () => {
-  test('should handle a call from REST API to v2 client, dialing into a Conference at answer', async ({
+  test(v2WebrtcFromRestDescription, async ({
     createCustomVanillaPage,
   }) => {
-    console.info('START: should handle a call from REST API to v2 client, dialing into a Conference at answer')
+    console.info('START: ', v2WebrtcFromRestDescription)
 
     const expectCallActive = async (page: Page) => {
       // Hangup call button locator
@@ -155,9 +160,12 @@ test.describe('v2WebrtcFromRest', () => {
 
     console.log('The call is active at ', new Date())
 
-    const callDurationMs = 20000
-    // Call duration
+    // With 40 seconds we can catch a media timeout
+    const callDurationMs = 40000
     await pageCallee.waitForTimeout(callDurationMs)
+
+    // Ensure the call hasn't been hang up, e.g. by a media timeout
+    await expectCallActive(pageCallee)
 
     console.log('Time to check the audio energy at ', new Date())
 
@@ -177,15 +185,16 @@ test.describe('v2WebrtcFromRest', () => {
     await pageCallee.click('#hangupCall')
     await expectCallHangup(pageCallee)
 
-    console.info('END: should handle a call from REST API to v2 client, dialing into a Conference at answer')
+    console.info('END: ', v2WebrtcFromRestDescription)
   })
 })
 
+const v2WebrtcFromRestTwoJoinAudioVideoDescription = 'should handle a call from REST API to v2 clients, dialing both into a Conference at answer, audio/video'
 test.describe('v2WebrtcFromRestTwoJoinAudioVideo', () => {
-  test('should handle a call from REST API to v2 clients, dialing both into a Conference at answer, audio/video', async ({
+  test(v2WebrtcFromRestTwoJoinAudioVideoDescription, async ({
     createCustomVanillaPage,
   }) => {
-    console.info('START: should handle a call from REST API to v2 clients, dialing both into a Conference at answer, audio/video')
+    console.info('START: ', v2WebrtcFromRestTwoJoinAudioVideoDescription)
 
     const expectCallActive = async (page: Page) => {
       // Hangup call button locator
@@ -258,9 +267,14 @@ test.describe('v2WebrtcFromRestTwoJoinAudioVideo', () => {
 
     console.log('The call is active at ', new Date())
 
-    const callDurationMs = 20000
-    // Call duration
+    // With 40 seconds we can catch a media timeout
+    const callDurationMs = 40000
     await pageCallee.waitForTimeout(callDurationMs)
+
+    await Promise.all([
+      expectCallActive(pageCallee),
+      expectCallActive(pageCallee2)
+    ])
 
     console.log('Time to check the audio energy at ', new Date())
 
@@ -279,7 +293,7 @@ test.describe('v2WebrtcFromRestTwoJoinAudioVideo', () => {
     await expectCallActive(pageCallee)
     await expectCallActive(pageCallee2)
 
-    console.log('Hanging up the call2 at ', new Date())
+    console.log('Hanging up the calls at ', new Date())
 
     await pageCallee.click('#hangupCall')
     await expectCallHangup(pageCallee)
@@ -287,12 +301,11 @@ test.describe('v2WebrtcFromRestTwoJoinAudioVideo', () => {
     await pageCallee2.click('#hangupCall')
     await expectCallHangup(pageCallee2)
 
-    console.info('END: should handle a call from REST API to v2 clients, dialing both into a Conference at answer, audio/video')
+    console.info('END: ', v2WebrtcFromRestTwoJoinAudioVideoDescription)
   })
 })
 
 const v2WebrtcFromRestTwoJoinAudioTURNDescription = 'should handle a call from REST API to 2 v2 clients, dialing both into a Conference at answer, audio G711, TURN only'
-
 test.describe('v2WebrtcFromRestTwoJoinAudioTURN', () => {
   test(v2WebrtcFromRestTwoJoinAudioTURNDescription, async ({
     createCustomVanillaPage,
@@ -382,12 +395,10 @@ test.describe('v2WebrtcFromRestTwoJoinAudioTURN', () => {
 
     console.log('call2 is active at ', new Date())
 
-    // Keep greater than 30 seconds to detect MEDIA_TIMEOUT
+    // With 40 seconds we can catch a media timeout
     const callDurationMs = 40000
     await pageCallee1.waitForTimeout(callDurationMs)
 
-
-    // TODO: check the calls are still up...
     await Promise.all([
       expect(callStatusCallee1).toContainText('-> active'),
       expect(callStatusCallee2).toContainText('-> active')
@@ -431,11 +442,12 @@ test.describe('v2WebrtcFromRestTwoJoinAudioTURN', () => {
   })
 })
 
+const v2WebrtcFromRest422Description = 'should handle a call from REST API to v2 client, receiving a 422 from REST API'
 test.describe('v2WebrtcFromRest422', () => {
-  test('should handle a call from REST API to v2 client, receiving a 422 from REST API', async ({
+  test(v2WebrtcFromRest422Description, async ({
     createCustomVanillaPage,
   }) => {
-    console.info('START: should handle a call from REST API to v2 client, receiving a 422 from REST API')
+    console.info('START: ', v2WebrtcFromRest422Description)
 
     const pageCallee = await createCustomVanillaPage({ name: '[callee]' })
     await pageCallee.goto(SERVER_URL + '/v2vanilla.html')
@@ -466,6 +478,6 @@ test.describe('v2WebrtcFromRest422', () => {
       inlineLaml
     )
     expect(createResult).toBe(422)
-    console.info('END: should handle a call from REST API to v2 client, receiving a 422 from REST API')
+    console.info('END: ', v2WebrtcFromRest422Description)
   })
 })

--- a/internal/e2e-js/tests/v2Webrtc/v2WebrtcFromRest.spec.ts
+++ b/internal/e2e-js/tests/v2Webrtc/v2WebrtcFromRest.spec.ts
@@ -14,12 +14,12 @@ import {
   randomizeResourceName
 } from '../../utils'
 
-const v2WebrtcFromRestSilenceDescription = 'should handle a call from REST API to v2 client, playing silence at answer'
+const silenceDescription = 'should handle a call from REST API to v2 client, playing silence at answer'
 test.describe('v2WebrtcFromRestSilence', () => {
-  test(v2WebrtcFromRestSilenceDescription, async ({
+  test(silenceDescription, async ({
     createCustomVanillaPage,
   }) => {
-    console.info('START: ', v2WebrtcFromRestSilenceDescription)
+    console.info('START: ', silenceDescription)
 
     const expectCallActive = async (page: Page) => {
       // Hangup call button locator
@@ -98,16 +98,16 @@ test.describe('v2WebrtcFromRestSilence', () => {
     await pageCallee.click('#hangupCall')
     await expectCallHangup(pageCallee)
 
-    console.info('END: ', v2WebrtcFromRestSilenceDescription)
+    console.info('END: ', silenceDescription)
   })
 })
 
-const v2WebrtcFromRestDescription = 'should handle a call from REST API to v2 client, dialing into a Conference at answer'
+const conferenceDescription = 'should handle a call from REST API to v2 client, dialing into a Conference at answer'
 test.describe('v2WebrtcFromRest', () => {
-  test(v2WebrtcFromRestDescription, async ({
+  test(conferenceDescription, async ({
     createCustomVanillaPage,
   }) => {
-    console.info('START: ', v2WebrtcFromRestDescription)
+    console.info('START: ', conferenceDescription)
 
     const expectCallActive = async (page: Page) => {
       // Hangup call button locator
@@ -184,16 +184,16 @@ test.describe('v2WebrtcFromRest', () => {
     await pageCallee.click('#hangupCall')
     await expectCallHangup(pageCallee)
 
-    console.info('END: ', v2WebrtcFromRestDescription)
+    console.info('END: ', conferenceDescription)
   })
 })
 
-const v2WebrtcFromRestTwoJoinAudioVideoDescription = 'should handle a call from REST API to v2 clients, dialing both into a Conference at answer, audio/video'
+const twoJoinAudioVideoDescription = 'should handle a call from REST API to v2 clients, dialing both into a Conference at answer, audio/video'
 test.describe('v2WebrtcFromRestTwoJoinAudioVideo', () => {
-  test(v2WebrtcFromRestTwoJoinAudioVideoDescription, async ({
+  test(twoJoinAudioVideoDescription, async ({
     createCustomVanillaPage,
   }) => {
-    console.info('START: ', v2WebrtcFromRestTwoJoinAudioVideoDescription)
+    console.info('START: ', twoJoinAudioVideoDescription)
 
     const expectCallActive = async (page: Page) => {
       // Hangup call button locator
@@ -301,16 +301,16 @@ test.describe('v2WebrtcFromRestTwoJoinAudioVideo', () => {
     await pageCallee2.click('#hangupCall')
     await expectCallHangup(pageCallee2)
 
-    console.info('END: ', v2WebrtcFromRestTwoJoinAudioVideoDescription)
+    console.info('END: ', twoJoinAudioVideoDescription)
   })
 })
 
-const v2WebrtcFromRestTwoJoinAudioTURNDescription = 'should handle a call from REST API to 2 v2 clients, dialing both into a Conference at answer, audio G711, TURN only'
+const twoJoinAudioTURNDescription = 'should handle a call from REST API to 2 v2 clients, dialing both into a Conference at answer, audio G711, TURN only'
 test.describe('v2WebrtcFromRestTwoJoinAudioTURN', () => {
-  test(v2WebrtcFromRestTwoJoinAudioTURNDescription, async ({
+  test(twoJoinAudioTURNDescription, async ({
     createCustomVanillaPage,
   }) => {
-    console.info('START: ', v2WebrtcFromRestTwoJoinAudioTURNDescription)
+    console.info('START: ', twoJoinAudioTURNDescription)
 
     const expectCallActive = async (page: Page) => {
       // Hangup call button locator
@@ -438,16 +438,16 @@ test.describe('v2WebrtcFromRestTwoJoinAudioTURN', () => {
       expectCallHangup(pageCallee2)
     ])
 
-    console.info('END: ', v2WebrtcFromRestTwoJoinAudioTURNDescription)
+    console.info('END: ', twoJoinAudioTURNDescription)
   })
 })
 
-const v2WebrtcFromRest422Description = 'should handle a call from REST API to v2 client, receiving a 422 from REST API'
+const get422Description = 'should handle a call from REST API to v2 client, receiving a 422 from REST API'
 test.describe('v2WebrtcFromRest422', () => {
-  test(v2WebrtcFromRest422Description, async ({
+  test(get422Description, async ({
     createCustomVanillaPage,
   }) => {
-    console.info('START: ', v2WebrtcFromRest422Description)
+    console.info('START: ', get422Description)
 
     const pageCallee = await createCustomVanillaPage({ name: '[callee]' })
     await pageCallee.goto(SERVER_URL + '/v2vanilla.html')
@@ -478,6 +478,6 @@ test.describe('v2WebrtcFromRest422', () => {
       inlineLaml
     )
     expect(createResult).toBe(422)
-    console.info('END: ', v2WebrtcFromRest422Description)
+    console.info('END: ', get422Description)
   })
 })

--- a/internal/e2e-js/tests/v2Webrtc/v2WebrtcFromRest.spec.ts
+++ b/internal/e2e-js/tests/v2Webrtc/v2WebrtcFromRest.spec.ts
@@ -4,6 +4,7 @@ import {
   SERVER_URL,
   createCallWithCompatibilityApi,
   createTestJWTToken,
+  expectInjectIceTransportPolicy,
   expectedMinPackets,
   expectInjectRelayHost,
   expectRelayConnected,
@@ -290,11 +291,11 @@ test.describe('v2WebrtcFromRestTwoJoinAudioVideo', () => {
   })
 })
 
-test.describe('v2WebrtcFromRestTwoJoinAudio', () => {
-  test('should handle a call from REST API to v2 clients, dialing both into a Conference at answer, audio G711', async ({
+test.describe('v2WebrtcFromRestTwoJoinAudioTURN', () => {
+  test('should handle a call from REST API to v2 clients, dialing both into a Conference at answer, audio G711, TURN only', async ({
     createCustomVanillaPage,
   }) => {
-    console.info('START: should handle a call from REST API to v2 clients, dialing both into a Conference at answer, audio G711')
+    console.info('START: should handle a call from REST API to v2 clients, dialing both into a Conference at answer, audio G711, TURN only')
 
     const expectCallActive = async (page: Page) => {
       // Hangup call button locator
@@ -323,6 +324,8 @@ test.describe('v2WebrtcFromRestTwoJoinAudio', () => {
     const relayHost = process.env.RELAY_HOST ?? ''
     await expectInjectRelayHost(pageCallee, relayHost)
     await expectInjectRelayHost(pageCallee2, relayHost)
+
+    await expectInjectIceTransportPolicy(pageCallee, 'relay')
 
     const envRelayProject = process.env.RELAY_PROJECT ?? ''
     expect(envRelayProject).not.toBe(null)

--- a/internal/e2e-js/tests/v2Webrtc/v2WebrtcFromRest.spec.ts
+++ b/internal/e2e-js/tests/v2Webrtc/v2WebrtcFromRest.spec.ts
@@ -54,10 +54,10 @@ test.describe('v2WebrtcFromRestSilence', () => {
 
     await expectRelayConnected(pageCallee, envRelayProject, jwtCallee)
 
-    // Set to 50 seconds to keep it running during the 40 seconds call
+    // Set to 30 seconds to keep it running during the 20 seconds call
     const inlineLaml = `<?xml version="1.0" encoding="UTF-8"?>
       <Response>
-      <Pause length="50"/>
+      <Pause length="30"/>
     </Response>`
 
     console.log('inline Laml: ', inlineLaml)
@@ -74,8 +74,7 @@ test.describe('v2WebrtcFromRestSilence', () => {
 
     console.log('The call is active at ', new Date())
 
-    // With 40 seconds we can catch a media timeout
-    const callDurationMs = 40000
+    const callDurationMs = 20000
     await pageCallee.waitForTimeout(callDurationMs)
 
     // We want to ensure at this point the call hasn't timed out

--- a/internal/e2e-js/tests/v2Webrtc/v2WebrtcFromRest.spec.ts
+++ b/internal/e2e-js/tests/v2Webrtc/v2WebrtcFromRest.spec.ts
@@ -54,11 +54,10 @@ test.describe('v2WebrtcFromRestSilence', () => {
 
     await expectRelayConnected(pageCallee, envRelayProject, jwtCallee)
 
+    // Set to 50 seconds to keep it running during the 40 seconds call
     const inlineLaml = `<?xml version="1.0" encoding="UTF-8"?>
       <Response>
-      <Say>
-        <prosody volume="silent">Words to speak Words to speak Words to speak Words to speak Words to speak Words to speak Words to speak Words to speak Words to speak Words to speak Words to speak Words to speak Words to speak Words to speak Words to speak Words to speak Words to speak Words to speak Words to speak Words to speak Words to speak Words to speak Words to speak Words to speak Words to speak Words to speak Words to speak Words to speak</prosody>
-      </Say>
+      <Pause length="50"/>
     </Response>`
 
     console.log('inline Laml: ', inlineLaml)
@@ -278,8 +277,9 @@ test.describe('v2WebrtcFromRestTwoJoinAudioVideo', () => {
 
     console.log('Time to check the audio energy at ', new Date())
 
-    // Empirical value; it depends on the call scenario
-    const minAudioEnergy = callDurationMs / 8000
+    // An empirical value that depends on the call duration
+    // Nothing to do with sample rates
+    const minAudioEnergy = callDurationMs / 16000
 
     // Check the audio energy level is above threshold
     console.log('Expected min audio energy: ', minAudioEnergy)
@@ -406,7 +406,7 @@ test.describe('v2WebrtcFromRestTwoJoinAudioTURN', () => {
 
     console.log('Time to check the audio energy at ', new Date())
 
-    // Empirical value; it depends on the call scenario
+    // An empirical value that depends on the call duration
     // Nothing to do with sample rates
     const minAudioEnergy = callDurationMs / 16000
 

--- a/internal/e2e-js/utils.ts
+++ b/internal/e2e-js/utils.ts
@@ -1003,7 +1003,7 @@ export const expectInjectIceTransportPolicy = async (page: Page, iceTransportPol
   await page.evaluate(
     async (params) => {
       // @ts-expect-error
-      window.__iceTransportPolicy = params
+      window.__iceTransportPolicy = params.iceTransportPolicy
     },
     {
       iceTransportPolicy: iceTransportPolicy

--- a/internal/e2e-js/utils.ts
+++ b/internal/e2e-js/utils.ts
@@ -1006,7 +1006,7 @@ export const expectInjectIceTransportPolicy = async (page: Page, iceTransportPol
       window.__iceTransportPolicy = params.iceTransportPolicy
     },
     {
-      iceTransportPolicy: iceTransportPolicy
+      iceTransportPolicy
     }
   )
 }

--- a/internal/e2e-js/utils.ts
+++ b/internal/e2e-js/utils.ts
@@ -999,6 +999,19 @@ export const expectInjectRelayHost = async (page: Page, host: string) => {
   )
 }
 
+export const expectInjectIceTransportPolicy = async (page: Page, iceTransportPolicy: string) => {
+  await page.evaluate(
+    async (params) => {
+      // @ts-expect-error
+      window.__iceTransportPolicy = params
+    },
+    {
+      iceTransportPolicy: iceTransportPolicy
+    }
+  )
+}
+
+
 export const expectRelayConnected = async (
   page: Page,
   envRelayProject: string,


### PR DESCRIPTION
# Description

- Changed CRLF format for vanilla HTML page
- Added ability to pass the `iceTransportPolicy` when creating the client instance in the page
- Made the new test long enough to detect a media timeout (40s)
- Changed most of the cases where the test was expecting something to happen on the first callee first, and then on the second, and now it's handling the promises together

## Type of change

- [x] Internal refactoring
- [ ] Bug fix (bugfix - non-breaking)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Code snippets

In case of new feature or breaking changes, please include code snippets.
