### PR TITLE
Fetch Address by name

### DIFF
--- a/.changeset/wicked-dogs-retire.md
+++ b/.changeset/wicked-dogs-retire.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/js': minor
+---
+
+Add a new `name` parameter to `client.address.getAddress`, allowing you to fetch an address by name.

--- a/internal/e2e-js/tests/callfabric/address.spec.ts
+++ b/internal/e2e-js/tests/callfabric/address.spec.ts
@@ -16,7 +16,7 @@ test.describe('Addresses', () => {
         const client = window._client
 
         const response = await client.address.getAddresses()
-        const addressToCompare = response.data[0]
+        const addressToCompare = response.data[1]
 
         const addressById = await client.address.getAddress({
           id: addressToCompare.id,

--- a/internal/e2e-js/tests/callfabric/address.spec.ts
+++ b/internal/e2e-js/tests/callfabric/address.spec.ts
@@ -10,19 +10,25 @@ test.describe('Addresses', () => {
 
     await createCFClient(page)
 
-    const { address, addressToCompare } = await page.evaluate(async () => {
-      // @ts-expect-error
-      const client = window._client
+    const { addressById, addressByName, addressToCompare } =
+      await page.evaluate(async () => {
+        // @ts-expect-error
+        const client = window._client
 
-      const response = await client.address.getAddresses()
-      const addressToCompare = response.data[0]
+        const response = await client.address.getAddresses()
+        const addressToCompare = response.data[0]
 
-      const address = await client.address.getAddress({
-        id: addressToCompare.id,
+        const addressById = await client.address.getAddress({
+          id: addressToCompare.id,
+        })
+
+        const addressByName = await client.address.getAddress({
+          name: addressToCompare.name,
+        })
+        return { addressById, addressByName, addressToCompare }
       })
-      return { address, addressToCompare }
-    })
 
-    expect(address.id).toEqual(addressToCompare.id)
+    expect(addressById.id).toEqual(addressToCompare.id)
+    expect(addressByName.id).toEqual(addressToCompare.id)
   })
 })

--- a/packages/js/src/fabric/HTTPClient.ts
+++ b/packages/js/src/fabric/HTTPClient.ts
@@ -58,7 +58,7 @@ export class HTTPClient {
   public async getAddress(params: GetAddressParams): Promise<GetAddressResult | undefined> {
     let path = '/api/fabric/addresses'
     if (isGetAddressByNameParams(params)) {
-      path = `${path}?name${params.name}`
+      path = `${path}?name=${params.name}`
     } else if (isGetAddressByIdParams(params)) {
       path = `${path}/${params.id}`
     }

--- a/packages/js/src/fabric/HTTPClient.ts
+++ b/packages/js/src/fabric/HTTPClient.ts
@@ -16,6 +16,7 @@ import type {
 import { CreateHttpClient, createHttpClient } from './createHttpClient'
 import { buildPaginatedResult } from '../utils/paginatedResult'
 import { makeQueryParamsUrls } from '../utils/makeQueryParamsUrl'
+import { isGetAddressByIdParam, isGetAddressBySafeNameParam, isGetAddressesResponse } from './utils/typeGuard'
 
 type JWTHeader = { ch?: string; typ?: string }
 
@@ -55,10 +56,18 @@ export class HTTPClient {
   }
 
   public async getAddress(params: GetAddressParams): Promise<GetAddressResult> {
-    const { id } = params
-    let path = `/api/fabric/addresses/${id}`
+    let path = '/api/fabric/addresses'
+    if (isGetAddressBySafeNameParam(params)) {
+      path = `${path}?name${params.name}`
+    } else if (isGetAddressByIdParam(params)) {
+      path = `${path}/${params.id}`
+    }
 
-    const { body } = await this.httpClient<GetAddressResponse>(path)
+
+    const { body } = await this.httpClient<GetAddressResponse | GetAddressesResponse>(path)
+    if (isGetAddressesResponse(body)) {
+      return body.data[0]
+    }
     return body
   }
 

--- a/packages/js/src/fabric/HTTPClient.ts
+++ b/packages/js/src/fabric/HTTPClient.ts
@@ -55,7 +55,7 @@ export class HTTPClient {
     return `fabric.${host.split('.').splice(1).join('.')}`
   }
 
-  public async getAddress(params: GetAddressParams): Promise<GetAddressResult> {
+  public async getAddress(params: GetAddressParams): Promise<GetAddressResult | undefined> {
     let path = '/api/fabric/addresses'
     if (isGetAddressBySafeNameParams(params)) {
       path = `${path}?name${params.name}`

--- a/packages/js/src/fabric/HTTPClient.ts
+++ b/packages/js/src/fabric/HTTPClient.ts
@@ -66,6 +66,7 @@ export class HTTPClient {
 
     const { body } = await this.httpClient<GetAddressResponse | GetAddressesResponse>(path)
     if (isGetAddressesResponse(body)) {
+      // FIXME until the server handles a index lookup by name we need to handle it as a search result
       return body.data[0]
     }
     return body

--- a/packages/js/src/fabric/HTTPClient.ts
+++ b/packages/js/src/fabric/HTTPClient.ts
@@ -16,7 +16,7 @@ import type {
 import { CreateHttpClient, createHttpClient } from './createHttpClient'
 import { buildPaginatedResult } from '../utils/paginatedResult'
 import { makeQueryParamsUrls } from '../utils/makeQueryParamsUrl'
-import { isGetAddressByIdParam, isGetAddressBySafeNameParam, isGetAddressesResponse } from './utils/typeGuard'
+import { isGetAddressByIdParams, isGetAddressBySafeNameParams, isGetAddressesResponse } from './utils/typeGuard'
 
 type JWTHeader = { ch?: string; typ?: string }
 
@@ -57,9 +57,9 @@ export class HTTPClient {
 
   public async getAddress(params: GetAddressParams): Promise<GetAddressResult> {
     let path = '/api/fabric/addresses'
-    if (isGetAddressBySafeNameParam(params)) {
+    if (isGetAddressBySafeNameParams(params)) {
       path = `${path}?name${params.name}`
-    } else if (isGetAddressByIdParam(params)) {
+    } else if (isGetAddressByIdParams(params)) {
       path = `${path}/${params.id}`
     }
 

--- a/packages/js/src/fabric/HTTPClient.ts
+++ b/packages/js/src/fabric/HTTPClient.ts
@@ -16,7 +16,7 @@ import type {
 import { CreateHttpClient, createHttpClient } from './createHttpClient'
 import { buildPaginatedResult } from '../utils/paginatedResult'
 import { makeQueryParamsUrls } from '../utils/makeQueryParamsUrl'
-import { isGetAddressByIdParams, isGetAddressBySafeNameParams, isGetAddressesResponse } from './utils/typeGuard'
+import { isGetAddressByIdParams, isGetAddressByNameParams, isGetAddressesResponse } from './utils/typeGuard'
 
 type JWTHeader = { ch?: string; typ?: string }
 
@@ -57,7 +57,7 @@ export class HTTPClient {
 
   public async getAddress(params: GetAddressParams): Promise<GetAddressResult | undefined> {
     let path = '/api/fabric/addresses'
-    if (isGetAddressBySafeNameParams(params)) {
+    if (isGetAddressByNameParams(params)) {
       path = `${path}?name${params.name}`
     } else if (isGetAddressByIdParams(params)) {
       path = `${path}/${params.id}`

--- a/packages/js/src/fabric/types.ts
+++ b/packages/js/src/fabric/types.ts
@@ -177,15 +177,15 @@ export interface GetAddressesParams {
   pageSize?: number
 }
 
-export interface GetAddressByIdParam {
+export interface GetAddressByIdParams {
   id: string
 }
 
-export interface GetAddressBySafeNameParam {
+export interface GetAddressBySafeNameParams {
   name: string
 }
 
-export type GetAddressParams = GetAddressByIdParam | GetAddressBySafeNameParam
+export type GetAddressParams = GetAddressByIdParams | GetAddressBySafeNameParams
 
 export type GetAddressResult = GetAddressResponse
 

--- a/packages/js/src/fabric/types.ts
+++ b/packages/js/src/fabric/types.ts
@@ -181,11 +181,11 @@ export interface GetAddressByIdParams {
   id: string
 }
 
-export interface GetAddressBySafeNameParams {
+export interface GetAddressByNameParams {
   name: string
 }
 
-export type GetAddressParams = GetAddressByIdParams | GetAddressBySafeNameParams
+export type GetAddressParams = GetAddressByIdParams | GetAddressByNameParams
 
 export type GetAddressResult = GetAddressResponse
 

--- a/packages/js/src/fabric/types.ts
+++ b/packages/js/src/fabric/types.ts
@@ -177,9 +177,15 @@ export interface GetAddressesParams {
   pageSize?: number
 }
 
-export interface GetAddressParams {
+export interface GetAddressByIdParam {
   id: string
 }
+
+export interface GetAddressBySafeNameParam {
+  name: string
+}
+
+export type GetAddressParams = GetAddressByIdParam | GetAddressBySafeNameParam
 
 export type GetAddressResult = GetAddressResponse
 

--- a/packages/js/src/fabric/utils/typeGuard.ts
+++ b/packages/js/src/fabric/utils/typeGuard.ts
@@ -1,0 +1,31 @@
+import {
+  GetAddressParams,
+  GetAddressBySafeNameParam,
+  GetAddressByIdParam,
+  GetAddressResponse,
+  GetAddressesResponse,
+} from '../types'
+
+export const isGetAddressBySafeNameParam = (
+  obj: GetAddressParams
+): obj is GetAddressBySafeNameParam => {
+  return obj && 'name' in obj
+}
+
+export const isGetAddressByIdParam = (
+  obj: GetAddressParams
+): obj is GetAddressByIdParam => {
+  return obj && 'id' in obj
+}
+
+export const isGetAddressResponse = (
+  obj: GetAddressResponse | GetAddressesResponse
+): obj is GetAddressResponse => {
+  return obj && 'id' in obj && 'name' in obj
+}
+
+export const isGetAddressesResponse = (
+  obj: GetAddressResponse | GetAddressesResponse
+): obj is GetAddressesResponse => {
+  return obj && 'id' in obj && 'name' in obj
+}

--- a/packages/js/src/fabric/utils/typeGuard.ts
+++ b/packages/js/src/fabric/utils/typeGuard.ts
@@ -1,20 +1,20 @@
 import {
   GetAddressParams,
-  GetAddressBySafeNameParam,
-  GetAddressByIdParam,
+  GetAddressBySafeNameParams,
+  GetAddressByIdParams,
   GetAddressResponse,
   GetAddressesResponse,
 } from '../types'
 
-export const isGetAddressBySafeNameParam = (
+export const isGetAddressBySafeNameParams = (
   obj: GetAddressParams
-): obj is GetAddressBySafeNameParam => {
+): obj is GetAddressBySafeNameParams => {
   return obj && 'name' in obj
 }
 
-export const isGetAddressByIdParam = (
+export const isGetAddressByIdParams = (
   obj: GetAddressParams
-): obj is GetAddressByIdParam => {
+): obj is GetAddressByIdParams => {
   return obj && 'id' in obj
 }
 

--- a/packages/js/src/fabric/utils/typeGuard.ts
+++ b/packages/js/src/fabric/utils/typeGuard.ts
@@ -1,14 +1,14 @@
 import {
   GetAddressParams,
-  GetAddressBySafeNameParams,
+  GetAddressByNameParams,
   GetAddressByIdParams,
   GetAddressResponse,
   GetAddressesResponse,
 } from '../types'
 
-export const isGetAddressBySafeNameParams = (
+export const isGetAddressByNameParams = (
   obj: GetAddressParams
-): obj is GetAddressBySafeNameParams => {
+): obj is GetAddressByNameParams => {
   return obj && 'name' in obj
 }
 

--- a/packages/js/src/fabric/utils/typeGuard.ts
+++ b/packages/js/src/fabric/utils/typeGuard.ts
@@ -27,5 +27,5 @@ export const isGetAddressResponse = (
 export const isGetAddressesResponse = (
   obj: GetAddressResponse | GetAddressesResponse
 ): obj is GetAddressesResponse => {
-  return obj && 'id' in obj && 'name' in obj
+  return obj && 'data' in obj
 }


### PR DESCRIPTION
# Description

Add a new `name` parameter to `client.address.getAddress`, allowing you to fetch an address by name.

## Type of change

- [ ] Internal refactoring
- [ ] Bug fix (bugfix - non-breaking)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Code snippets

In case of new feature or breaking changes, please include code snippets.

```
const addressByName = await client.address.getAddress({name: addressToCompare.name})
```
