### PR TITLE
Expose `addressId` from the Conversation contract

### DIFF
--- a/.changeset/rude-ravens-joke.md
+++ b/.changeset/rude-ravens-joke.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/js': patch
+---
+
+CF SDK: Expose the `addressId` from the Conversation contract

--- a/packages/js/src/fabric/ConversationAPI.ts
+++ b/packages/js/src/fabric/ConversationAPI.ts
@@ -9,27 +9,31 @@ import {
 export class ConversationAPI implements ConversationContract {
   constructor(
     private conversation: Conversation,
-    private data: ConversationResponse
+    private payload: ConversationResponse
   ) {}
 
   get id() {
-    return this.data.id
+    return this.payload.id
+  }
+
+  get addressId() {
+    return this.payload.address_id
   }
 
   get createdAt() {
-    return this.data.created_at
+    return this.payload.created_at
   }
 
   get lastMessageAt() {
-    return this.data.last_message_at
+    return this.payload.last_message_at
   }
 
   get metadata() {
-    return this.data.metadata
+    return this.payload.metadata
   }
 
   get name() {
-    return this.data.name
+    return this.payload.name
   }
 
   sendMessage(params: ConversationAPISendMessageParams) {

--- a/packages/js/src/fabric/types.ts
+++ b/packages/js/src/fabric/types.ts
@@ -197,8 +197,9 @@ export type GetAddressesResult = PaginatedResult<GetAddressResponse>
  * Conversations
  */
 export interface ConversationContract {
-  readonly id: string
+  readonly addressId: string
   readonly createdAt: number
+  readonly id: string
   readonly lastMessageAt: number
   readonly metadata: Record<string, any>
   readonly name: string
@@ -231,6 +232,7 @@ export interface GetConversationsParams {
 }
 
 export interface ConversationResponse {
+  address_id: string
   created_at: number
   id: string
   last_message_at: number


### PR DESCRIPTION
# Description

Expose the `addressId` from the Conversation response and contract. 

I have also replaced `data` with `payload` as a class param since this is consistent with other SDK classes.

## Type of change

- [ ] Internal refactoring
- [x] Bug fix (bugfix - non-breaking)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Code snippets

In case of new feature or breaking changes, please include code snippets.
