### PR TITLE
Fix minor markdown issues to be able to autogenerate docs

### DIFF
--- a/packages/core/src/redux/interfaces.ts
+++ b/packages/core/src/redux/interfaces.ts
@@ -89,9 +89,12 @@ export type CustomSaga<T> = (params: CustomSagaParams<T>) => SagaIterator<any>
 
 /**
  * Converts from:
- * { event_type: <value>, params: <value> }
+ * 
+ * `{ event_type: <value>, params: <value> }`
+ * 
  * into
- * { type: <value>, payload: <value> }
+ * 
+ * `{ type: <value>, payload: <value> }`
  */
 export type MapToPubSubShape<T> = {
   [K in keyof T as K extends 'event_type'

--- a/packages/js/README.md
+++ b/packages/js/README.md
@@ -2,7 +2,7 @@
 
 # RELAY Browser SDK
 
-[![The Build Status of the package @signalwire/js.](https://ci.signalwire.com/api/badges/signalwire/signalwire-js/status.svg)](https://ci.signalwire.com/signalwire/signalwire-js) ![The NPM shield for the package @signalwire/js.](https://img.shields.io/npm/v/@signalwire/js.svg?color=brightgreen)
+[![The build status of the package @signalwire/js.](https://ci.signalwire.com/api/badges/signalwire/signalwire-js/status.svg)](https://ci.signalwire.com/signalwire/signalwire-js) ![The NPM shield for the package @signalwire/js.](https://img.shields.io/npm/v/@signalwire/js.svg?color=brightgreen)
 
 The RELAY Browser SDK transforms your standard browser into a realtime media engine, enabling developers to directly make audio and video calls to phone numbers, SIP endpoints, and other browsers. Using the JavaScript SDK you can add immersive, scalable communication - from video conferences and softphones to click-to-call and mobile gaming - all available right in your own web pages and applications.
 

--- a/packages/js/README.md
+++ b/packages/js/README.md
@@ -2,7 +2,7 @@
 
 # RELAY Browser SDK
 
-[![Build Status](https://ci.signalwire.com/api/badges/signalwire/signalwire-js/status.svg)](https://ci.signalwire.com/signalwire/signalwire-js) ![NPM](https://img.shields.io/npm/v/@signalwire/js.svg?color=brightgreen)
+[![The Build Status of the package @signalwire/js.](https://ci.signalwire.com/api/badges/signalwire/signalwire-js/status.svg)](https://ci.signalwire.com/signalwire/signalwire-js) ![The NPM shield for the package @signalwire/js.](https://img.shields.io/npm/v/@signalwire/js.svg?color=brightgreen)
 
 The RELAY Browser SDK transforms your standard browser into a realtime media engine, enabling developers to directly make audio and video calls to phone numbers, SIP endpoints, and other browsers. Using the JavaScript SDK you can add immersive, scalable communication - from video conferences and softphones to click-to-call and mobile gaming - all available right in your own web pages and applications.
 
@@ -33,7 +33,7 @@ The JavaScript SDK is a package inside the [signalwire-js](https://github.com/si
 
 ## Versioning
 
-SignalWire JavaScript SDK follows Semantic Versioning 2.0 as defined at <http://semver.org>.
+SignalWire JavaScript SDK follows Semantic Versioning 2.0 as defined at [http://semver.org](http://semver.org).
 
 ## License
 

--- a/packages/realtime-api/README.md
+++ b/packages/realtime-api/README.md
@@ -2,7 +2,7 @@
 
 # RELAY RealTime SDK
 
-[![Build Status](https://ci.signalwire.com/api/badges/signalwire/signalwire-js/status.svg)](https://ci.signalwire.com/signalwire/signalwire-js) ![NPM](https://img.shields.io/npm/v/@signalwire/realtime-api.svg?color=brightgreen)
+[![The build status for the package @signalwire/realtime-api.](https://ci.signalwire.com/api/badges/signalwire/signalwire-js/status.svg)](https://ci.signalwire.com/signalwire/signalwire-js) ![The NPM shield for the package @signalwire/realtime-api.](https://img.shields.io/npm/v/@signalwire/realtime-api.svg?color=brightgreen)
 
 The RealTime SDK enables Node.js developers to connect and use SignalWire's RealTime APIs within their own Node.js code. Our RealTime SDK allows developers to build or add robust and innovative communication services to their applications.
 
@@ -31,7 +31,7 @@ The RealTime SDK is a package inside the [signalwire-js](https://github.com/sign
 
 ## Versioning
 
-SignalWire RealTime SDK follows Semantic Versioning 2.0 as defined at <http://semver.org>.
+SignalWire RealTime SDK follows Semantic Versioning 2.0 as defined at [http://semver.org](http://semver.org).
 
 ## License
 

--- a/packages/realtime-api/README.md
+++ b/packages/realtime-api/README.md
@@ -2,7 +2,7 @@
 
 # RELAY RealTime SDK
 
-[![The build status for the package @signalwire/realtime-api.](https://ci.signalwire.com/api/badges/signalwire/signalwire-js/status.svg)](https://ci.signalwire.com/signalwire/signalwire-js) ![The NPM shield for the package @signalwire/realtime-api.](https://img.shields.io/npm/v/@signalwire/realtime-api.svg?color=brightgreen)
+[![The build status of the package @signalwire/realtime-api.](https://ci.signalwire.com/api/badges/signalwire/signalwire-js/status.svg)](https://ci.signalwire.com/signalwire/signalwire-js) ![The NPM shield for the package @signalwire/realtime-api.](https://img.shields.io/npm/v/@signalwire/realtime-api.svg?color=brightgreen)
 
 The RealTime SDK enables Node.js developers to connect and use SignalWire's RealTime APIs within their own Node.js code. Our RealTime SDK allows developers to build or add robust and innovative communication services to their applications.
 

--- a/packages/webrtc/src/utils/primitives.ts
+++ b/packages/webrtc/src/utils/primitives.ts
@@ -60,7 +60,7 @@ export const supportsMediaOutput = () => {
  *
  * > 📘
  * > Some browsers do not support output device selection. You can check by
- * > calling [`supportsMediaOutput`](supportsmediaoutput).
+ * > calling [`supportsMediaOutput`](supportsMediaOutput).
  *
  * @param el target element
  * @param deviceId id of the audio output device


### PR DESCRIPTION
# Description

Made some minor edits to a few comments and README files (trying not to change the content), for better documentation auto-generation with [typedoc](https://typedoc.org/).

## Type of change

- [ ] Internal refactoring
- [x] Bug fix (bugfix - non-breaking)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
