### PR TITLE
Allow unsubscribe from the conversation subscribe API

### DIFF
--- a/.changeset/tender-maps-beam.md
+++ b/.changeset/tender-maps-beam.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/js': patch
+---
+
+CF SDK: Allow user unsubscribe from the conversation subscribe API

--- a/packages/js/src/fabric/Conversation.test.ts
+++ b/packages/js/src/fabric/Conversation.test.ts
@@ -458,7 +458,7 @@ describe('Conversation', () => {
       expect(mockCallback).toHaveBeenCalledWith(valid)
     })
 
-    it.only('should connect the WS client and register the chat callback', async () => {
+    it('should connect the WS client and register the chat callback', async () => {
       const addressId = 'abc'
       const mockCallback = jest.fn()
       await conversation.subscribeChatMessages({
@@ -472,7 +472,7 @@ describe('Conversation', () => {
       )
     })
 
-    it.only('should cancel the correct chat subscription', async () => {
+    it('should cancel the correct chat subscription', async () => {
       const mockCallback1 = jest.fn()
       const mockCallback2 = jest.fn()
       const mockCallback3 = jest.fn()

--- a/packages/js/src/fabric/Conversation.test.ts
+++ b/packages/js/src/fabric/Conversation.test.ts
@@ -240,12 +240,15 @@ describe('Conversation', () => {
       })
 
       expect(result).toEqual(expectedResponse)
-      expect(httpClient.fetch).toHaveBeenCalledWith('/api/fabric/conversations/join', {
-        method: 'POST',
-        body: {
-          conversation_id: addressId,
-        },
-      })
+      expect(httpClient.fetch).toHaveBeenCalledWith(
+        '/api/fabric/conversations/join',
+        {
+          method: 'POST',
+          body: {
+            conversation_id: addressId,
+          },
+        }
+      )
     })
 
     it('should handles errors with joinConversation', async () => {
@@ -266,14 +269,36 @@ describe('Conversation', () => {
   })
 
   describe('subscribe', () => {
-    let callback
-
-    it('connects the WS client and registers the callback', async () => {
-      callback = jest.fn()
-      conversation.subscribe(callback)
+    it('should connect the WS client and register the callback', async () => {
+      const callback = jest.fn()
+      await conversation.subscribe(callback)
 
       expect(wsClient.connect).toHaveBeenCalledTimes(1)
       expect(conversation['callbacks']).toContain(callback)
+    })
+
+    it('should unsubscribe the correct callback', async () => {
+      const callback1 = jest.fn()
+      await conversation.subscribe(callback1)
+
+      const callback2 = jest.fn()
+      const { unsubscribe: unsubscribe2 } = await conversation.subscribe(
+        callback2
+      )
+
+      const callback3 = jest.fn()
+      await conversation.subscribe(callback3)
+
+      expect(wsClient.connect).toHaveBeenCalledTimes(3)
+      expect(conversation['callbacks']).toContain(callback1)
+      expect(conversation['callbacks']).toContain(callback2)
+      expect(conversation['callbacks']).toContain(callback3)
+
+      unsubscribe2()
+
+      expect(conversation['callbacks']).toContain(callback1)
+      expect(conversation['callbacks']).not.toContain(callback2)
+      expect(conversation['callbacks']).toContain(callback3)
     })
   })
 
@@ -359,7 +384,10 @@ describe('Conversation', () => {
       })
 
       const addressId = 'abc'
-      const messages = await conversation.getChatMessages({ addressId, pageSize:3 })
+      const messages = await conversation.getChatMessages({
+        addressId,
+        pageSize: 3,
+      })
 
       expect(messages.data).toHaveLength(4)
       expect(messages.data.every((item) => item.subtype === 'chat')).toBe(true)
@@ -400,8 +428,11 @@ describe('Conversation', () => {
     it('should get only address chat event', async () => {
       const mockCallback = jest.fn()
       const addressId = 'abc'
-      await conversation.subscribeChatMessages({addressId, onMessage: mockCallback})
-      
+      await conversation.subscribeChatMessages({
+        addressId,
+        onMessage: mockCallback,
+      })
+
       const valid = {
         type: 'message',
         subtype: 'chat',
@@ -427,39 +458,96 @@ describe('Conversation', () => {
       expect(mockCallback).toHaveBeenCalledWith(valid)
     })
 
-    it('should cancel chat address subscription', async () => {
-      const mockCallback = jest.fn()
+    it.only('should connect the WS client and register the chat callback', async () => {
       const addressId = 'abc'
-      const subscription = await conversation.subscribeChatMessages({addressId, onMessage: mockCallback})
-      
-      const valid = {
-        type: 'message',
+      const mockCallback = jest.fn()
+      await conversation.subscribeChatMessages({
+        addressId,
+        onMessage: mockCallback,
+      })
+
+      expect(wsClient.connect).toHaveBeenCalledTimes(1)
+      expect(conversation['chatSubscriptions'][addressId]).toContain(
+        mockCallback
+      )
+    })
+
+    it.only('should cancel the correct chat subscription', async () => {
+      const mockCallback1 = jest.fn()
+      const mockCallback2 = jest.fn()
+      const mockCallback3 = jest.fn()
+      const addressId1 = 'abc'
+      const addressId2 = 'xyz'
+      await conversation.subscribeChatMessages({
+        addressId: addressId1,
+        onMessage: mockCallback1,
+      })
+      const subscription2 = await conversation.subscribeChatMessages({
+        addressId: addressId1,
+        onMessage: mockCallback2,
+      })
+      await conversation.subscribeChatMessages({
+        addressId: addressId2,
+        onMessage: mockCallback3,
+      })
+
+      expect(conversation['chatSubscriptions'][addressId1]).toContain(
+        mockCallback1
+      )
+      expect(conversation['chatSubscriptions'][addressId1]).toContain(
+        mockCallback2
+      )
+      expect(conversation['chatSubscriptions'][addressId1]).not.toContain(
+        mockCallback3
+      )
+      expect(conversation['chatSubscriptions'][addressId2]).toContain(
+        mockCallback3
+      )
+
+      const eventForAddressId1 = {
+        conversation_id: addressId1,
+        conversation_name: 'test_conversation_name',
+        details: {},
+        hidden: false,
+        id: 'test_id',
+        kind: 'test_kind',
+        metadata: {},
         subtype: 'chat',
-        conversation_id: 'abc',
-        text: 'text',
+        type: 'message',
+        text: 'test_text',
+        ts: 1,
+        user_id: 'test_user_id',
+        user_name: 'test_user_name',
       }
-      //@ts-expect-error
-      conversation.handleEvent(valid)
-      //@ts-expect-error
+      conversation.handleEvent(eventForAddressId1)
+
       conversation.handleEvent({
-        type: 'message',
+        ...eventForAddressId1,
+        conversation_id: 'different_id',
         subtype: 'chat',
-        conversation_id: 'xyz',
-        text: 'text',
-      })
-      //@ts-expect-error
-      conversation.handleEvent({
         type: 'message',
-        subtype: 'log',
-        conversation_id: 'abc',
       })
 
-      expect(mockCallback).toHaveBeenCalledWith(valid)
+      conversation.handleEvent({
+        ...eventForAddressId1,
+        conversation_id: 'abc',
+        subtype: 'log',
+        type: 'message',
+      })
 
-      subscription.cancel()
-      //@ts-expect-error
-      conversation.handleEvent(valid)
-      expect(mockCallback).toBeCalledTimes(1)
+      expect(mockCallback1).toHaveBeenCalledWith(eventForAddressId1)
+      expect(mockCallback1).toHaveBeenCalledTimes(1)
+      expect(mockCallback2).toHaveBeenCalledWith(eventForAddressId1)
+      expect(mockCallback2).toHaveBeenCalledTimes(1)
+      expect(mockCallback3).not.toHaveBeenCalledWith(eventForAddressId1)
+      expect(mockCallback3).toHaveBeenCalledTimes(0)
+
+      subscription2.unsubscribe()
+      conversation.handleEvent(eventForAddressId1)
+
+      expect(mockCallback1).toHaveBeenCalledTimes(2)
+      expect(mockCallback2).toHaveBeenCalledTimes(1)
+      expect(mockCallback3).toHaveBeenCalledTimes(0)
     })
   })
 })

--- a/packages/js/src/fabric/Conversation.ts
+++ b/packages/js/src/fabric/Conversation.ts
@@ -60,7 +60,7 @@ export class Conversation {
   public handleEvent(event: ConversationEventParams) {
     if (event.subtype === 'chat') {
       const chatCallbacks = this.chatSubscriptions[event.conversation_id]
-      if (chatCallbacks.size) {
+      if (chatCallbacks?.size) {
         chatCallbacks.forEach((cb) => cb(event))
       }
     }

--- a/packages/js/src/fabric/Conversation.ts
+++ b/packages/js/src/fabric/Conversation.ts
@@ -59,10 +59,9 @@ export class Conversation {
   /** @internal */
   public handleEvent(event: ConversationEventParams) {
     if (event.subtype === 'chat') {
-      const conversationSubscription =
-        this.chatSubscriptions[event.conversation_id]
-      if (!!conversationSubscription) {
-        conversationSubscription.forEach((cb) => cb(event))
+      const chatCallbacks = this.chatSubscriptions[event.conversation_id]
+      if (chatCallbacks.size) {
+        chatCallbacks.forEach((cb) => cb(event))
       }
     }
 

--- a/packages/js/src/fabric/Conversation.ts
+++ b/packages/js/src/fabric/Conversation.ts
@@ -23,6 +23,7 @@ import type {
   JoinConversationParams,
   JoinConversationResponse,
   JoinConversationResult,
+  CoversationSubscribeResult,
 } from './types'
 import { conversationWorker } from './workers'
 import { buildPaginatedResult } from '../utils/paginatedResult'
@@ -39,16 +40,9 @@ interface ConversationOptions {
 export class Conversation {
   private httpClient: HTTPClient
   private wsClient: WSClient
-  private callbacks: CoversationSubscribeCallback[] = [
-    (event: ConversationEventParams) => {
-      if(event.subtype !== 'chat') return
-      const conversationSubscription = this.chatSubscriptions[event.conversation_id];
-      if(!!conversationSubscription) {
-          conversationSubscription.forEach((cb) => cb(event))
-      }
-    }
-  ]
-  private chatSubscriptions: Record<string, CoversationSubscribeCallback[]> = {}
+  private callbacks = new Set<CoversationSubscribeCallback>()
+  private chatSubscriptions: Record<string, Set<CoversationSubscribeCallback>> =
+    {}
 
   constructor(options: ConversationOptions) {
     this.httpClient = options.httpClient
@@ -64,7 +58,15 @@ export class Conversation {
 
   /** @internal */
   public handleEvent(event: ConversationEventParams) {
-    if (this.callbacks.length) {
+    if (event.subtype === 'chat') {
+      const conversationSubscription =
+        this.chatSubscriptions[event.conversation_id]
+      if (!!conversationSubscription) {
+        conversationSubscription.forEach((cb) => cb(event))
+      }
+    }
+
+    if (this.callbacks.size) {
       this.callbacks.forEach((callback) => {
         callback(event)
       })
@@ -196,11 +198,17 @@ export class Conversation {
     }
   }
 
-  public async subscribe(callback: CoversationSubscribeCallback) {
+  public async subscribe(
+    callback: CoversationSubscribeCallback
+  ): Promise<CoversationSubscribeResult> {
     // Connect the websocket client first
     this.wsClient.connect()
 
-    this.callbacks.push(callback)
+    this.callbacks.add(callback)
+
+    return {
+      unsubscribe: () => this.callbacks.delete(callback),
+    }
   }
 
   public async subscribeChatMessages(
@@ -211,14 +219,13 @@ export class Conversation {
     // Connect the websocket client first
     await this.wsClient.connect()
 
-    if(!(addressId in this.chatSubscriptions)) {
-      this.chatSubscriptions[addressId] = []
+    if (!(addressId in this.chatSubscriptions)) {
+      this.chatSubscriptions[addressId] = new Set()
     }
 
-    this.chatSubscriptions[addressId].push(onMessage);
-    const subscriptionIndex = this.chatSubscriptions[addressId].length - 1
+    this.chatSubscriptions[addressId].add(onMessage)
     return {
-      cancel: () => this.chatSubscriptions[addressId].splice(subscriptionIndex, 1)
+      unsubscribe: () => this.chatSubscriptions[addressId].delete(onMessage),
     }
   }
 

--- a/packages/js/src/fabric/types.ts
+++ b/packages/js/src/fabric/types.ts
@@ -252,14 +252,16 @@ export type CoversationSubscribeCallback = (
   event: ConversationEventParams
 ) => unknown
 
+export interface CoversationSubscribeResult {
+  unsubscribe: () => void
+}
+
 export interface ConversationChatMessagesSubscribeParams {
   addressId: string
   onMessage: CoversationSubscribeCallback
 }
 
-export interface ConversationChatMessagesSubscribeResult {
-  cancel: () => CoversationSubscribeCallback[]
-}
+export type ConversationChatMessagesSubscribeResult = CoversationSubscribeResult
 
 export interface JoinConversationParams {
   addressId: string


### PR DESCRIPTION
# Description

The PR will allow the user to unsubscribe from the conversation API.

## Type of change

- [ ] Internal refactoring
- [ ] Bug fix (bugfix - non-breaking)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Code snippets

```ts
const { unsubscribe } = await client.conversation.subscribe(() => { ... })
unsubscribe();
```
