### PR TITLE
Throw error from `startScreenShare` method if permission is denied

### DIFF
--- a/.changeset/lazy-colts-hang.md
+++ b/.changeset/lazy-colts-hang.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/js': patch
+---
+
+Throw error from `startScreenShare` method if permission is denied

--- a/internal/playground-js/src/fabric/index.js
+++ b/internal/playground-js/src/fabric/index.js
@@ -232,7 +232,7 @@ async function getClient() {
 /**
  * Connect with Relay creating a client and attaching all the event handler.
  */
-window.connect = async ({ reattach = false }) => {
+window.connect = async ({ reattach = false } = {}) => {
   const client = await getClient()
   window.__client = client
 

--- a/packages/js/src/BaseRoomSession.ts
+++ b/packages/js/src/BaseRoomSession.ts
@@ -146,52 +146,52 @@ export class RoomSessionConnection
         layout,
         positions,
       } = opts
-      const displayStream: MediaStream = await getDisplayMedia({
-        audio: audio === true ? SCREENSHARE_AUDIO_CONSTRAINTS : audio,
-        video,
-      })
-      const options: BaseConnectionOptions = {
-        ...this.options,
-        screenShare: true,
-        recoverCall: false,
-        localStream: displayStream,
-        remoteStream: undefined,
-        userVariables: {
-          ...(this.options?.userVariables || {}),
-          memberCallId: this.callId,
-          memberId: this.memberId,
-        },
-        layout,
-        positions,
-      }
-
-      const screenShare = connect<
-        RoomSessionScreenShareEvents,
-        RoomSessionScreenShareConnection,
-        RoomSessionScreenShare
-      >({
-        store: this.store,
-        Component: RoomSessionScreenShareAPI,
-      })(options)
-
-      /**
-       * Hangup if the user stop the screenShare from the
-       * native browser button or if the videoTrack ends.
-       */
-      displayStream.getVideoTracks().forEach((t) => {
-        t.addEventListener('ended', () => {
-          if (screenShare && screenShare.active) {
-            screenShare.leave()
-          }
-        })
-      })
-
-      screenShare.once('destroy', () => {
-        screenShare.emit('room.left')
-        this._screenShareList.delete(screenShare)
-      })
-
       try {
+        const displayStream: MediaStream = await getDisplayMedia({
+          audio: audio === true ? SCREENSHARE_AUDIO_CONSTRAINTS : audio,
+          video,
+        })
+        const options: BaseConnectionOptions = {
+          ...this.options,
+          screenShare: true,
+          recoverCall: false,
+          localStream: displayStream,
+          remoteStream: undefined,
+          userVariables: {
+            ...(this.options?.userVariables || {}),
+            memberCallId: this.callId,
+            memberId: this.memberId,
+          },
+          layout,
+          positions,
+        }
+
+        const screenShare = connect<
+          RoomSessionScreenShareEvents,
+          RoomSessionScreenShareConnection,
+          RoomSessionScreenShare
+        >({
+          store: this.store,
+          Component: RoomSessionScreenShareAPI,
+        })(options)
+
+        /**
+         * Hangup if the user stop the screenShare from the
+         * native browser button or if the videoTrack ends.
+         */
+        displayStream.getVideoTracks().forEach((t) => {
+          t.addEventListener('ended', () => {
+            if (screenShare && screenShare.active) {
+              screenShare.leave()
+            }
+          })
+        })
+
+        screenShare.once('destroy', () => {
+          screenShare.emit('room.left')
+          this._screenShareList.delete(screenShare)
+        })
+
         screenShare.runWorker('childMemberJoinedWorker', {
           worker: workers.childMemberJoinedWorker,
           onDone: () => resolve(screenShare),

--- a/packages/js/src/index.ts
+++ b/packages/js/src/index.ts
@@ -118,4 +118,5 @@ export type {
   RoomSessionObjectEventsHandlerMap as RoomObjectEventsHandlerMap,
   RoomSessionObjectEvents as RoomObjectEvents,
   RoomEventNames,
+  StartScreenShareOptions,
 } from './utils/interfaces'

--- a/packages/js/src/video.ts
+++ b/packages/js/src/video.ts
@@ -42,4 +42,3 @@ export type {
   RoomSessionRecording,
   RoomSessionPlayback,
 } from '@signalwire/core'
-


### PR DESCRIPTION
# Description

The `startScreenShare` method is now going to throw the permission denied error if the user does not allow getDisplayMedia permissions.

Additional work:
- Fix playground with reattach
- Expose the `StartScreenShareOptions` type

## Type of change

- [ ] Internal refactoring
- [x] Bug fix (bugfix - non-breaking)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Code snippets

In case of new feature or breaking changes, please include code snippets.
