### PR TITLE
Remove `channel` param from the `verto.invite`

### DIFF
--- a/packages/js/src/fabric/WSClient.ts
+++ b/packages/js/src/fabric/WSClient.ts
@@ -87,14 +87,11 @@ export class WSClient {
     let video = params.video ?? true
     let negotiateVideo = true
 
-    if (to) {
-      const channelRegex = /\?channel\=(?<channel>(audio|video))/
-      const result = channelRegex.exec(to)
+    const toURL = new URL(`address:${to}`)
 
-      if (result && result.groups?.channel === 'audio') {
-        video = false
-        negotiateVideo = false
-      }
+    if (to && toURL.searchParams.get('channel') === 'audio') {
+      video = false
+      negotiateVideo = false
     }
 
     const call = this.wsClient.makeCallFabricObject({
@@ -106,7 +103,7 @@ export class WSClient {
       applyLocalVideoOverlay: true,
       stopCameraWhileMuted: true,
       stopMicrophoneWhileMuted: true,
-      destinationNumber: params.to,
+      destinationNumber: toURL.pathname,
       watchMediaPackets: false,
       remoteSdp: sdp,
       prevCallId: callID,


### PR DESCRIPTION
# Description

Stop sending to `channel` param in the `verto.invite`.

## Type of change

- [x] Internal refactoring
- [ ] Bug fix (bugfix - non-breaking)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Code snippets

In case of new feature or breaking changes, please include code snippets.
