### PR TITLE
CF SDK: Integrate set member position API

### DIFF
--- a/.changeset/cyan-seahorses-wash.md
+++ b/.changeset/cyan-seahorses-wash.md
@@ -1,0 +1,6 @@
+---
+'@signalwire/core': minor
+'@signalwire/js': minor
+---
+
+CF SDK: Introduce the set member position API

--- a/internal/e2e-js/playwright.config.ts
+++ b/internal/e2e-js/playwright.config.ts
@@ -44,6 +44,7 @@ const callfabricTests = [
   'relayApp.spec.ts',
   'swml.spec.ts',
   'videoRoom.spec.ts',
+  'videoRoomLayout.spec.ts',
 ]
 const v2WebRTC = ['v2WebrtcFromRest.spec.ts', 'webrtcCalling.spec.ts']
 

--- a/internal/e2e-js/tests/callfabric/videoRoomLayout.spec.ts
+++ b/internal/e2e-js/tests/callfabric/videoRoomLayout.spec.ts
@@ -1,0 +1,213 @@
+import {
+  uuid,
+  VideoLayoutChangedEventParams,
+  VideoPosition,
+} from '@signalwire/core'
+import { test, expect } from '../../fixtures'
+import {
+  createCFClient,
+  dialAddress,
+  expectMCUVisible,
+  SERVER_URL,
+} from '../../utils'
+import { CallFabricRoomSession } from '@signalwire/js'
+
+test.describe('CallFabric Video Room Layout', () => {
+  test('should join a room and be able to change the layout', async ({
+    createCustomPage,
+    resource,
+  }) => {
+    const page = await createCustomPage({ name: '[page]' })
+    await page.goto(SERVER_URL)
+
+    const roomName = `e2e-video-layout_${uuid()}`
+    await resource.createVideoRoomResource(roomName)
+
+    await createCFClient(page)
+
+    // Dial an address and join a video room
+    const roomSession = await dialAddress(page, {
+      address: `/public/${roomName}`,
+    })
+
+    expect(roomSession.room_session).toBeDefined()
+
+    await expectMCUVisible(page)
+
+    // --------------- Set the 8x8 layout ---------------
+    await page.evaluate(
+      async ({ roomSessionId }) => {
+        const expectLayout = '8x8'
+        // @ts-expect-error
+        const roomObj: CallFabricRoomSession = window._roomObj
+
+        const layoutUpdated = new Promise((resolve) => {
+          roomObj.on(
+            'layout.changed',
+            (params: VideoLayoutChangedEventParams) => {
+              if (
+                params.room_session_id === roomSessionId &&
+                params.layout.id == expectLayout
+              ) {
+                resolve(true)
+              }
+            }
+          )
+        })
+
+        await roomObj.setLayout({ name: expectLayout })
+
+        return layoutUpdated
+      },
+      { roomSessionId: roomSession.room_session.room_session_id }
+    )
+  })
+
+  test('should join a room and be able to change the member position in the layout', async ({
+    createCustomPage,
+    resource,
+  }) => {
+    const page = await createCustomPage({ name: '[page]' })
+    await page.goto(SERVER_URL)
+
+    const roomName = `e2e-video-layout-position_${uuid()}`
+    await resource.createVideoRoomResource(roomName)
+
+    await createCFClient(page)
+
+    // Dial an address and join a video room
+    const roomSession = await dialAddress(page, {
+      address: `/public/${roomName}`,
+    })
+
+    expect(roomSession.room_session).toBeDefined()
+
+    await expectMCUVisible(page)
+
+    // --------------- Assert the current layout and position ---------------
+    const { currentLayout, currentPosition } = await page.evaluate(async () => {
+      // @ts-expect-error
+      const roomObj: CallFabricRoomSession = window._roomObj
+      return {
+        currentLayout: roomObj.currentLayout,
+        currentPosition: roomObj.currentPosition,
+      }
+    })
+    expect(currentLayout).toBeDefined()
+    expect(currentPosition).toBeDefined()
+
+    const secondPosition = currentLayout?.layers[1].position
+    expect(secondPosition).toBeDefined()
+
+    expect(currentPosition).not.toBe(secondPosition)
+
+    // --------------- Set position based on the current layout ---------------
+    await page.evaluate(
+      async ({ roomSessionId, secondPosition }) => {
+        // @ts-expect-error
+        const roomObj: CallFabricRoomSession = window._roomObj
+
+        const memberUpdated = new Promise((resolve) => {
+          roomObj.on('member.updated', (params) => {
+            if (
+              params.room_session_id === roomSessionId &&
+              params.member.current_position === secondPosition
+            ) {
+              resolve(true)
+            }
+          })
+        })
+
+        await roomObj.setPositions({
+          positions: { self: secondPosition as VideoPosition },
+        })
+
+        return memberUpdated
+      },
+      {
+        roomSessionId: roomSession.room_session.room_session_id,
+        secondPosition,
+      }
+    )
+  })
+
+  // TODO: Complete this
+  test.skip('should join a room and be able to change other member position in the layout', async ({
+    createCustomPage,
+    resource,
+  }) => {
+    const pageOne = await createCustomPage({ name: '[page-one]' })
+    const pageTwo = await createCustomPage({ name: '[page-two]' })
+    await pageOne.goto(SERVER_URL)
+    await pageTwo.goto(SERVER_URL)
+
+    const roomName = `e2e-video-layout-position_${uuid()}`
+    await resource.createVideoRoomResource(roomName)
+
+    // Create client for pageOne and Dial an address to join a video room
+    await createCFClient(pageOne)
+    const roomSessionOne = await dialAddress(pageOne, {
+      address: `/public/${roomName}`,
+    })
+    expect(roomSessionOne.room_session).toBeDefined()
+    await expectMCUVisible(pageOne)
+
+    // Create client for pageTwo and Dial an address to join a video room
+    await createCFClient(pageOne)
+    const roomSessionTwo = await dialAddress(pageTwo, {
+      address: `/public/${roomName}`,
+    })
+    expect(roomSessionTwo.room_session).toBeDefined()
+    await expectMCUVisible(pageTwo)
+
+    // --------------- Assert the current layout and position ---------------
+    const { currentLayout, currentPosition } = await pageOne.evaluate(
+      async () => {
+        // @ts-expect-error
+        const roomObj: CallFabricRoomSession = window._roomObj
+        return {
+          currentLayout: roomObj.currentLayout,
+          currentPosition: roomObj.currentPosition,
+        }
+      }
+    )
+    expect(currentLayout).toBeDefined()
+    expect(currentPosition).toBeDefined()
+
+    console.log('>> currentLayout', currentLayout)
+
+    // const secondPosition = currentLayout?.layers[1].position
+    // expect(secondPosition).toBeDefined()
+
+    // expect(currentPosition).not.toBe(secondPosition)
+
+    // // --------------- Set position based on the current layout ---------------
+    // await page.evaluate(
+    //   async ({ roomSessionId, secondPosition }) => {
+    //     // @ts-expect-error
+    //     const roomObj: CallFabricRoomSession = window._roomObj
+
+    //     const memberUpdated = new Promise((resolve) => {
+    //       roomObj.on('member.updated', (params) => {
+    //         if (
+    //           params.room_session_id === roomSessionId &&
+    //           params.member.current_position === secondPosition
+    //         ) {
+    //           resolve(true)
+    //         }
+    //       })
+    //     })
+
+    //     await roomObj.setPositions({
+    //       positions: { self: secondPosition as VideoPosition },
+    //     })
+
+    //     return memberUpdated
+    //   },
+    //   {
+    //     roomSessionId: roomSession.room_session.room_session_id,
+    //     secondPosition,
+    //   }
+    // )
+  })
+})

--- a/internal/e2e-js/utils.ts
+++ b/internal/e2e-js/utils.ts
@@ -1,4 +1,4 @@
-import type { Video } from '@signalwire/js'
+import type { SignalWireContract, Video } from '@signalwire/js'
 import type { MediaEvent } from '@signalwire/webrtc'
 import { createServer } from 'vite'
 import path from 'path'
@@ -1215,14 +1215,14 @@ export const dialAddress = (page: Page, params: DialAddressParams) => {
     }) => {
       return new Promise<any>(async (resolve, _reject) => {
         // @ts-expect-error
-        const client = window._client
+        const client: SignalWireContract = window._client
 
         const dialer = reattach ? client.reattach : client.dial
 
         const call = await dialer({
           to: address,
           ...(shouldPassRootElement && {
-            rootElement: document.getElementById('rootElement'),
+            rootElement: document.getElementById('rootElement')!,
           }),
         })
 

--- a/internal/playground-js/src/fabric/index.html
+++ b/internal/playground-js/src/fabric/index.html
@@ -238,11 +238,21 @@
 
               <h5 class="mt-3" for="layout">Layouts</h5>
               <div class="col-12">
+                <label for="layout" class="form-label">Layout for room</label>
                 <select
                   class="form-select"
                   onchange="changeLayout(this)"
                   value=""
                   id="layout"
+                ></select>
+              </div>
+              <div class="col-12">
+                <label for="position" class="form-label">Member position</label>
+                <select
+                  class="form-select"
+                  onchange="changePosition(this)"
+                  value=""
+                  id="position"
                 ></select>
               </div>
 

--- a/internal/playground-js/src/fabric/index.js
+++ b/internal/playground-js/src/fabric/index.js
@@ -560,7 +560,7 @@ window.changeLayout = (select) => {
 }
 
 window.changePosition = (select) => {
-  roomObj.setPosition({ position: select.value })
+  roomObj.setPositions({ positions: { self: select.value } })
   currentPositionId = select.value
 }
 

--- a/internal/playground-js/src/fabric/index.js
+++ b/internal/playground-js/src/fabric/index.js
@@ -109,6 +109,29 @@ async function loadLayouts(currentLayoutId) {
   }
 }
 
+let currentPositionId = null
+async function loadPositions(layout) {
+  const positionEl = document.getElementById('position')
+  positionEl.innerHTML = ''
+
+  const defOption = document.createElement('option')
+  defOption.value = ''
+  defOption.innerHTML = 'Change position...'
+  positionEl.appendChild(defOption)
+
+  const layers = layout.layers || []
+  for (var i = 0; i < layers.length; i++) {
+    const position = layers[i].position
+    var opt = document.createElement('option')
+    opt.value = position
+    opt.innerHTML = position
+    positionEl.appendChild(opt)
+  }
+  if (currentPositionId) {
+    positionEl.value = currentPositionId
+  }
+}
+
 function setDeviceOptions({ deviceInfos, el, kind }) {
   if (!deviceInfos || deviceInfos.length === 0) {
     return
@@ -333,9 +356,10 @@ window.connect = async ({ reattach = false } = {}) => {
     }
   })
 
-  roomObj.on('layout.changed', (params) =>
+  roomObj.on('layout.changed', (params) => {
     console.debug('>> layout.changed', params)
-  )
+    loadPositions(params.layout)
+  })
 
   roomObj.on('track', (event) => console.debug('>> DEMO track', event))
 
@@ -533,6 +557,11 @@ window.unlockRoom = () => {
 
 window.changeLayout = (select) => {
   roomObj.setLayout({ name: select.value })
+}
+
+window.changePosition = (select) => {
+  roomObj.setPosition({ position: select.value })
+  currentPositionId = select.value
 }
 
 window.changeMicrophone = (select) => {

--- a/packages/core/src/memberPosition/workers.ts
+++ b/packages/core/src/memberPosition/workers.ts
@@ -131,19 +131,6 @@ export function* memberUpdatedWorker({
   yield dispatcher?.(action.type, memberUpdatedPayload, instance)
 }
 
-export const MEMBER_POSITION_COMPOUND_EVENTS = new Map<any, any>([
-  [
-    'video.member.updated',
-    [
-      'video.layout.changed',
-      // `member.joined` and `member.left` are needed to
-      // keep the member list up to date
-      'video.member.joined',
-      'video.member.left',
-    ],
-  ],
-])
-
 export const memberPositionWorker: SDKWorker<any> =
   function* memberPositionWorker({
     instance,
@@ -256,9 +243,12 @@ const initializeMemberList = (payload: VideoRoomSubscribedEventParams) => {
   const memberList: MemberEventParamsList = new Map()
 
   members.forEach((member) => {
-    memberList.set(member.id, {
+    const memberId = member.id || member.member_id!
+    const roomSessionId =
+      payload.room_session.id || payload.room_session.room_session_id!
+    memberList.set(memberId, {
       room_id: payload.room_session.room_id,
-      room_session_id: payload.room_session.id,
+      room_session_id: roomSessionId,
       // At this point we don't have `member.updated`
       // @ts-expect-error
       member,

--- a/packages/core/src/rooms/RoomSessionMember.ts
+++ b/packages/core/src/rooms/RoomSessionMember.ts
@@ -40,17 +40,14 @@ export class RoomSessionMemberAPI extends BaseComponent<RoomSessionMemberEventsH
   }
 
   get id() {
-    //@ts-ignore
     return this._payload.member.id ?? this._payload.member.member_id
   }
 
   get callId() {
-    //@ts-ignore
     return this._payload.member.call_id
   }
 
   get nodeId() {
-    //@ts-ignore
     return this._payload.member.node_id
   }
 

--- a/packages/core/src/utils/interfaces.ts
+++ b/packages/core/src/utils/interfaces.ts
@@ -355,6 +355,7 @@ export type CallFabricMethod =
   | 'call.layout.list'
   | 'call.member.list'
   | 'call.member.remove'
+  | 'call.member.position.set'
   | 'call.layout.set'
   | 'call.microphone.volume.set'
   | 'call.microphone.sensitivity.set'

--- a/packages/js/src/utils/interfaces/callFabric.ts
+++ b/packages/js/src/utils/interfaces/callFabric.ts
@@ -1,10 +1,14 @@
-import { VideoLayoutChangedEventParams } from '@signalwire/core'
+import { VideoLayoutChangedEventParams, VideoPosition } from '@signalwire/core'
 
 export interface CallFabricRoomSessionConnectionContract {
   /**
    * The layout returned from the `layout.changed` event based on the current room layout
    */
-  currentLayout: VideoLayoutChangedEventParams['layout'] | undefined
+  currentLayout: VideoLayoutChangedEventParams['layout']
+  /**
+   * The current position of the member returned from the `layout.changed` event
+   */
+  currentPosition: VideoPosition
   /**
    * Starts the call via the WebRTC connection
    *


### PR DESCRIPTION
# Description

Allow user to set the self or other member's position in the layout. 

## Type of change

- [ ] Internal refactoring
- [ ] Bug fix (bugfix - non-breaking)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Code snippets

It accepts params as `"member-id-12213": "position-name"`. For the self-member, the developer can pass the `self`, a valid `memberId` is also accpeted.

```ts
roomObj.setPositions({ positions: { self: "standard-3" } })
```
