### PR TITLE
Subscribe to chat channels on session reconnect

### DIFF
--- a/.changeset/tiny-mugs-worry.md
+++ b/.changeset/tiny-mugs-worry.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/realtime-api': minor
+---
+
+Fixed chat suscription after a websocket reconnection

--- a/packages/realtime-api/src/BaseNamespace.ts
+++ b/packages/realtime-api/src/BaseNamespace.ts
@@ -116,6 +116,19 @@ export class BaseNamespace<
     })
   }
 
+  protected _areListenersAttached(topics: string[], listeners: Listeners<T>) {
+    return topics.every((topic) =>
+      Object.entries(listeners).every(([key, listener]) => {
+        const event = prefixEvent(
+          topic,
+          this._eventMap[key as keyof Listeners<T>] as string
+        )
+        // @ts-expect-error
+        return this.emitter.listeners(event).includes(listener)
+      })
+    )
+  }
+
   protected _detachListenersWithTopics(
     topics: string[],
     listeners: Listeners<T>

--- a/packages/realtime-api/src/chat/BaseChat.test.ts
+++ b/packages/realtime-api/src/chat/BaseChat.test.ts
@@ -140,7 +140,7 @@ describe('BaseChat', () => {
         Function
       )
 
-      unsub()
+      await unsub()
       addChannelsMock.mockClear()
       
       expect(listenersMap['session.reconnecting']).toBeDefined()

--- a/packages/realtime-api/src/chat/BaseChat.test.ts
+++ b/packages/realtime-api/src/chat/BaseChat.test.ts
@@ -22,10 +22,12 @@ describe('BaseChat', () => {
         execute: jest.fn(),
         session: {
           on: jest.fn().mockImplementation((event: string, callback: ()=>void) => {
-            console.log(event, callback)
             listenersMap[event] = callback
           }),
-          removeListener: jest.fn()
+          once: jest.fn().mockImplementation((event: string, callback: ()=>void) => {
+            listenersMap[event] = callback
+          }),
+          off: jest.fn()
         }
       },
     }

--- a/packages/realtime-api/src/chat/BaseChat.test.ts
+++ b/packages/realtime-api/src/chat/BaseChat.test.ts
@@ -116,6 +116,7 @@ describe('BaseChat', () => {
       await expect(baseChat.subscribe(listenOptions)).resolves.toBeInstanceOf(
         Function
       )
+      
       expect(listenersMap['session.reconnecting']).toBeDefined()
       // simulate ws closed
       listenersMap['session.reconnecting']()
@@ -127,6 +128,33 @@ describe('BaseChat', () => {
       expect(addChannelsMock).toHaveBeenCalledTimes(2)
 
     })
+
+    it('should resubscribe only to one channel after a session reconnection', async () => {
+      const addChannelsMock = jest
+        .spyOn(baseChat, 'addChannels')
+        .mockResolvedValueOnce(null)
+
+      const unsub = await baseChat.subscribe(listenOptions);
+
+      await expect(baseChat.subscribe({...listenOptions, channels: ['channel-2']})).resolves.toBeInstanceOf(
+        Function
+      )
+
+      unsub()
+      addChannelsMock.mockClear()
+      
+      expect(listenersMap['session.reconnecting']).toBeDefined()
+      // simulate ws closed
+      listenersMap['session.reconnecting']()
+
+      expect(listenersMap['session.connected']).toBeDefined()
+      // simulate ws opened
+      listenersMap['session.connected']()
+
+      expect(addChannelsMock).toHaveBeenCalledTimes(1)
+
+    })
+
   })
 
   describe('publish', () => {

--- a/packages/realtime-api/src/chat/BaseChat.ts
+++ b/packages/realtime-api/src/chat/BaseChat.ts
@@ -47,7 +47,7 @@ export class BaseChat<
       if (this._eventMap[_key]) events.push(this._eventMap[_key] as string)
     })
 
-    // will be called if requires a new subscribe 
+    // will be called if requires a new subscribe
     const sessionReconnectedHandler = () => {
       if (this._areListenersAttached(channels, listeners as Listeners<T>)) {
         this.addChannels(channels, events).then(() =>
@@ -61,13 +61,9 @@ export class BaseChat<
       getLogger().debug(
         'session.reconnecting emitted! handling existing subscriptions'
       )
-      if (this._areListenersAttached(channels, listeners as Listeners<T>)) {
-        this._client.session.off(
-          'session.connected',
-          sessionReconnectedHandler
-        )
-        this._client.session.on('session.connected', sessionReconnectedHandler)
-      }
+      // remove the previous listener if any
+      this._client.session.off('session.connected', sessionReconnectedHandler)
+      this._client.session.once('session.connected', sessionReconnectedHandler)
     }
 
     this._client.session.on('session.reconnecting', sessionReconnectingHandler)

--- a/packages/realtime-api/src/chat/BaseChat.ts
+++ b/packages/realtime-api/src/chat/BaseChat.ts
@@ -62,7 +62,7 @@ export class BaseChat<
         'session.reconnecting emitted! handling existing subscriptions'
       )
       if (this._areListenersAttached(channels, listeners as Listeners<T>)) {
-        this._client.session.removeListener(
+        this._client.session.off(
           'session.connected',
           sessionReconnectedHandler
         )

--- a/packages/realtime-api/src/chat/BaseChat.ts
+++ b/packages/realtime-api/src/chat/BaseChat.ts
@@ -91,6 +91,10 @@ export class BaseChat<
             'session.reconnecting',
             sessionReconnectingHandler
           )
+          this._client.session.off(
+            'session.connected',
+            sessionReconnectedHandler
+          )
 
           resolve()
         } catch (error) {

--- a/packages/realtime-api/src/chat/BaseChat.ts
+++ b/packages/realtime-api/src/chat/BaseChat.ts
@@ -91,7 +91,7 @@ export class BaseChat<
           // Remove channels from the listener map
           this.removeFromListenerMap(_uuid)
 
-          this._client.session.removeListener(
+          this._client.session.off(
             'session.reconnecting',
             sessionReconnectingHandler
           )


### PR DESCRIPTION
# Description

Make the chat message subscription resilient to websocket reconections.


## Type of change

- [ ] Internal refactoring
- [ ] Bug fix (bugfix - non-breaking)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Code snippets

In case of new feature or breaking changes, please include code snippets.
