### PR TITLE
use topic instead of reference when creating relay applications

### DIFF
--- a/internal/e2e-js/tests/callfabric/relayApp.spec.ts
+++ b/internal/e2e-js/tests/callfabric/relayApp.spec.ts
@@ -26,14 +26,14 @@ test.describe('CallFabric Relay Application', () => {
       },
     })
 
-    const reference = `e2e-relay-app_${uuid()}`
+    const topic = `e2e-relay-app_${uuid()}`
     await resource.createRelayAppResource({
-      name: reference,
-      reference,
+      name: topic,
+      topic,
     })
 
     await client.voice.listen({
-      topics: [reference],
+      topics: [topic],
       onCallReceived: async (call) => {
         try {
           console.log('Call received', call.id)
@@ -61,7 +61,7 @@ test.describe('CallFabric Relay Application', () => {
     await createCFClient(page)
 
     await dialAddress(page, {
-      address: `/private/${reference}`,
+      address: `/private/${topic}`,
       shouldWaitForJoin: false,
       shouldStartCall: false,
     })
@@ -135,14 +135,14 @@ test.describe('CallFabric Relay Application', () => {
       },
     })
 
-    const reference = `e2e-relay-app_${uuid()}`
+    const topic = `e2e-relay-app_${uuid()}`
     await resource.createRelayAppResource({
-      name: reference,
-      reference,
+      name: topic,
+      topic,
     })
 
     await client.voice.listen({
-      topics: [reference],
+      topics: [topic],
       onCallReceived: async (call) => {
         try {
           console.log('Call received', call.id)
@@ -166,7 +166,7 @@ test.describe('CallFabric Relay Application', () => {
     await createCFClient(page)
 
     await dialAddress(page, {
-      address: `/private/${reference}`,
+      address: `/private/${topic}`,
       shouldWaitForJoin: false,
       shouldStartCall: false,
     })
@@ -249,14 +249,14 @@ test.describe('CallFabric Relay Application', () => {
       },
     })
 
-    const reference = `e2e-relay-app_${uuid()}`
+    const topic = `e2e-relay-app_${uuid()}`
     await resource.createRelayAppResource({
-      name: reference,
-      reference,
+      name: topic,
+      topic,
     })
 
     await client.voice.listen({
-      topics: [reference],
+      topics: [topic],
       onCallReceived: async (call) => {
         try {
           console.log('Call received', call.id)
@@ -278,7 +278,7 @@ test.describe('CallFabric Relay Application', () => {
     await createCFClient(page)
 
     await dialAddress(page, {
-      address: `/private/${reference}`,
+      address: `/private/${topic}`,
       shouldWaitForJoin: false,
       shouldStartCall: false,
     })

--- a/internal/e2e-js/utils.ts
+++ b/internal/e2e-js/utils.ts
@@ -1151,11 +1151,11 @@ export const createSWMLAppResource = async ({
 
 export interface CreateRelayAppResourceParams {
   name?: string
-  reference: string
+  topic: string
 }
 export const createRelayAppResource = async ({
   name,
-  reference,
+  topic,
 }: CreateRelayAppResourceParams) => {
   const response = await fetch(
     `https://${process.env.API_HOST}/api/fabric/resources/relay_applications`,
@@ -1167,7 +1167,7 @@ export const createRelayAppResource = async ({
       },
       body: JSON.stringify({
         name: name ?? `e2e-relay-app_${uuid()}`,
-        reference,
+        topic,
       }),
     }
   )

--- a/internal/e2e-realtime-api/src/utils.ts
+++ b/internal/e2e-realtime-api/src/utils.ts
@@ -62,7 +62,7 @@ const apiFetch = async (url: string, options: RequestInit) => {
 
 interface CreateRelayAppResourceParams {
   name: string
-  reference: string
+  topic: string
 }
 export const createRelayAppResource = async (
   params: CreateRelayAppResourceParams
@@ -231,7 +231,7 @@ export const createTestRunner = ({
           // Create a relay application resource
           relayApp = await createRelayAppResource({
             name: relayAppName,
-            reference: context,
+            topic: context,
           })
 
           // Assign a Relay App resource as a call handler on a Domain App


### PR DESCRIPTION
# Description

The interface for a POST to `/api/fabri/resources/relay_applications` has changed, and now requires `topic` instead of `reference`. 

## Type of change

- [ ] Internal refactoring
- [x] Bug fix (bugfix - non-breaking)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Code snippets

In case of new feature or breaking changes, please include code snippets.
