### PR TITLE
Expose `withAudio` and `withVideo` from the `BaseConnection`

### DIFF
--- a/.changeset/early-pots-wink.md
+++ b/.changeset/early-pots-wink.md
@@ -1,0 +1,6 @@
+---
+'@signalwire/webrtc': minor
+'@signalwire/core': minor
+---
+
+Browser SDKs: Expose the `withAudio` and `withVideo` flags to indicate the receiving media.

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -60,13 +60,17 @@ export interface BaseConnectionContract<
   readonly cameraId: string | null
   /** The label of the video device, or null if not available */
   readonly cameraLabel: string | null
+  /** Provides access to the local [MediaStream](https://developer.mozilla.org/en-US/docs/Web/API/MediaStream) */
+  readonly localStream: MediaStream | undefined
+  /** Indicates if there is any receiving audio */
+  readonly withAudio: boolean
+  /** Indicates if there is any receiving video */
+  readonly withVideo: boolean
   /**
    * Provides access to the local audio
    * [MediaStreamTrack](https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamTrack).
    */
   readonly localAudioTrack: MediaStreamTrack | null
-  /** Provides access to the local [MediaStream](https://developer.mozilla.org/en-US/docs/Web/API/MediaStream) */
-  readonly localStream: MediaStream | undefined
   /**
    * Provides access to the local video
    * [MediaStreamTrack](https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamTrack).

--- a/packages/webrtc/src/BaseConnection.ts
+++ b/packages/webrtc/src/BaseConnection.ts
@@ -203,7 +203,7 @@ export class BaseConnection<EventTypes extends EventEmitter.ValidEventTypes>
   dialogParams(rtcPeerId: string) {
     const {
       destinationNumber,
-      attach, 
+      attach,
       callerName,
       callerNumber,
       remoteCallerName,
@@ -249,22 +249,20 @@ export class BaseConnection<EventTypes extends EventEmitter.ValidEventTypes>
     return this.peer ? this.peer.getDeviceLabel('audio') : null
   }
 
-  /** @internal */
   get withAudio() {
     return Boolean(this.peer?.hasAudioReceiver)
   }
 
-  /** @internal */
   get withVideo() {
     return Boolean(this.peer?.hasVideoReceiver)
   }
 
-  get localVideoTrack() {
-    return this.peer ? this.peer.localVideoTrack : null
-  }
-
   get localAudioTrack() {
     return this.peer ? this.peer.localAudioTrack : null
+  }
+
+  get localVideoTrack() {
+    return this.peer ? this.peer.localVideoTrack : null
   }
 
   get peer() {


### PR DESCRIPTION
# Description

Return boolean flags  `withAudio` and `withVideo` to indicate the receiving media flow from both `CallFabricRoomSession` and `Video.RoomSession`.

## Type of change

- [ ] Internal refactoring
- [ ] Bug fix (bugfix - non-breaking)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Code snippets

```ts
room.withAudio // Indicate if the room has any audio receiver

room.withVideo // Indicate if the room has any video receiver
```