### PR TITLE
Remove the `videoElement` test from the `default` Playwright project

### DIFF
--- a/internal/e2e-js/playwright.config.ts
+++ b/internal/e2e-js/playwright.config.ts
@@ -9,12 +9,6 @@ const streamingTests = [
   'roomSessionAutomaticStream.spec.ts',
 ]
 const badNetworkTests = ['roomSessionBadNetwork.spec.ts']
-const audienceTests = [
-  'roomSessionAudienceCount.spec.ts',
-  'roomSessionFollowLeader.spec.ts',
-  'roomSessionTalkingEventsToAudience.spec.ts',
-  'roomSessionUnauthorized.spec.ts',
-]
 const promoteTests = [
   'roomSessionPromoteDemote.spec.ts',
   'roomSessionPromoteMeta.spec.ts',
@@ -26,6 +20,12 @@ const demoteTests = [
   'roomSessionDemoteAudience.spec.ts',
   'roomSessionDemoteReattachPromote.spec.ts',
   'roomSessionDemotePromote.spec.ts',
+]
+const audienceTests = [
+  'roomSessionAudienceCount.spec.ts',
+  'roomSessionFollowLeader.spec.ts',
+  'roomSessionTalkingEventsToAudience.spec.ts',
+  'roomSessionUnauthorized.spec.ts',
 ]
 const reattachTests = [
   'roomSessionReattach.spec.ts',
@@ -45,11 +45,11 @@ const callfabricTests = [
   'videoRoom.spec.ts',
   'videoRoomLayout.spec.ts',
 ]
-const v2WebRTC = ['v2WebrtcFromRest.spec.ts', 'webrtcCalling.spec.ts']
 const videoElementTests = [
   'buildVideoWithVideoSdk.spec.ts',
   'buildVideoWithCFSdk.spec.ts',
 ]
+const v2WebRTC = ['v2WebrtcFromRest.spec.ts', 'webrtcCalling.spec.ts']
 
 const useDesktopChrome = {
   ...devices['Desktop Chrome'],
@@ -89,6 +89,7 @@ const config: PlaywrightTestConfig = {
         ...audienceTests,
         ...reattachTests,
         ...callfabricTests,
+        ...videoElementTests,
         ...v2WebRTC,
       ],
     },


### PR DESCRIPTION
# Description

The `videoElement` tests were running twice through `videoElement` project and a `default` project.

I have removed these tests from the `default` project. 

## Type of change

- [x] Internal refactoring
- [ ] Bug fix (bugfix - non-breaking)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Code snippets

In case of new feature or breaking changes, please include code snippets.
