### PR TITLE
Introduce a custom reporter for Playwright

### DIFF
--- a/internal/e2e-js/SDKReporter.ts
+++ b/internal/e2e-js/SDKReporter.ts
@@ -10,8 +10,7 @@ import type {
 } from '@playwright/test/reporter'
 
 /**
- * A fully custom reporter that implements Playwright Reporter interface methods.
- * It prints logs similar to "normal" test events without delegating to any built-in reporter.
+ * A custom SDK reporter that implements Playwright Reporter interface methods.
  */
 export default class SDKReporter implements Reporter {
   private totalTests = 0
@@ -22,8 +21,7 @@ export default class SDKReporter implements Reporter {
   private timedOutTests = 0
 
   /**
-   * Called once before running tests. All tests have been already discovered
-   * and put into a hierarchy of `Suite`s.
+   * Called once before running tests.
    */
   onBegin(_config: FullConfig, suite: Suite): void {
     this.totalTests = suite.allTests().length
@@ -33,10 +31,10 @@ export default class SDKReporter implements Reporter {
   }
 
   /**
-   * Called after all tests have run, or the run was interrupted. (Can be async.)
+   * Called after all tests have run, or the run was interrupted.
    */
   async onEnd(result: FullResult): Promise<void> {
-    console.log('\n')
+    console.log('\n\n')
     console.log('============================================')
     console.log(`Test run finished with status: ${result.status.toUpperCase()}`)
     console.log('--------------------------------------------')
@@ -46,11 +44,11 @@ export default class SDKReporter implements Reporter {
     console.log(`Skipped:        ${this.skippedTests}`)
     console.log(`Timed Out:      ${this.timedOutTests}`)
     console.log('============================================')
-    console.log('\n')
+    console.log('\n\n')
   }
 
   /**
-   * Called on a global error, for example an unhandled exception in the worker.
+   * Called on a global error, for example an unhandled exception in the test.
    */
   onError(error: TestError): void {
     console.log('============================================')
@@ -62,9 +60,9 @@ export default class SDKReporter implements Reporter {
   /**
    * Called immediately before the test runner exits, after onEnd() and all
    * reporters have finished.
+   * If required: upload logs to a server here.
    */
   async onExit(): Promise<void> {
-    // If required: upload logs to a server here.
     console.log('[SDKReporter] Exit')
   }
 

--- a/internal/e2e-js/SDKReporter.ts
+++ b/internal/e2e-js/SDKReporter.ts
@@ -1,0 +1,144 @@
+import type {
+  Reporter,
+  FullConfig,
+  Suite,
+  TestCase,
+  TestResult,
+  FullResult,
+  TestError,
+  TestStep,
+} from '@playwright/test/reporter'
+
+/**
+ * A fully custom reporter that implements Playwright Reporter interface methods.
+ * It prints logs similar to "normal" test events without delegating to any built-in reporter.
+ */
+export default class SDKReporter implements Reporter {
+  private totalTests = 0
+  private completedTests = 0
+  private failedTests = 0
+  private passedTests = 0
+  private skippedTests = 0
+  private timedOutTests = 0
+
+  /**
+   * Called once before running tests. All tests have been already discovered
+   * and put into a hierarchy of `Suite`s.
+   */
+  onBegin(_config: FullConfig, suite: Suite): void {
+    this.totalTests = suite.allTests().length
+    console.log('============================================')
+    console.log(`Starting the run with ${this.totalTests} tests...`)
+    console.log('============================================')
+  }
+
+  /**
+   * Called after all tests have run, or the run was interrupted. (Can be async.)
+   */
+  async onEnd(result: FullResult): Promise<void> {
+    console.log('\n')
+    console.log('============================================')
+    console.log(`Test run finished with status: ${result.status.toUpperCase()}`)
+    console.log('--------------------------------------------')
+    console.log(`Total Tests:    ${this.totalTests}`)
+    console.log(`Passed:         ${this.passedTests}`)
+    console.log(`Failed:         ${this.failedTests}`)
+    console.log(`Skipped:        ${this.skippedTests}`)
+    console.log(`Timed Out:      ${this.timedOutTests}`)
+    console.log('============================================')
+    console.log('\n')
+  }
+
+  /**
+   * Called on a global error, for example an unhandled exception in the worker.
+   */
+  onError(error: TestError): void {
+    console.log('============================================')
+    console.log(`Global Error: ${error.message}`)
+    console.log(error)
+    console.log('============================================')
+  }
+
+  /**
+   * Called immediately before the test runner exits, after onEnd() and all
+   * reporters have finished.
+   */
+  async onExit(): Promise<void> {
+    // If required: upload logs to a server here.
+    console.log('[SDKReporter] Exit')
+  }
+
+  /**
+   * Called when a test step (i.e., `test.step(...)`) begins in the worker.
+   */
+  onStepBegin(_test: TestCase, _result: TestResult, step: TestStep): void {
+    /**
+     * Playwright creates some internal steps as well.
+     * We do not care about those steps.
+     * We only log our own custom test steps.
+     */
+    if (step.category === 'test.step') {
+      console.log(`--- STEP BEGIN: "${step.title}"`)
+    }
+  }
+
+  /**
+   * Called when a test step finishes.
+   */
+  onStepEnd(_test: TestCase, _result: TestResult, step: TestStep): void {
+    if (step.category === 'test.step') {
+      if (step.error) {
+        console.log(`--- STEP FAILED: "${step.title}"`)
+        console.log(step.error)
+      } else {
+        console.log(`--- STEP FINISHED: "${step.title}"`)
+      }
+    }
+  }
+
+  /**
+   * Called when a test begins in the worker process.
+   */
+  onTestBegin(test: TestCase, _result: TestResult): void {
+    console.log('--------------------------------------------')
+    console.log(`⏯️ Test Started: ${test.title}`)
+    console.log('--------------------------------------------')
+  }
+
+  /**
+   * Called when a test ends (pass, fail, timeout, etc.).
+   */
+  onTestEnd(test: TestCase, result: TestResult): void {
+    console.log('--------------------------------------------')
+    this.completedTests += 1
+    switch (result.status) {
+      case 'passed':
+        this.passedTests += 1
+        console.log(`✅ Test Passed: ${test.title}`)
+        break
+      case 'failed':
+        this.failedTests += 1
+        console.log(`❌ Test Failed: ${test.title}`)
+        if (result.error) {
+          console.log(`📧 Error: ${result.error.message}`)
+          if (result.error.stack) {
+            console.log(`📚 Stack: ${result.error.stack}`)
+          }
+        }
+        break
+      case 'timedOut':
+        this.timedOutTests += 1
+        console.log(`⏰ Test Timed Out: ${test.title}`)
+        break
+      case 'skipped':
+        this.skippedTests += 1
+        console.log(`↩️ Test Skipped: ${test.title}`)
+        break
+      default:
+        console.log(`Test Ended with status "${result.status}": ${test.title}`)
+        break
+    }
+    console.log('--------------------------------------------')
+    console.log('\n\n')
+  }
+}

--- a/internal/e2e-js/SDKReporter.ts
+++ b/internal/e2e-js/SDKReporter.ts
@@ -141,4 +141,12 @@ export default class SDKReporter implements Reporter {
     console.log('--------------------------------------------')
     console.log('\n\n')
   }
+
+  /**
+   * Indicates this reporter does not handle stdout and stderr printing.
+   * So that Playwright print those logs.
+   */
+  printsToStdio(): boolean {
+    return false
+  }
 }

--- a/internal/e2e-js/fixtures.ts
+++ b/internal/e2e-js/fixtures.ts
@@ -57,7 +57,10 @@ const test = baseTest.extend<CustomFixture>({
     try {
       await use(maker)
     } finally {
+      console.log('====================================')
       console.log('Cleaning up pages..')
+      console.log('====================================')
+
       /**
        * If we have a __roomObj in the page means we tested the Video/Fabric APIs
        * so we must leave the room.
@@ -75,6 +78,8 @@ const test = baseTest.extend<CustomFixture>({
        * Make sure we cleanup the client as well.
        */
       await Promise.all(context.pages().map(disconnectClient))
+
+      await context.close()
     }
   },
   createCustomVanillaPage: async ({ context }, use) => {
@@ -112,7 +117,10 @@ const test = baseTest.extend<CustomFixture>({
     try {
       await use(resource)
     } finally {
+      console.log('====================================')
       console.log('Cleaning up resources..')
+      console.log('====================================')
+
       // Clean up resources after use
       const deleteResources = resources.map(async (resource) => {
         try {

--- a/internal/e2e-js/playwright.config.ts
+++ b/internal/e2e-js/playwright.config.ts
@@ -65,18 +65,19 @@ const useDesktopChrome = {
 
 const config: PlaywrightTestConfig = {
   testDir: 'tests',
-  reporter: process.env.CI ? 'github' : 'list',
+  reporter: [[process.env.CI ? 'github' : 'list'], ['./SDKReporter.ts']],
   globalSetup: require.resolve('./global-setup'),
   testMatch: undefined,
   testIgnore: undefined,
   timeout: 120_000,
+  workers: 1,
+  maxFailures: 1,
   expect: {
     // Default is 5000
     timeout: 10_000,
   },
   // Forbid test.only on CI
   forbidOnly: !!process.env.CI,
-  workers: 1,
   projects: [
     {
       name: 'default',


### PR DESCRIPTION
# Description

This PR includes:
1. A custom reporter for the Playwright end-to-end test for the Browser SDKs. 
2. Set maxFailures to 1 in the Playwright config so that the failed test is the last one on the logs which makes it easier to debug.
3. Clean the context before moving to the next test.

## Type of change

- [x] Internal refactoring
- [ ] Bug fix (bugfix - non-breaking)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Code snippets

In case of new feature or breaking changes, please include code snippets.
