### PR TITLE
Min/browser sdk room settings e2e fix

### DIFF
--- a/.changeset/ninety-schools-own.md
+++ b/.changeset/ninety-schools-own.md
@@ -1,0 +1,5 @@
+---
+'@sw-internal/e2e-js': patch
+---
+
+fixed flakey roomSettings.spec.ts

--- a/internal/e2e-js/tests/roomSettings.spec.ts
+++ b/internal/e2e-js/tests/roomSettings.spec.ts
@@ -75,8 +75,8 @@ test.describe('Room Settings', () => {
         initialEvents: [],
       })
 
-      // --------------- Joining the room or wait for recording.started event---------------
-      const params = await Promise.race([
+      // --------------- wait for room.joined or recording.started event---------------
+      let params = await Promise.race([
         expectRoomJoined(page),
         expectRecordingStarted(page)
       ])

--- a/internal/e2e-js/tests/roomSettings.spec.ts
+++ b/internal/e2e-js/tests/roomSettings.spec.ts
@@ -7,6 +7,7 @@ import {
   CreateOrUpdateRoomOptions,
   randomizeRoomName,
   expectRoomJoined,
+  expectRecordingStarted,
 } from '../utils'
 
 interface TestConfig {
@@ -34,9 +35,22 @@ test.describe('Room Settings', () => {
       roomSettings: {
         record_on_start: true,
       },
-      expect: (joinParams) => {
-        expect(joinParams.room_session.recording).toEqual(true)
-        expect(joinParams.room.recording).toEqual(true)
+      expect: (params) => {
+        // match either room.joined or recording.started events
+        try {
+          expect(params).toEqual(expect.objectContaining({
+            room_session: expect.objectContaining({
+              recording: true
+            }),
+            room: expect.objectContaining({
+              recording: true
+            })
+          }))
+        } catch(_e) {
+          expect(params).toEqual(expect.objectContaining({
+            state: 'recording'
+          }))
+        }
       },
     },
   ]
@@ -61,11 +75,13 @@ test.describe('Room Settings', () => {
         initialEvents: [],
       })
 
-      // --------------- Joining the room ---------------
-      const joinParams = await expectRoomJoined(page)
-
+      // --------------- Joining the room or wait for recording.started event---------------
+      const params = await Promise.race([
+        expectRoomJoined(page),
+        expectRecordingStarted(page)
+      ])
       // Run custom expectations for each run
-      row.expect(joinParams)
+      row.expect(params)
 
       await deleteRoom(roomData.id)
     })


### PR DESCRIPTION
# Description

`internal/e2e-js/tests/roomSettings.spec.ts`'s `should set auto-record and start recording` test is failing time to time because there's race condition in FS depending on whether it starts the recording first and then sends out  `liveArray.add` (video.room.subscribedon SDK side) or sends out `liveArray.add` event first and then start the recording. When the test ran into the former case we have no issue, but if it ran into the latter, `video.room.subscribed`doesn't have `room/room_session.recording: true` since the test is asserting for those it's failing. In order to refactor that I updated the test to wait on either of `video.room.subscribed` or `recoring.started` event and do the different asserts depending on the event payload.

## Type of change

- [ ] Internal refactoring
- [x] Bug fix (bugfix - non-breaking)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Code snippets

In case of new feature or breaking changes, please include code snippets.
