### PR TITLE
CF SDK: Pass complete destination address

### DIFF
--- a/.changeset/sweet-birds-drop.md
+++ b/.changeset/sweet-birds-drop.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/js': patch
+---
+
+CF SDK: Pass complete destination resource address

--- a/packages/js/src/fabric/WSClient.ts
+++ b/packages/js/src/fabric/WSClient.ts
@@ -181,7 +181,7 @@ export class WSClient extends BaseClient<{}> implements WSClientContract {
       stopCameraWhileMuted: true,
       stopMicrophoneWhileMuted: true,
       watchMediaPackets: false,
-      destinationNumber: pathname,
+      destinationNumber: params.to,
       nodeId: params.nodeId,
       attach: params.attach ?? false,
       disableUdpIceServers: params.disableUdpIceServers || false,


### PR DESCRIPTION
# Description

The SDK was sending only the resource name to the server when initiating the call.

This PR allows the SDK to send the complete resource address including the query. 

## Type of change

- [x] Internal refactoring
- [ ] Bug fix (bugfix - non-breaking)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Code snippets

In case of new feature or breaking changes, please include code snippets.
