### PR TITLE
Fix the ESBuild for each package

### DIFF
--- a/scripts/sw-build/index.js
+++ b/scripts/sw-build/index.js
@@ -33,6 +33,7 @@ const COMMON_WEB = {
   bundle: true,
   plugins: [nodeExternalsPlugin()],
 }
+
 const OPTIONS_MAP = {
   '--node': [
     {
@@ -302,16 +303,22 @@ const mergeOptions = (options, defaultOptions = {}) => {
  */
 const build = async ({ options, setupFile }) => {
   return Promise.all(
-    options.map((opt) => {
+    options.map(async (opt) => {
       // `esbuild` can't generate `umd` so we'll skip it here.
       if (opt.format === 'umd') {
         return Promise.resolve()
       }
 
-      return esbuild.build({
-        ...opt,
-        ...setupFile,
-      })
+      // If watch mode is requested (i.e. in dev mode), we need to use esbuild context API
+      if (opt.watch) {
+        const { watch, ...optWithoutWatch } = opt
+        const ctx = await esbuild.context({ ...optWithoutWatch, ...setupFile })
+        await ctx.watch()
+        return ctx
+      } else {
+        // For production builds, we use esbuild.build()
+        return esbuild.build({ ...opt, ...setupFile })
+      }
     })
   )
 }


### PR DESCRIPTION
# Description

The latest version of the `esbuild` has removed the `watch` more from the API and recommends using the new `context` API.

This PR is making that change for the `--dev` mode flag.

## Type of change

- [ ] Internal refactoring
- [x] Bug fix (bugfix - non-breaking)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Code snippets

In case of new feature or breaking changes, please include code snippets.
