### PR TITLE
CF & Video SDKs: Introduce Hold/Unhold APIs

### DIFF
--- a/.changeset/proud-rabbits-sing.md
+++ b/.changeset/proud-rabbits-sing.md
@@ -1,0 +1,14 @@
+---
+'@signalwire/webrtc': minor
+'@signalwire/core': minor
+---
+
+CF & Video SDK: Introduce the hold/unhold API
+
+```ts
+// To hold the call
+await call.hold()
+
+// To unhold the call
+await call.unhold()
+```

--- a/internal/e2e-js/playwright.config.ts
+++ b/internal/e2e-js/playwright.config.ts
@@ -39,6 +39,7 @@ const callfabricTests = [
   'address.spec.ts',
   'cleanup.spec.ts',
   'conversation.spec.ts',
+  'holdunhold.spec.ts',
   'raiseHand.spec.ts',
   'reattach.spec.ts',
   'relayApp.spec.ts',

--- a/internal/e2e-js/tests/callfabric/holdunhold.spec.ts
+++ b/internal/e2e-js/tests/callfabric/holdunhold.spec.ts
@@ -1,0 +1,89 @@
+import { uuid } from '@signalwire/core'
+import { FabricRoomSession } from '@signalwire/js'
+import { test, expect } from '../../fixtures'
+import {
+  createCFClient,
+  dialAddress,
+  expectMCUVisible,
+  expectStatWithPolling,
+  getStats,
+  SERVER_URL,
+  waitForStabilizedStats,
+} from '../../utils'
+
+test.describe('CallFabric Hold/Unhold Call', () => {
+  test('should dial a call and be able to hold/unhold the call', async ({
+    createCustomPage,
+    resource,
+  }) => {
+    const pageOne = await createCustomPage({ name: '[page-one]' })
+    const pageTwo = await createCustomPage({ name: '[page-two]' })
+    await pageOne.goto(SERVER_URL)
+    await pageTwo.goto(SERVER_URL)
+
+    const roomName = `e2e-hold-unhold_${uuid()}`
+    await resource.createVideoRoomResource(roomName)
+
+    await test.step('[page-one] should create a client and dial a call', async () => {
+      await createCFClient(pageOne)
+      await dialAddress(pageOne, {
+        address: `/public/${roomName}?channel=video`,
+      })
+      await expectMCUVisible(pageOne)
+    })
+
+    await test.step('[page-two] should create a client and dial a call', async () => {
+      await createCFClient(pageTwo)
+      await dialAddress(pageTwo, {
+        address: `/public/${roomName}?channel=video`,
+      })
+      await expectMCUVisible(pageTwo)
+    })
+
+    await test.step('[page-one] should have incoming/outgoing audio/video streams', async () => {
+      const stats = await getStats(pageOne)
+      expect(stats.outboundRTP.audio?.packetsSent).toBeGreaterThan(0)
+      expect(stats.inboundRTP.audio?.packetsReceived).toBeGreaterThan(0)
+      expect(stats.outboundRTP.video?.packetsSent).toBeGreaterThan(0)
+      expect(stats.inboundRTP.video?.packetsReceived).toBeGreaterThan(0)
+    })
+
+    await test.step('[page-one] should hold the call', async () => {
+      await pageOne.evaluate(async () => {
+        // @ts-expect-error
+        const roomObj: FabricRoomSession = window._roomObj
+        await roomObj.hold()
+      })
+    })
+
+    await test.step('[page-one] should have stopped receiving audio/video streams', async () => {
+      await waitForStabilizedStats(pageOne, {
+        propertyPath: 'inboundRTP.audio.packetsReceived',
+      })
+      await waitForStabilizedStats(pageOne, {
+        propertyPath: 'inboundRTP.video.packetsReceived',
+      })
+    })
+
+    await test.step('[page-one] should uhold the call', async () => {
+      await pageOne.evaluate(async () => {
+        // @ts-expect-error
+        const roomObj: FabricRoomSession = window._roomObj
+        await roomObj.unhold()
+      })
+    })
+
+    await test.step('[page-one] should have resumed receiving audio/video streams', async () => {
+      await expectStatWithPolling(pageOne, {
+        propertyPath: 'inboundRTP.audio.packetsReceived',
+        matcher: 'toBeGreaterThan',
+        expected: 0,
+      })
+      await expectStatWithPolling(pageOne, {
+        propertyPath: 'inboundRTP.video.packetsReceived',
+        matcher: 'toBeGreaterThan',
+        expected: 0,
+      })
+    })
+  })
+})

--- a/internal/e2e-js/tests/callfabric/raiseHand.spec.ts
+++ b/internal/e2e-js/tests/callfabric/raiseHand.spec.ts
@@ -5,7 +5,7 @@ import {
   dialAddress,
   expectMCUVisible,
   SERVER_URL,
-} from 'internal/e2e-js/utils'
+} from '../../utils'
 import { FabricRoomSession } from '@signalwire/js'
 
 test.describe('CallFabric Raise/Lower Hand', () => {

--- a/internal/playground-js/src/fabric/index.html
+++ b/internal/playground-js/src/fabric/index.html
@@ -250,6 +250,25 @@
                 </button>
               </div>
 
+              <div class="btn-group w-100" role="group">
+                <button
+                  id="holdCallBtn"
+                  class="btn btn-warning px-3 mt-2"
+                  onClick="holdCall()"
+                  disabled="true"
+                >
+                  Hold call
+                </button>
+                <button
+                  id="unholdCallBtn"
+                  class="btn btn-warning px-3 mt-2"
+                  onClick="unholdCall()"
+                  disabled="true"
+                >
+                  Unhold call
+                </button>
+              </div>
+
               <h5 class="mt-3" for="layout">Layouts</h5>
               <div class="col-12">
                 <label for="layout" class="form-label">Layout for room</label>

--- a/internal/playground-js/src/fabric/index.js
+++ b/internal/playground-js/src/fabric/index.js
@@ -42,6 +42,8 @@ const inCallElements = [
   showVMutedBtn,
   lockRoomBtn,
   unlockRoomBtn,
+  holdCallBtn,
+  unholdCallBtn,
   hideScreenShareBtn,
   showScreenShareBtn,
   controlRecording,
@@ -642,6 +644,14 @@ window.lockRoom = () => {
 
 window.unlockRoom = () => {
   roomObj.unlock()
+}
+
+window.holdCall = () => {
+  roomObj.hold()
+}
+
+window.unholdCall = () => {
+  roomObj.unhold()
 }
 
 window.changeLayout = (select) => {

--- a/packages/core/src/RPCMessages/VertoMessages.ts
+++ b/packages/core/src/RPCMessages/VertoMessages.ts
@@ -66,7 +66,7 @@ export const VertoResult = (id: string, method: VertoMethod) => {
 export interface VertoModifyResponse {
   action: string
   callID: string
-  holdState: 'hold' | 'active'
-  node_id: string
-  sdp: string
+  holdState: 'held' | 'active'
+  node_id?: string
+  sdp?: string
 }

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -166,6 +166,11 @@ export interface BaseConnectionContract<
    * @param params - {@link UpdateMediaParams}
    *
    * @returns A Promise that resolves once the requested media is negotiated or failed.
+   *
+   * @example
+   * ```typescript
+   * room.updateMedia({ video: { direction: 'sendrecv' } })
+   * ```
    */
   updateMedia(params: UpdateMediaParams): Promise<void>
 
@@ -176,6 +181,11 @@ export interface BaseConnectionContract<
    * @param params - {@link UpdateMediaDirection}
    *
    * @returns A Promise that resolves once the requested audio is negotiated or failed.
+   *
+   * @example
+   * ```typescript
+   * room.setAudioDirection('sendrecv')
+   * ```
    */
   setAudioDirection(direction: UpdateMediaDirection): Promise<void>
 
@@ -186,8 +196,39 @@ export interface BaseConnectionContract<
    * @param params - {@link UpdateMediaDirection}
    *
    * @returns A Promise that resolves once the requested video is negotiated or failed.
+   *
+   * @example
+   * ```typescript
+   * room.setVideoDirection('recvonly')
+   * ```
    */
   setVideoDirection(direction: UpdateMediaDirection): Promise<void>
+
+  /**
+   * Hold the call.
+   * It stops the self member's outbound video/audio and other member's inbound video/audio.
+   *
+   * @returns A Promise that resolves once the hold state is acheived.
+   *
+   * @example
+   * ```typescript
+   * room.hold()
+   * ```
+   */
+  hold(): Promise<void>
+
+  /**
+   * Unhold the call.
+   * It resumes the self member's outbound video/audio and other member's inbound video/audio.
+   *
+   * @returns A Promise that resolves once the active call state is acheived.
+   *
+   * @example
+   * ```typescript
+   * room.unhold()
+   * ```
+   */
+  unhold(): Promise<void>
 
   /** @internal */
   stopOutboundAudio(): void

--- a/packages/webrtc/src/BaseConnection.ts
+++ b/packages/webrtc/src/BaseConnection.ts
@@ -330,7 +330,6 @@ export class BaseConnection<
   }
 
   /**
-   * @internal
    * Verto messages have to be wrapped into an execute
    * request and sent using the proper RPC WebRTCMethod.
    */
@@ -848,9 +847,8 @@ export class BaseConnection<
    *   - requesting: we received a redirectDestination so need to send it again
    *     specifying nodeId.
    *
-   * @internal
    */
-  async executeInvite(sdp: string, rtcPeerId: string, nodeId?: string) {
+  private async executeInvite(sdp: string, rtcPeerId: string, nodeId?: string) {
     const rtcPeer = this.getRTCPeerById(rtcPeerId)
     if (!rtcPeer || (rtcPeer.instance.remoteDescription && !this.resuming)) {
       throw new Error(
@@ -904,9 +902,8 @@ export class BaseConnection<
   /**
    * Send the `verto.answer` only if the state is `new`
    *   - new: the first time we send out the answer.
-   * @internal
    */
-  async executeAnswer(sdp: string, rtcPeerId: string, nodeId?: string) {
+  private async executeAnswer(sdp: string, rtcPeerId: string, nodeId?: string) {
     // Set state to `answering` only when `new`, otherwise keep it as `answering`.
     if (this.state === 'new') {
       this.setState('answering')
@@ -937,9 +934,8 @@ export class BaseConnection<
   /**
    * Send the `verto.modify` when it's an offer and remote is already present
    * It helps in renegotiation.
-   * @internal
    */
-  async executeUpdateMedia(sdp: string, rtcPeerId: string) {
+  private async executeUpdateMedia(sdp: string, rtcPeerId: string) {
     try {
       const message = VertoModify({
         ...this.dialogParams(rtcPeerId),
@@ -1380,6 +1376,30 @@ export class BaseConnection<
       video: {
         direction,
       },
+    })
+  }
+
+  public async hold() {
+    const message = VertoModify({
+      ...this.dialogParams(this.callId),
+      action: 'hold',
+    })
+    return await this.vertoExecute<VertoModifyResponse>({
+      message,
+      callID: this.callId,
+      node_id: this.nodeId,
+    })
+  }
+
+  public async unhold() {
+    const message = VertoModify({
+      ...this.dialogParams(this.callId),
+      action: 'unhold',
+    })
+    return this.vertoExecute<VertoModifyResponse>({
+      message,
+      callID: this.callId,
+      node_id: this.nodeId,
     })
   }
 }

--- a/packages/webrtc/src/BaseConnection.ts
+++ b/packages/webrtc/src/BaseConnection.ts
@@ -947,14 +947,17 @@ export class BaseConnection<
         callID: rtcPeerId,
         node_id: this.nodeId,
       })
-      if (!response.sdp) {
-        this.logger.error('UpdateMedia invalid SDP answer', response)
-      }
 
       this.logger.debug('UpdateMedia response', response)
+
       if (!this.peer) {
         return this.logger.error('Invalid RTCPeer to updateMedia')
       }
+
+      if (!response.sdp) {
+        return this.logger.error('UpdateMedia invalid SDP answer', response)
+      }
+
       await this.peer.onRemoteSdp(response.sdp)
     } catch (error) {
       // Should we hangup when renegotiation fails?
@@ -1384,7 +1387,7 @@ export class BaseConnection<
       ...this.dialogParams(this.callId),
       action: 'hold',
     })
-    return await this.vertoExecute<VertoModifyResponse>({
+    await this.vertoExecute<VertoModifyResponse>({
       message,
       callID: this.callId,
       node_id: this.nodeId,
@@ -1396,7 +1399,7 @@ export class BaseConnection<
       ...this.dialogParams(this.callId),
       action: 'unhold',
     })
-    return this.vertoExecute<VertoModifyResponse>({
+    this.vertoExecute<VertoModifyResponse>({
       message,
       callID: this.callId,
       node_id: this.nodeId,


### PR DESCRIPTION
# Description

Hold and Unhold APIs will allow users to hold the current call. 

## Type of change

- [ ] Internal refactoring
- [ ] Bug fix (bugfix - non-breaking)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Code snippets

```ts
// To hold the call
await call.hold()

// To unhold the call
await call.unhold()
```
