### PR TITLE
Realtime-API: Re-subscribe voice call topics after socket reconnects

### DIFF
--- a/.changeset/late-snails-care.md
+++ b/.changeset/late-snails-care.md
@@ -1,0 +1,6 @@
+---
+'@signalwire/realtime-api': patch
+'@signalwire/core': patch
+---
+
+Realtime-API: Bug Fix - Resubscribe topics/channels after WS reconnection

--- a/.changeset/late-snails-care.md
+++ b/.changeset/late-snails-care.md
@@ -4,3 +4,5 @@
 ---
 
 Realtime-API: Bug Fix - Resubscribe topics/channels after WS reconnection
+
+Realtime-API Chat: Fix type interfaces for `getMessages` and `getMembers`.

--- a/packages/core/src/BaseSession.test.ts
+++ b/packages/core/src/BaseSession.test.ts
@@ -110,7 +110,7 @@ describe('BaseSession', () => {
     session.disconnect()
   })
 
-  it.only('should dispatch reconnecting action on socket close and then call connect again', async () => {
+  it('should dispatch reconnecting action on socket close and then call connect again', async () => {
     const connectSpy = jest.spyOn(session, 'connect')
 
     session.connect()

--- a/packages/core/src/chat/applyCommonMethods.ts
+++ b/packages/core/src/chat/applyCommonMethods.ts
@@ -7,21 +7,25 @@ import { toExternalJSON } from '../utils'
 import { BaseRPCResult } from '../utils/interfaces'
 import { isValidChannels, toInternalChatChannels } from './utils'
 
-export interface GetMembersInput extends BaseRPCResult {
-  members: InternalChatMemberEntity[]
+export interface GetMembersInput {
+  channel: string
 }
 
-export interface GetMessagesInput extends BaseRPCResult {
-  messages: InternalChatMessageEntity[]
-  cursor: PaginationCursor
+export interface GetMessagesInput {
+  channel: string
 }
 
 interface ChatMemberMethodParams extends Record<string, unknown> {
   memberId?: string
 }
 
-interface GetMemberStateOutput {
-  channels: any
+interface GetMembersOutput extends BaseRPCResult {
+  members: InternalChatMemberEntity[]
+}
+
+export interface GetMessagesOutput extends BaseRPCResult {
+  messages: InternalChatMessageEntity[]
+  cursor: PaginationCursor
 }
 
 const transformParamChannels = (params: ChatMemberMethodParams) => {
@@ -48,7 +52,7 @@ export function applyCommonMethods<T extends new (...args: any[]) => any>(
           params,
         },
         {
-          transformResolve: (payload: GetMembersInput) => ({
+          transformResolve: (payload: GetMembersOutput) => ({
             members: payload.members.map((member) => toExternalJSON(member)),
           }),
         }
@@ -62,7 +66,7 @@ export function applyCommonMethods<T extends new (...args: any[]) => any>(
           params,
         },
         {
-          transformResolve: (payload: GetMessagesInput) => ({
+          transformResolve: (payload: GetMessagesOutput) => ({
             messages: payload.messages.map((message) =>
               toExternalJSON(message)
             ),
@@ -98,7 +102,7 @@ export function applyCommonMethods<T extends new (...args: any[]) => any>(
           },
         },
         {
-          transformResolve: (payload: GetMemberStateOutput) => ({
+          transformResolve: (payload: GetMembersOutput) => ({
             channels: payload.channels,
           }),
           transformParams: transformParamChannels,

--- a/packages/realtime-api/src/BaseNamespace.ts
+++ b/packages/realtime-api/src/BaseNamespace.ts
@@ -41,7 +41,6 @@ export class BaseNamespace<
   private onSessionDisconnect() {
     this._client.session.off('session.reconnecting', this.onSessionReconnect)
     this._client.destroy()
-    this.unsubscribeAll()
   }
 
   protected addTopics(topics: string[]) {

--- a/packages/realtime-api/src/BaseNamespace.ts
+++ b/packages/realtime-api/src/BaseNamespace.ts
@@ -32,7 +32,7 @@ export class BaseNamespace<
         topics?.forEach((topic) => resendTopics.add(topic))
       }
       if (resendTopics.size > 0) {
-        getLogger().info('Re-subscribing channels after reconnection')
+        getLogger().info('Re-subscribing topics after reconnection')
         await this.addTopics([...resendTopics])
       }
     })

--- a/packages/realtime-api/src/SWClient.test.ts
+++ b/packages/realtime-api/src/SWClient.test.ts
@@ -22,6 +22,11 @@ describe('SWClient', () => {
       disconnect: jest.fn(),
       runWorker: jest.fn(),
       sessionEmitter: { on: jest.fn() },
+      session: {
+        on: jest.fn(),
+        once: jest.fn(),
+        off: jest.fn(),
+      },
     }
     ;(createClient as any).mockReturnValue(clientMock)
 

--- a/packages/realtime-api/src/messaging/Messaging.test.ts
+++ b/packages/realtime-api/src/messaging/Messaging.test.ts
@@ -16,6 +16,11 @@ describe('Messaging', () => {
       execute: jest.fn(),
       runWorker: jest.fn(),
       logger: { error: jest.fn() },
+      session: {
+        on: jest.fn(),
+        once: jest.fn(),
+        off: jest.fn(),
+      },
     },
   }
 


### PR DESCRIPTION
# Description

Resubscribe topics/channels after WS reconnection.

## Type of change

- [ ] Internal refactoring
- [x] Bug fix (bugfix - non-breaking)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Code snippets

In case of new feature or breaking changes, please include code snippets.
