### PR TITLE
Resolve user_name in the `getChatMessages` API

### DIFF
--- a/.changeset/plain-steaks-wash.md
+++ b/.changeset/plain-steaks-wash.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/js': patch
+---
+
+resolves the user_name from the getChatMessages API

--- a/internal/e2e-js/utils.ts
+++ b/internal/e2e-js/utils.ts
@@ -1329,7 +1329,7 @@ export interface Resource {
 
 export const createVideoRoomResource = async (name?: string) => {
   const response = await fetch(
-    `https://${process.env.API_HOST}/api/fabric/resources/video_rooms`,
+    `https://${process.env.API_HOST}/api/fabric/resources/conference_rooms`,
     {
       method: 'POST',
       headers: {

--- a/packages/js/src/fabric/Conversation.test.ts
+++ b/packages/js/src/fabric/Conversation.test.ts
@@ -4,6 +4,10 @@ import { HTTPClient } from './HTTPClient'
 import { WSClient } from './WSClient'
 import { uuid } from '@signalwire/core'
 
+const mock_getAddressSpy = jest.fn(() =>
+  Promise.resolve({ display_name: 'subscriber-name' })
+)
+
 // Mock HTTPClient
 jest.mock('./HTTPClient', () => {
   return {
@@ -13,6 +17,7 @@ jest.mock('./HTTPClient', () => {
         fetchSubscriberInfo: jest.fn(() =>
           Promise.resolve({ id: 'subscriber-id' })
         ),
+        getAddress: mock_getAddressSpy
       }
     }),
   }
@@ -320,6 +325,11 @@ describe('Conversation', () => {
   })
 
   describe('Chat utilities', () => {
+
+    beforeEach(() => {
+      jest.clearAllMocks()
+    })
+
     it('Should return adresss chat messages only', async () => {
       ;(httpClient.fetch as jest.Mock).mockResolvedValue({
         body: {
@@ -336,6 +346,7 @@ describe('Conversation', () => {
       const messages = await conversation.getChatMessages({ addressId })
 
       expect(messages.data).toHaveLength(1)
+      expect(mock_getAddressSpy).toHaveBeenCalledTimes(1)
       expect(messages.data[0].conversation_id).toEqual(addressId)
     })
 
@@ -360,6 +371,7 @@ describe('Conversation', () => {
       const messages = await conversation.getChatMessages({ addressId })
 
       expect(messages.data).toHaveLength(10)
+      expect(mock_getAddressSpy).toHaveBeenCalledTimes(10)    
       expect(messages.data.every((item) => item.subtype === 'chat')).toBe(true)
       expect(
         messages.data.every((item) => item.conversation_id === addressId)
@@ -387,6 +399,8 @@ describe('Conversation', () => {
       let messages = await conversation.getChatMessages({ addressId })
 
       expect(messages.data).toHaveLength(10)
+      expect(mock_getAddressSpy).toHaveBeenCalledTimes(10)
+      
       expect(messages.data.every((item) => item.subtype === 'chat')).toBe(true)
       expect(
         messages.data.every((item) => item.conversation_id === addressId)
@@ -424,6 +438,8 @@ describe('Conversation', () => {
       })
 
       expect(messages.data).toHaveLength(3)
+      expect(mock_getAddressSpy).toHaveBeenCalledTimes(3)
+      
       expect(messages.data.every((item) => item.subtype === 'chat')).toBe(true)
       expect(
         messages.data.every((item) => item.conversation_id === addressId)
@@ -453,6 +469,8 @@ describe('Conversation', () => {
       const messages = await conversation.getChatMessages({ addressId })
 
       expect(messages.data).toHaveLength(3)
+      expect(mock_getAddressSpy).toHaveBeenCalledTimes(3)
+      
       expect(messages.data.every((item) => item.subtype === 'chat')).toBe(true)
       expect(
         messages.data.every((item) => item.conversation_id === addressId)

--- a/packages/js/src/fabric/Conversation.ts
+++ b/packages/js/src/fabric/Conversation.ts
@@ -181,7 +181,7 @@ export class Conversation {
       cached: ConversationMessage[] = [],
       isDirectionNext = true
     ): Promise<GetConversationChatMessageResult> => {
-      const chatMessages = [...cached]
+      let chatMessages = [...cached]
       const isValid = (item: ConversationMessage) =>
         item.conversation_id === addressId && item.subtype === 'chat'
 
@@ -221,6 +221,11 @@ export class Conversation {
       if (remaining < chatOnlyMessages.length) {
         missingReturns = chatOnlyMessages.slice(remaining)
       }
+
+      chatMessages = await Promise.all(chatMessages.map(async message => ({
+        ...message,
+        user_name: await this.httpClient.getAddress({id: message.from_address_id})
+      })))
 
       return {
         data: chatMessages as ConversationChatMessage[],

--- a/packages/js/src/fabric/Conversation.ts
+++ b/packages/js/src/fabric/Conversation.ts
@@ -224,7 +224,7 @@ export class Conversation {
 
       chatMessages = await Promise.all(chatMessages.map(async message => ({
         ...message,
-        user_name: await this.httpClient.getAddress({id: message.from_address_id})
+        user_name: (await this.httpClient.getAddress({id: message.from_address_id})).display_name
       })))
 
       return {

--- a/packages/js/src/fabric/interfaces/conversation.ts
+++ b/packages/js/src/fabric/interfaces/conversation.ts
@@ -104,6 +104,7 @@ export type GetMessagesResult = PaginatedResult<ConversationMessage>
 
 export type ConversationChatMessage = Omit<ConversationMessage, 'kind'> & {
   text: string
+  user_name: string
 }
 
 export interface GetConversationChatMessageParams {


### PR DESCRIPTION
# Description

Resolve `user_name` in the `getChatMessages` API making the return consistent with the live chat message event.

## Type of change

- [x] Internal refactoring
- [ ] Bug fix (bugfix - non-breaking)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Code snippets

In case of new feature or breaking changes, please include code snippets.
