### PR TITLE
Fix GHA pipeline

### DIFF
--- a/.github/workflows/update-playgrounds.yml
+++ b/.github/workflows/update-playgrounds.yml
@@ -32,7 +32,7 @@ jobs:
           VITE_FB_MEASUREMENT_ID: ${{ secrets.VITE_FB_MEASUREMENT_ID }}
           VITE_FB_VAPI_KEY: ${{ secrets.VITE_FB_VAPI_KEY }}
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           # Upload entire repository
           path: './public'


### PR DESCRIPTION
# Description

actions/upload-pages-artifact@v1 is not supported any more.

## Type of change

- [x] Internal refactoring
- [ ] Bug fix (bugfix - non-breaking)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Code snippets

In case of new feature or breaking changes, please include code snippets.
