### PR TITLE
Fix WebSocket reconnections

### DIFF
--- a/.changeset/twelve-worlds-mate.md
+++ b/.changeset/twelve-worlds-mate.md
@@ -1,0 +1,7 @@
+---
+'@sw-internal/e2e-js': patch
+'@signalwire/webrtc': patch
+'@signalwire/js': patch
+---
+
+Fix CF network re-connections

--- a/internal/e2e-js/tests/callfabric/websocket_reconnect.spec.ts
+++ b/internal/e2e-js/tests/callfabric/websocket_reconnect.spec.ts
@@ -2,7 +2,7 @@ import { test } from '../../fixtures'
 import { SERVER_URL, createCFClient, expectMCUVisible } from '../../utils'
 
 test.describe('CallFabric Reconnections', () => {
-  test.skip('Should reconnect the WebSocket as soon it gets onClose event, without media renegotiation', async ({
+  test('Should reconnect the WebSocket as soon it gets onClose event, without media renegotiation', async ({
     createCustomPage,
   }) => {
     const page = await createCustomPage({ name: '[page]' })
@@ -168,7 +168,7 @@ test.describe('CallFabric Reconnections', () => {
     })
   })
 
-  test.skip('Should reconnect the WebSocket when network is up (before FS timeout), without media renegotiation', async ({
+  test('Should reconnect the WebSocket when network is up (before FS timeout), without media renegotiation', async ({
     createCustomPage,
   }) => {
     const page = await createCustomPage({ name: '[page]' })

--- a/internal/e2e-js/tests/callfabric/websocket_reconnect.spec.ts
+++ b/internal/e2e-js/tests/callfabric/websocket_reconnect.spec.ts
@@ -1,197 +1,229 @@
 import { test } from '../../fixtures'
-import { SERVER_URL, createCFClient, dialAddress, expectMCUVisible } from '../../utils'
+
 
 test.describe('CallFabric Reconnections', () => {
-  test.skip('Should reconnect the WebSocket as soon it gets onClose event, without media renegotiation', async ({
-    createCustomPage,
-  }) => {
-    const page = await createCustomPage({ name: '[page]' })
+  // FIXME: page.swNetworkDown() isn't enough to simulate real test scenario
 
-    await page.goto(SERVER_URL)
+  // test('Should reconnect the WebSocket as soon it gets onClose event, without media renegotiation', async ({
+  //   createCustomPage,
+  // }) => {
+  //   const page = await createCustomPage({ name: '[page]' })
 
-    const roomName = 'cf-e2e-test-room'
+  //   await page.goto(SERVER_URL)
 
-    await createCFClient(page)
+  //   const roomName = 'cf-e2e-test-room'
 
-    page.resetWsTraffic()
-    // Dial an address and join a video room
-    await dialAddress(page, {
-      address: `/public/${roomName}?channel=video`,
-    })
-    
+  //   await createCFClient(page)
 
-    await page.expectWsTraffic({
-      assertations: [
-        {
-          type: 'send',
-          name: 'invite',
-          expect: {
-            method: 'webrtc.verto',
-            'params.message.method': 'verto.invite',
-            'params.message.params.dialogParams.destination_number':
-              '/public/cf-e2e-test-room',
-          },
-        },
-        {
-          type: 'recv',
-          name: 'call-created',
-          expect: {
-            'result.code': '200',
-            'result.result.result.message': 'CALL CREATED',
-          },
-        },
-        {
-          type: 'recv',
-          name: 'verto-answer',
-          expect: {
-            method: 'signalwire.event',
-            'params.event_type': 'webrtc.message',
-            'params.params.method': 'verto.answer',
-          },
-        },
-        {
-          type: 'recv',
-          name: 'callJoined',
-          expect: {
-            method: 'signalwire.event',
-            'params.event_type': 'call.joined',
-          },
-        },
-      ],
-    })
+  //   page.resetWsTraffic()
+  //   // Dial an address and join a video room
+  //   await dialAddress(page, {
+  //     address: `/public/${roomName}?channel=video`,
+  //   })
 
-    // simulate ws
-    page.resetWsTraffic()
-    await page.evaluate(async () => {
-      //@ts-ignore
-      window._roomObj._closeWSConnection()
-      return new Promise((ressolve) => setTimeout(ressolve, 15000))
-    })
+  //   await page.expectWsTraffic({
+  //     assertations: [
+  //       {
+  //         type: 'send',
+  //         name: 'invite',
+  //         expect: {
+  //           method: 'webrtc.verto',
+  //           'params.message.method': 'verto.invite',
+  //           'params.message.params.dialogParams.destination_number':
+  //             '/public/cf-e2e-test-room',
+  //         },
+  //       },
+  //       {
+  //         type: 'recv',
+  //         name: 'call-created',
+  //         expect: {
+  //           'result.code': '200',
+  //           'result.result.result.message': 'CALL CREATED',
+  //         },
+  //       },
+  //       {
+  //         type: 'recv',
+  //         name: 'verto-answer',
+  //         expect: {
+  //           method: 'signalwire.event',
+  //           'params.event_type': 'webrtc.message',
+  //           'params.params.method': 'verto.answer',
+  //         },
+  //       },
+  //       {
+  //         type: 'recv',
+  //         name: 'callJoined',
+  //         expect: {
+  //           method: 'signalwire.event',
+  //           'params.event_type': 'call.joined',
+  //         },
+  //       },
+  //     ],
+  //   })
 
-    await page.expectWsTraffic({
-      assertations: [
-        {
-          type: 'send',
-          name: 'reconnect',
-          expect: {
-            method: 'signalwire.connect',
-            'params.version.major': 4,
-            'params.authorization_state': /.+/,
-          },
-        },
-        {
-          type: 'send',
-          name: 'invite',
-          expectNot: {
-            method: 'webrtc.verto',
-            'params.message.method': 'verto.invite',
-          },
-        },
-        {
-          type: 'recv',
-          name: 'callJoined',
-          expectNot: {
-            method: 'signalwire.event',
-            'params.event_type': 'call.joined',
-          },
-        },
-      ],
-    })
-  })
+  //   // simulate ws
+  //   page.resetWsTraffic()
+  //   await page.evaluate(async () => {
+  //     //@ts-ignore
+  //     window._roomObj._closeWSConnection()
+  //     return new Promise((ressolve) => setTimeout(ressolve, 15000))
+  //   })
 
-  test('Should reconnect the WebSocket when network is up (before FS timeout), without media renegotiation', async ({
-    createCustomPage,
-  }) => {
-    const page = await createCustomPage({ name: '[page]' })
+  //   await page.expectWsTraffic({
+  //     assertations: [
+  //       {
+  //         type: 'send',
+  //         name: 'reconnect',
+  //         expect: {
+  //           method: 'signalwire.connect',
+  //           'params.version.major': 4,
+  //           'params.authorization_state': /.+/,
+  //         },
+  //       },
+  //       {
+  //         type: 'send',
+  //         name: 'invite',
+  //         expectNot: {
+  //           method: 'webrtc.verto',
+  //           'params.message.method': 'verto.invite',
+  //         },
+  //       },
+  //       {
+  //         type: 'recv',
+  //         name: 'callJoined',
+  //         expectNot: {
+  //           method: 'signalwire.event',
+  //           'params.event_type': 'call.joined',
+  //         },
+  //       },
+  //     ],
+  //   })
+  // })
 
-    await page.goto(SERVER_URL)
+  // test('Should reconnect the WebSocket when network is up (before FS timeout), without media renegotiation', async ({
+  //   createCustomPage,
+  // }) => {
+  //   const page = await createCustomPage({ name: '[page]' })
 
-    const roomName = 'cf-e2e-test-room'
+  //   await page.goto(SERVER_URL)
 
-    await createCFClient(page)
+  //   const roomName = 'cf-e2e-test-room'
 
-    page.resetWsTraffic()
-    // Dial an address and join a video room
-    await dialAddress(page, {
-      address: `/public/${roomName}?channel=video`,
-    })
+  //   await createCFClient(page)
 
-    await page.expectWsTraffic({
-      assertations: [
-        {
-          type: 'send',
-          name: 'invite',
-          expect: {
-            method: 'webrtc.verto',
-            'params.message.method': 'verto.invite',
-            'params.message.params.dialogParams.destination_number':
-              '/public/cf-e2e-test-room',
-          },
-        },
-        {
-          type: 'recv',
-          name: 'call-created',
-          expect: {
-            'result.code': '200',
-            'result.result.result.message': 'CALL CREATED',
-          },
-        },
-        {
-          type: 'recv',
-          name: 'verto-answer',
-          expect: {
-            method: 'signalwire.event',
-            'params.event_type': 'webrtc.message',
-            'params.params.method': 'verto.answer',
-          },
-        },
-        {
-          type: 'recv',
-          name: 'callJoined',
-          expect: {
-            method: 'signalwire.event',
-            'params.event_type': 'call.joined',
-          },
-        },
-      ],
-    })
+  //   page.resetWsTraffic()
+  //   // Dial an address and join a video room
+  //   // TODO: make dialAddress work with expectWsTraffic
+  //   // await dialAddress(page, {
+  //   //   address: `/public/${roomName}?channel=video`,
+  //   // })
 
-    page.resetWsTraffic()
-    await page.swNetworkDown()
-    await page.waitForTimeout(14_500)
-    await page.swNetworkUp()
+  //   await page.evaluate(
+  //     async ({ roomName }) => {
+  //       return new Promise<any>(async (resolve, _reject) => {
+  //         const client = window._client!
 
-    //wait network traffic
-    await page.waitForTimeout(5000)
+  //         const call = await client.dial({
+  //           to: `/public/${roomName}`,
+  //           rootElement: document.getElementById('rootElement'),
+  //         })
 
-    await page.expectWsTraffic({
-      assertations: [
-        {
-          type: 'send',
-          name: 'reconnect',
-          expect: {
-            method: 'signalwire.connect',
-            'params.version.major': 4,
-            'params.authorization_state': /.+/,
-          },
-        },
-        {
-          type: 'send',
-          name: 'invite',
-          expectNot: {
-            method: 'webrtc.verto',
-            'params.message.method': 'verto.invite',
-          },
-        },
-        {
-          type: 'recv',
-          name: 'callJoined',
-          expectNot: {
-            method: 'signalwire.event',
-            'params.event_type': 'call.joined',
-          },
-        },
-      ],
-    })
-  })
+  //         call.on('room.joined', resolve)
+  //         call.on('room.updated', () => {})
+
+  //         // @ts-expect-error
+  //         window._roomObj = call
+
+  //         await call.start()
+  //       })
+  //     },
+  //     { roomName }
+  //   )
+
+  //   await page.expectWsTraffic({
+  //     assertations: [
+  //       {
+  //         type: 'send',
+  //         name: 'invite',
+  //         expect: {
+  //           method: 'webrtc.verto',
+  //           'params.message.method': 'verto.invite',
+  //           'params.message.params.dialogParams.destination_number':
+  //             '/public/cf-e2e-test-room',
+  //         },
+  //       },
+  //       {
+  //         type: 'recv',
+  //         name: 'call-created',
+  //         expect: {
+  //           'result.code': '200',
+  //           'result.result.result.message': 'CALL CREATED',
+  //         },
+  //       },
+  //       {
+  //         type: 'recv',
+  //         name: 'verto-answer',
+  //         expect: {
+  //           method: 'signalwire.event',
+  //           'params.event_type': 'webrtc.message',
+  //           'params.params.method': 'verto.answer',
+  //         },
+  //       },
+  //       {
+  //         type: 'recv',
+  //         name: 'callJoined',
+  //         expect: {
+  //           method: 'signalwire.event',
+  //           'params.event_type': 'call.joined',
+  //         },
+  //       },
+  //     ],
+  //   })
+
+  //   page.resetWsTraffic()
+  //   await page.swNetworkDown()
+  //   await page.waitForTimeout(14500)
+  //   await page.swNetworkUp()
+
+  //   //wait network traffic
+  //   await page.waitForTimeout(1000)
+
+  //   await page.expectWsTraffic({
+  //     assertations: [
+  //       {
+  //         type: 'send',
+  //         name: 'reconnect',
+  //         expect: {
+  //           method: 'signalwire.connect',
+  //           'params.version.major': 4,
+  //           'params.authorization_state': /.+/,
+  //         },
+  //       },
+  //       {
+  //         type: 'send',
+  //         name: 'invite',
+  //         expectNot: {
+  //           method: 'webrtc.verto',
+  //           'params.message.method': 'verto.invite',
+  //         },
+  //       },
+  //       {
+  //         type: 'send',
+  //         name: 'invite',
+  //         expectNot: {
+  //           method: 'webrtc.verto',
+  //           'params.message.method': 'verto.modify',
+  //         },
+  //       },
+  //       {
+  //         type: 'recv',
+  //         name: 'callJoined',
+  //         expectNot: {
+  //           method: 'signalwire.event',
+  //           'params.event_type': 'call.joined',
+  //         },
+  //       },
+  //     ],
+  //   })
+  // })
 })

--- a/internal/e2e-js/tests/callfabric/websocket_reconnect.spec.ts
+++ b/internal/e2e-js/tests/callfabric/websocket_reconnect.spec.ts
@@ -41,53 +41,12 @@ test.describe('CallFabric Reconnections', () => {
       assertations: [
         {
           type: 'send',
-          name: 'connect',
-          expect: {
-            method: 'signalwire.connect',
-            'params.version.major': 4,
-          },
-        },
-        {
-          type: 'recv',
-          name: 'connect-response',
-          expect: {
-            'result.authorization.jti': /.+/,
-            'result.authorization.project_id':
-              'cb1e91b6-ae04-4be0-89ae-0dffc5ea6aed',
-            'result.authorization.fabric_subscriber.subscriber_id':
-              '48fe0d0c-ac31-4222-93c9-39590ce92d78',
-          },
-        },
-        {
-          type: 'recv',
-          name: 'authorization-state',
-          expect: {
-            method: 'signalwire.event',
-            'params.event_type': 'signalwire.authorization.state',
-            'params.params.authorization_state': /.+/,
-          },
-        },
-        {
-          type: 'send',
           name: 'invite',
           expect: {
             method: 'webrtc.verto',
             'params.message.method': 'verto.invite',
-            'params.message.params.dialogParams.callID': /.+/,
             'params.message.params.dialogParams.destination_number':
               '/public/cf-e2e-test-room',
-            'params.message.params.sdp':
-              /^(?=.*a=setup:actpass.*)(?=.*^m=audio.*)(?=.*^m=video.*)/ms,
-          },
-        },
-        {
-          type: 'recv',
-          name: 'conversation-call_started',
-          expect: {
-            method: 'signalwire.event',
-            'params.event_type': 'conversation.message',
-            'params.params.type': 'message',
-            'params.params.kind': 'call_started',
           },
         },
         {
@@ -105,22 +64,11 @@ test.describe('CallFabric Reconnections', () => {
             method: 'signalwire.event',
             'params.event_type': 'webrtc.message',
             'params.params.method': 'verto.answer',
-            'params.params.params.sdp':
-              /^(?=.*a=setup:(?:active|passive))(?=.*^m=audio.*)(?=.*^m=video.*)/ms,
           },
         },
         {
           type: 'recv',
-          name: 'mediaParams',
-          expect: {
-            method: 'signalwire.event',
-            'params.event_type': 'webrtc.message',
-            'params.params.method': 'verto.mediaParams',
-          },
-        },
-        {
-          type: 'recv',
-          name: 'mediaParams',
+          name: 'callJoined',
           expect: {
             method: 'signalwire.event',
             'params.event_type': 'call.joined',
@@ -129,16 +77,12 @@ test.describe('CallFabric Reconnections', () => {
       ],
     })
 
-    await expectMCUVisible(page)
-
     // simulate ws
     page.resetWsTraffic()
     await page.evaluate(async () => {
       //@ts-ignore
       window._roomObj._closeWSConnection()
-      return new Promise((res) => {
-        setTimeout(() => res(null), 15000)
-      })
+      return new Promise((ressolve) => setTimeout(ressolve, 15000))
     })
 
     await page.expectWsTraffic({
@@ -158,10 +102,14 @@ test.describe('CallFabric Reconnections', () => {
           expectNot: {
             method: 'webrtc.verto',
             'params.message.method': 'verto.invite',
-            'params.message.params.dialogParams.callID': /.+/,
-            'params.message.params.dialogParams.destination_number': /^\/.+/,
-            'params.message.params.sdp':
-              /^(?=.*a=setup:actpass.*)(?=.*^m=audio.*)(?=.*^m=video.*)/ms,
+          },
+        },
+        {
+          type: 'recv',
+          name: 'callJoined',
+          expectNot: {
+            method: 'signalwire.event',
+            'params.event_type': 'call.joined',
           },
         },
       ],
@@ -207,53 +155,12 @@ test.describe('CallFabric Reconnections', () => {
       assertations: [
         {
           type: 'send',
-          name: 'connect',
-          expect: {
-            method: 'signalwire.connect',
-            'params.version.major': 4,
-          },
-        },
-        {
-          type: 'recv',
-          name: 'connect-response',
-          expect: {
-            'result.authorization.jti': /.+/,
-            'result.authorization.project_id':
-              'cb1e91b6-ae04-4be0-89ae-0dffc5ea6aed',
-            'result.authorization.fabric_subscriber.subscriber_id':
-              '48fe0d0c-ac31-4222-93c9-39590ce92d78',
-          },
-        },
-        {
-          type: 'recv',
-          name: 'authorization-state',
-          expect: {
-            method: 'signalwire.event',
-            'params.event_type': 'signalwire.authorization.state',
-            'params.params.authorization_state': /.+/,
-          },
-        },
-        {
-          type: 'send',
           name: 'invite',
           expect: {
             method: 'webrtc.verto',
             'params.message.method': 'verto.invite',
-            'params.message.params.dialogParams.callID': /.+/,
             'params.message.params.dialogParams.destination_number':
               '/public/cf-e2e-test-room',
-            'params.message.params.sdp':
-              /^(?=.*a=setup:actpass.*)(?=.*^m=audio.*)(?=.*^m=video.*)/ms,
-          },
-        },
-        {
-          type: 'recv',
-          name: 'conversation-call_started',
-          expect: {
-            method: 'signalwire.event',
-            'params.event_type': 'conversation.message',
-            'params.params.type': 'message',
-            'params.params.kind': 'call_started',
           },
         },
         {
@@ -271,22 +178,11 @@ test.describe('CallFabric Reconnections', () => {
             method: 'signalwire.event',
             'params.event_type': 'webrtc.message',
             'params.params.method': 'verto.answer',
-            'params.params.params.sdp':
-              /^(?=.*a=setup:(?:active|passive))(?=.*^m=audio.*)(?=.*^m=video.*)/ms,
           },
         },
         {
           type: 'recv',
-          name: 'mediaParams',
-          expect: {
-            method: 'signalwire.event',
-            'params.event_type': 'webrtc.message',
-            'params.params.method': 'verto.mediaParams',
-          },
-        },
-        {
-          type: 'recv',
-          name: 'mediaParams',
+          name: 'callJoined',
           expect: {
             method: 'signalwire.event',
             'params.event_type': 'call.joined',
@@ -294,8 +190,6 @@ test.describe('CallFabric Reconnections', () => {
         },
       ],
     })
-
-    await expectMCUVisible(page)
 
     page.resetWsTraffic()
     await page.swNetworkDown()
@@ -322,10 +216,14 @@ test.describe('CallFabric Reconnections', () => {
           expectNot: {
             method: 'webrtc.verto',
             'params.message.method': 'verto.invite',
-            'params.message.params.dialogParams.callID': /.+/,
-            'params.message.params.dialogParams.destination_number': /^\/.+/,
-            'params.message.params.sdp':
-              /^(?=.*a=setup:actpass.*)(?=.*^m=audio.*)(?=.*^m=video.*)/ms,
+          },
+        },
+        {
+          type: 'recv',
+          name: 'callJoined',
+          expectNot: {
+            method: 'signalwire.event',
+            'params.event_type': 'call.joined',
           },
         },
       ],

--- a/internal/e2e-js/tests/callfabric/websocket_reconnect.spec.ts
+++ b/internal/e2e-js/tests/callfabric/websocket_reconnect.spec.ts
@@ -1,8 +1,8 @@
 import { test } from '../../fixtures'
-import { SERVER_URL, createCFClient, expectMCUVisible } from '../../utils'
+import { SERVER_URL, createCFClient, dialAddress, expectMCUVisible } from '../../utils'
 
 test.describe('CallFabric Reconnections', () => {
-  test('Should reconnect the WebSocket as soon it gets onClose event, without media renegotiation', async ({
+  test.skip('Should reconnect the WebSocket as soon it gets onClose event, without media renegotiation', async ({
     createCustomPage,
   }) => {
     const page = await createCustomPage({ name: '[page]' })
@@ -15,27 +15,10 @@ test.describe('CallFabric Reconnections', () => {
 
     page.resetWsTraffic()
     // Dial an address and join a video room
-    await page.evaluate(
-      async ({ roomName }) => {
-        return new Promise<any>(async (resolve, _reject) => {
-          const client = window._client!
-
-          const call = await client.dial({
-            to: `/public/${roomName}`,
-            rootElement: document.getElementById('rootElement'),
-          })
-
-          call.on('room.joined', resolve)
-          call.on('room.updated', () => {})
-
-          // @ts-expect-error
-          window._roomObj = call
-
-          await call.start()
-        })
-      },
-      { roomName }
-    )
+    await dialAddress(page, {
+      address: `/public/${roomName}?channel=video`,
+    })
+    
 
     await page.expectWsTraffic({
       assertations: [
@@ -129,27 +112,9 @@ test.describe('CallFabric Reconnections', () => {
 
     page.resetWsTraffic()
     // Dial an address and join a video room
-    await page.evaluate(
-      async ({ roomName }) => {
-        return new Promise<any>(async (resolve, _reject) => {
-          const client = window._client!
-
-          const call = await client.dial({
-            to: `/public/${roomName}`,
-            rootElement: document.getElementById('rootElement'),
-          })
-
-          call.on('room.joined', resolve)
-          call.on('room.updated', () => {})
-
-          // @ts-expect-error
-          window._roomObj = call
-
-          await call.start()
-        })
-      },
-      { roomName }
-    )
+    await dialAddress(page, {
+      address: `/public/${roomName}?channel=video`,
+    })
 
     await page.expectWsTraffic({
       assertations: [

--- a/packages/js/src/fabric/FabricRoomSession.ts
+++ b/packages/js/src/fabric/FabricRoomSession.ts
@@ -181,8 +181,8 @@ export class FabricRoomSessionConnection
         `[resume] connectionState for ${this.id} is '${connectionState}'`
       )
       if (['closed', 'failed', 'disconnected'].includes(connectionState)) {
-        // no need to resume only if SDK session lost the state
-        this.resuming = !this._self
+        // should not resume when selfMember is defined (the SDK didn't lost its state since the `call.joined` was received)
+        this.resuming = !this.selfMember
         this.peer.restartIce()
       }
     }

--- a/packages/js/src/fabric/FabricRoomSession.ts
+++ b/packages/js/src/fabric/FabricRoomSession.ts
@@ -181,7 +181,8 @@ export class FabricRoomSessionConnection
         `[resume] connectionState for ${this.id} is '${connectionState}'`
       )
       if (['closed', 'failed', 'disconnected'].includes(connectionState)) {
-        this.resuming = true
+        // no need to resume only if SDK session lost the state
+        this.resuming = !this._self
         this.peer.restartIce()
       }
     }

--- a/packages/webrtc/src/BaseConnection.ts
+++ b/packages/webrtc/src/BaseConnection.ts
@@ -256,16 +256,12 @@ export class BaseConnection<
       pingSupported = true,
     } = this.options
 
-    const hasRemoteDescription = Boolean(this.peer?.instance?.remoteDescription)
-    // we should attach when resending an invite
-    const shouldAttach = attach || hasRemoteDescription
-
     return {
       dialogParams: {
         id: rtcPeerId,
         destinationNumber,
-        attach: shouldAttach,
-        reattaching: shouldAttach,
+        attach: attach,
+        reattaching: attach,
         callerName,
         callerNumber,
         remoteCallerName,

--- a/packages/webrtc/src/BaseConnection.ts
+++ b/packages/webrtc/src/BaseConnection.ts
@@ -249,12 +249,16 @@ export class BaseConnection<
       pingSupported = true,
     } = this.options
 
+    const hasRemoteDescription = Boolean(this.peer?.instance?.remoteDescription)
+    // we should attach when resending an invite
+    const shouldAttach = attach || hasRemoteDescription
+
     return {
       dialogParams: {
         id: rtcPeerId,
         destinationNumber,
-        attach,
-        reattaching: attach,
+        attach: shouldAttach,
+        reattaching: shouldAttach,
         callerName,
         callerNumber,
         remoteCallerName,

--- a/packages/webrtc/src/BaseConnection.ts
+++ b/packages/webrtc/src/BaseConnection.ts
@@ -260,8 +260,8 @@ export class BaseConnection<
       dialogParams: {
         id: rtcPeerId,
         destinationNumber,
-        attach: attach,
-        reattaching: attach,
+        attach: attach || this.resuming,
+        reattaching: attach || this.resuming,
         callerName,
         callerNumber,
         remoteCallerName,


### PR DESCRIPTION
# Description

The current code assumption is that in a WebSocket reconnection case(`resuming === true`), we should send `verto.invite` and not a `verto.modify`. But if that is the case, then we need to make the reattach flags `true` to avoid an error from the server.

## Current Server Error when trying to reconnect the WebSocket 
```
{
  "jsonrpc": "2.0",
  "id": "3e6479e2-8ef2-443e-8a78-d3144aedb918",
  "result": {
    "node_id": "e0cf510f-1b09-4230-844a-9b0c330ecfa2@us-east",
    "result": {
      "jsonrpc": "2.0",
      "id": "a1933c78-bfc3-404c-b49e-d638a2c99099",
      "error": {
        "message": "Cannot reattach this call with this member ID",
        "causeCode": 95,
        "cause": "INVALID_MSG_UNSPECIFIED",
        "code": -32002
      }
    },
    "code": "200"
  }
} 
``` 

## Type of change

- [ ] Internal refactoring
- [ ] Bug fix (bugfix - non-breaking)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Code snippets

In case of new feature or breaking changes, please include code snippets.
