### PR TITLE
CF SDK(bug): Expose Pagination types

### DIFF
--- a/.changeset/small-wasps-carry.md
+++ b/.changeset/small-wasps-carry.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/js': patch
+---
+
+CF SDK(bug): Include the missing Pagination type

--- a/internal/e2e-js/tests/callfabric/reattach.spec.ts
+++ b/internal/e2e-js/tests/callfabric/reattach.spec.ts
@@ -425,7 +425,10 @@ test.describe('CallFabric Reattach', () => {
             })
           })
 
-          await roomObj.setOutputVolume({ volume: SPEAKER_VOLUME })
+          await roomObj.setOutputVolume({
+            volume: SPEAKER_VOLUME,
+            memberId: memberTwoId,
+          })
           await memberUpdatedEvent
         },
         { SPEAKER_VOLUME, memberTwoId }

--- a/internal/e2e-js/tests/callfabric/reattach.spec.ts
+++ b/internal/e2e-js/tests/callfabric/reattach.spec.ts
@@ -418,7 +418,7 @@ test.describe('CallFabric Reattach', () => {
           const memberUpdatedEvent = new Promise((res) => {
             roomObj.on('member.updated', (event) => {
               if (
-                event.member.input_volume === SPEAKER_VOLUME &&
+                event.member.output_volume === SPEAKER_VOLUME &&
                 event.member.member_id === memberTwoId
               )
                 res(true)

--- a/internal/e2e-js/tests/callfabric/reattach.spec.ts
+++ b/internal/e2e-js/tests/callfabric/reattach.spec.ts
@@ -69,6 +69,9 @@ test.describe('CallFabric Reattach', () => {
     createCustomPage,
     resource,
   }) => {
+    const MIC_VOLUME = 10
+    const SPEAKER_VOLUME = 10
+
     const page = await createCustomPage({ name: '[page]' })
     await page.goto(SERVER_URL)
 
@@ -152,13 +155,10 @@ test.describe('CallFabric Reattach', () => {
       )
     })
 
-    const MIC_VOLUME = 10
-    const SPEAKER_VOLUME = 10
-
     // --------------- Change Audio Volume (self) ---------------
     await test.step('change mic volume', async () => {
       await page.evaluate(
-        async ({ MIC_VOLUME, memberId }) => {
+        async ({ volume, memberId }) => {
           // @ts-expect-error
           const roomObj: FabricRoomSession = window._roomObj
 
@@ -166,24 +166,24 @@ test.describe('CallFabric Reattach', () => {
             roomObj.on('member.updated', (event) => {
               if (
                 event.member.member_id === memberId &&
-                event.member.input_volume === MIC_VOLUME
+                event.member.input_volume === volume
               ) {
                 res(true)
               }
             })
           })
 
-          await roomObj.setInputVolume({ volume: MIC_VOLUME })
+          await roomObj.setInputVolume({ volume: volume })
           await memberUpdatedEvent
         },
-        { MIC_VOLUME, memberId }
+        { volume: MIC_VOLUME, memberId }
       )
     })
 
     // --------------- Change Speaker Volume (self) ---------------
     await test.step('change speaker volume', async () => {
       await page.evaluate(
-        async ({ SPEAKER_VOLUME, memberId }) => {
+        async ({ volume, memberId }) => {
           // @ts-expect-error
           const roomObj: FabricRoomSession = window._roomObj
 
@@ -191,17 +191,17 @@ test.describe('CallFabric Reattach', () => {
             roomObj.on('member.updated', (event) => {
               if (
                 event.member.member_id === memberId &&
-                event.member.output_volume === SPEAKER_VOLUME
+                event.member.output_volume === volume
               ) {
                 res(true)
               }
             })
           })
 
-          await roomObj.setOutputVolume({ volume: SPEAKER_VOLUME })
+          await roomObj.setOutputVolume({ volume: volume })
           await memberUpdatedEvent
         },
-        { SPEAKER_VOLUME, memberId }
+        { volume: SPEAKER_VOLUME, memberId }
       )
     })
 
@@ -233,14 +233,14 @@ test.describe('CallFabric Reattach', () => {
     // })
 
     const roomSessionAfter =
-      await test.step('relaod page and reattach', async () => {
+      await test.step('reload page and reattach', async () => {
         await page.reload({ waitUntil: 'domcontentloaded' })
         await createCFClient(page)
 
         // Reattach to an address to join the same call session
         const roomSession: CallJoinedEventParams = await page.evaluate(
           async ({ roomName }) => {
-            return new Promise<any>(async (resolve, _reject) => {
+            return new Promise(async (resolve, _reject) => {
               const client = window._client!
 
               const call = await client.reattach({
@@ -295,6 +295,9 @@ test.describe('CallFabric Reattach', () => {
     createCustomPage,
     resource,
   }) => {
+    const MIC_VOLUME = 10
+    const SPEAKER_VOLUME = 10
+
     const pageOne = await createCustomPage({ name: '[pageOne]' })
     const pageTwo = await createCustomPage({ name: '[pageTwo]' })
     await pageOne.goto(SERVER_URL)
@@ -336,14 +339,14 @@ test.describe('CallFabric Reattach', () => {
 
     // --------------- Muting Video (other member) ---------------
     await test.step('[pageOne] mute video of memberTwo', async () => {
-      await pageOne.evaluate(async (memberTwoId) => {
+      await pageOne.evaluate(async (memberId) => {
         // @ts-expect-error
         const roomObj: FabricRoomSession = window._roomObj
 
         const memberUpdatedMutedEvent = new Promise((res) => {
           roomObj.on('member.updated.videoMuted', (event) => {
             if (
-              event.member.member_id === memberTwoId &&
+              event.member.member_id === memberId &&
               event.member.video_muted == true
             ) {
               res(true)
@@ -351,21 +354,21 @@ test.describe('CallFabric Reattach', () => {
           })
         })
 
-        await roomObj.videoMute({ memberId: memberTwoId })
+        await roomObj.videoMute({ memberId })
         await memberUpdatedMutedEvent
       }, memberTwoId)
     })
 
     // --------------- Muting Audio (other member) ---------------
     await test.step('[pageOne] mute audio of memberTwo', async () => {
-      await pageOne.evaluate(async (memberTwoId) => {
+      await pageOne.evaluate(async (memberId) => {
         // @ts-expect-error
         const roomObj: FabricRoomSession = window._roomObj
 
         const memberUpdatedMutedEvent = new Promise((res) => {
           roomObj.on('member.updated.audioMuted', (event) => {
             if (
-              event.member.member_id === memberTwoId &&
+              event.member.member_id === memberId &&
               event.member.audio_muted == true
             ) {
               res(true)
@@ -373,73 +376,64 @@ test.describe('CallFabric Reattach', () => {
           })
         })
 
-        await roomObj.audioMute({ memberId: memberTwoId })
+        await roomObj.audioMute({ memberId })
         await memberUpdatedMutedEvent
       }, memberTwoId)
     })
 
-    const MIC_VOLUME = 10
-    const SPEAKER_VOLUME = 10
-
     // --------------- Change Audio Volume (other member) ---------------
     await test.step('[pageOne] change mic volume for memberTwo', async () => {
       await pageOne.evaluate(
-        async ({ MIC_VOLUME, memberTwoId }) => {
+        async ({ volume, memberId }) => {
           // @ts-expect-error
           const roomObj: FabricRoomSession = window._roomObj
 
           const memberUpdatedEvent = new Promise((res) => {
             roomObj.on('member.updated', (event) => {
               if (
-                event.member.member_id === memberTwoId &&
-                event.member.input_volume === MIC_VOLUME
+                event.member.member_id === memberId &&
+                event.member.input_volume === volume
               )
                 res(true)
             })
           })
 
-          await roomObj.setInputVolume({
-            volume: MIC_VOLUME,
-            memberId: memberTwoId,
-          })
+          await roomObj.setInputVolume({ volume, memberId })
           await memberUpdatedEvent
         },
-        { MIC_VOLUME, memberTwoId }
+        { volume: MIC_VOLUME, memberId: memberTwoId }
       )
     })
 
     // --------------- Change Speaker Volume (other member) ---------------
     await test.step('[pageOne] change speaker volume for memberTwo', async () => {
       await pageOne.evaluate(
-        async ({ SPEAKER_VOLUME, memberTwoId }) => {
+        async ({ volume, memberId }) => {
           // @ts-expect-error
           const roomObj: FabricRoomSession = window._roomObj
 
           const memberUpdatedEvent = new Promise((res) => {
             roomObj.on('member.updated', (event) => {
               if (
-                event.member.member_id === memberTwoId &&
-                event.member.output_volume === SPEAKER_VOLUME
+                event.member.member_id === memberId &&
+                event.member.output_volume === volume
               )
                 res(true)
             })
           })
 
-          await roomObj.setOutputVolume({
-            volume: SPEAKER_VOLUME,
-            memberId: memberTwoId,
-          })
+          await roomObj.setOutputVolume({ volume, memberId })
           await memberUpdatedEvent
         },
-        { SPEAKER_VOLUME, memberTwoId }
+        { volume: SPEAKER_VOLUME, memberId: memberTwoId }
       )
     })
 
     // --------------- Change Noise Gate ---------------
-    // TODO: Add "setInputSensitivity" this when the server issue is fixed
+    // TODO: Add "setInputSensitivity" API test when the server issue is fixed
 
     const roomSessionTwoAfter =
-      await test.step('[pageTwo] relaod page and reattach', async () => {
+      await test.step('[pageTwo] reload page and reattach', async () => {
         await pageTwo.reload({ waitUntil: 'domcontentloaded' })
         await createCFClient(pageTwo)
 

--- a/internal/e2e-js/tests/callfabric/reattach.spec.ts
+++ b/internal/e2e-js/tests/callfabric/reattach.spec.ts
@@ -41,7 +41,7 @@ test.describe('CallFabric Reattach', () => {
     // Reattach to an address to join the same call session
     roomSession = await page.evaluate(
       async ({ roomName }) => {
-        return new Promise<any>(async (resolve, _reject) => {
+        return new Promise(async (resolve, _reject) => {
           // @ts-expect-error
           const client: SignalWireClient = window._client
 
@@ -440,7 +440,7 @@ test.describe('CallFabric Reattach', () => {
         // Reattach to an address to join the same call session
         const roomSession: CallJoinedEventParams = await pageTwo.evaluate(
           async ({ roomName }) => {
-            return new Promise<any>(async (resolve, _reject) => {
+            return new Promise(async (resolve, _reject) => {
               const client = window._client!
 
               const call = await client.reattach({

--- a/internal/e2e-js/tests/callfabric/reattach.spec.ts
+++ b/internal/e2e-js/tests/callfabric/reattach.spec.ts
@@ -191,7 +191,7 @@ test.describe('CallFabric Reattach', () => {
             roomObj.on('member.updated', (event) => {
               if (
                 event.member.member_id === memberId &&
-                event.member.input_volume === SPEAKER_VOLUME
+                event.member.output_volume === SPEAKER_VOLUME
               ) {
                 res(true)
               }
@@ -366,7 +366,7 @@ test.describe('CallFabric Reattach', () => {
           roomObj.on('member.updated.audioMuted', (event) => {
             if (
               event.member.member_id === memberTwoId &&
-              event.member.video_muted == true
+              event.member.audio_muted == true
             ) {
               res(true)
             }
@@ -391,8 +391,8 @@ test.describe('CallFabric Reattach', () => {
           const memberUpdatedEvent = new Promise((res) => {
             roomObj.on('member.updated', (event) => {
               if (
-                event.member.input_volume === MIC_VOLUME &&
-                event.member.member_id === memberTwoId
+                event.member.member_id === memberTwoId &&
+                event.member.input_volume === MIC_VOLUME
               )
                 res(true)
             })
@@ -418,8 +418,8 @@ test.describe('CallFabric Reattach', () => {
           const memberUpdatedEvent = new Promise((res) => {
             roomObj.on('member.updated', (event) => {
               if (
-                event.member.output_volume === SPEAKER_VOLUME &&
-                event.member.member_id === memberTwoId
+                event.member.member_id === memberTwoId &&
+                event.member.output_volume === SPEAKER_VOLUME
               )
                 res(true)
             })

--- a/internal/e2e-js/tests/callfabric/reattach.spec.ts
+++ b/internal/e2e-js/tests/callfabric/reattach.spec.ts
@@ -65,55 +65,68 @@ test.describe('CallFabric Reattach', () => {
     // await expectMCUVisible(page)
   })
 
-  test('should join a room, update room states, reload and reattach with correct states', async ({
+  test('should join a room, update room and self member states, reload and reattach with correct states', async ({
     createCustomPage,
     resource,
   }) => {
     const page = await createCustomPage({ name: '[page]' })
     await page.goto(SERVER_URL)
 
-    const roomName = `e2e-video-room_${uuid()}`
+    const roomName = `e2e-video-room-${uuid()}`
     await resource.createVideoRoomResource(roomName)
 
     await createCFClient(page)
 
     // Dial an address and join a video room
-    let roomSessionBefore = await dialAddress(page, {
+    const roomSessionBefore: CallJoinedEventParams = await dialAddress(page, {
       address: `/public/${roomName}?channel=video`,
     })
-
     expect(roomSessionBefore.room_session).toBeDefined()
-
     await expectMCUVisible(page)
+    const memberId = roomSessionBefore.member_id
 
     // --------------- Muting Video (self) ---------------
     await test.step('mute the self video', async () => {
-      await page.evaluate(async () => {
+      await page.evaluate(async (memberId) => {
         // @ts-expect-error
         const roomObj: FabricRoomSession = window._roomObj
 
         const memberUpdatedMutedEvent = new Promise((res) => {
-          roomObj.on('member.updated.videoMuted', () => res(true))
+          roomObj.on('member.updated.videoMuted', (event) => {
+            if (
+              event.member.member_id === memberId &&
+              event.member.video_muted === true
+            ) {
+              res(true)
+            }
+          })
         })
 
         await roomObj.videoMute()
         await memberUpdatedMutedEvent
-      })
+      }, memberId)
     })
 
     // --------------- Muting Audio (self) ---------------
     await test.step('mute the self audio', async () => {
-      await page.evaluate(async () => {
+      await page.evaluate(async (memberId) => {
         // @ts-expect-error
         const roomObj: FabricRoomSession = window._roomObj
 
         const memberUpdatedMutedEvent = new Promise((res) => {
-          roomObj.on('member.updated.audioMuted', () => res(true))
+          roomObj.on('member.updated.audioMuted', (event) => {
+            if (
+              event.member.member_id === memberId &&
+              event.member.audio_muted === true
+            ) {
+              res(true)
+            }
+          })
         })
 
         await roomObj.audioMute()
         await memberUpdatedMutedEvent
-      })
+      }, memberId)
     })
 
     // --------------- Room lock ---------------
@@ -124,10 +137,10 @@ test.describe('CallFabric Reattach', () => {
           // @ts-expect-error
           const roomObj: FabricRoomSession = window._roomObj
 
-          const roomUpdatedLocked = new Promise((resolve) => {
+          const roomUpdatedLocked = new Promise((res) => {
             roomObj.on('room.updated', (params) => {
               if (params.room_session.locked === true) {
-                resolve(true)
+                res(true)
               }
             })
           })
@@ -142,58 +155,81 @@ test.describe('CallFabric Reattach', () => {
     const MIC_VOLUME = 10
     const SPEAKER_VOLUME = 10
 
-    // --------------- Change Audio Volume ---------------
+    // --------------- Change Audio Volume (self) ---------------
     await test.step('change mic volume', async () => {
-      await page.evaluate(async (MIC_VOLUME) => {
-        // @ts-expect-error
-        const roomObj: FabricRoomSession = window._roomObj
+      await page.evaluate(
+        async ({ MIC_VOLUME, memberId }) => {
+          // @ts-expect-error
+          const roomObj: FabricRoomSession = window._roomObj
 
-        const memberUpdatedEvent = new Promise((res) => {
-          roomObj.on('member.updated', (event) => {
-            if (event.member.input_volume === MIC_VOLUME) res(true)
+          const memberUpdatedEvent = new Promise((res) => {
+            roomObj.on('member.updated', (event) => {
+              if (
+                event.member.member_id === memberId &&
+                event.member.input_volume === MIC_VOLUME
+              ) {
+                res(true)
+              }
+            })
           })
-        })
 
-        await roomObj.setInputVolume({ volume: MIC_VOLUME })
-        await memberUpdatedEvent
-      }, MIC_VOLUME)
+          await roomObj.setInputVolume({ volume: MIC_VOLUME })
+          await memberUpdatedEvent
+        },
+        { MIC_VOLUME, memberId }
+      )
     })
 
-    // --------------- Change Speaker Volume ---------------
+    // --------------- Change Speaker Volume (self) ---------------
     await test.step('change speaker volume', async () => {
-      await page.evaluate(async (SPEAKER_VOLUME) => {
-        // @ts-expect-error
-        const roomObj: FabricRoomSession = window._roomObj
+      await page.evaluate(
+        async ({ SPEAKER_VOLUME, memberId }) => {
+          // @ts-expect-error
+          const roomObj: FabricRoomSession = window._roomObj
 
-        const memberUpdatedEvent = new Promise((res) => {
-          roomObj.on('member.updated', (event) => {
-            if (event.member.input_volume === SPEAKER_VOLUME) res(true)
+          const memberUpdatedEvent = new Promise((res) => {
+            roomObj.on('member.updated', (event) => {
+              if (
+                event.member.member_id === memberId &&
+                event.member.input_volume === SPEAKER_VOLUME
+              ) {
+                res(true)
+              }
+            })
           })
-        })
 
-        await roomObj.setOutputVolume({ volume: SPEAKER_VOLUME })
-        await memberUpdatedEvent
-      }, SPEAKER_VOLUME)
+          await roomObj.setOutputVolume({ volume: SPEAKER_VOLUME })
+          await memberUpdatedEvent
+        },
+        { SPEAKER_VOLUME, memberId }
+      )
     })
 
     // --------------- Change Noise Gate ---------------
     // TODO: Enable this when the server issue is fixed
     // await test.step('change noise gate', async () => {
-    //   await page.evaluate(async () => {
-    //     // @ts-expect-error
-    //     const roomObj: FabricRoomSession = window._roomObj
+    //   await page.evaluate(
+    //     async ({ memberId }) => {
+    //       // @ts-expect-error
+    //       const roomObj: FabricRoomSession = window._roomObj
 
-    //     const NOISE_SENSITIVITY = 10
-    //     const memberUpdatedEvent = new Promise((res) => {
-    //       roomObj.on('member.updated', (event) => {
-    //         if (event.member.input_sensitivity === NOISE_SENSITIVITY) res(true)
-    //         res(true)
+    //       const NOISE_SENSITIVITY = 10
+    //       const memberUpdatedEvent = new Promise((res) => {
+    //         roomObj.on('member.updated', (event) => {
+    //           if (
+    //             event.member.member_id === memberId &&
+    //             event.member.input_sensitivity === NOISE_SENSITIVITY
+    //           ) {
+    //             res(true)
+    //           }
+    //         })
     //       })
-    //     })
 
-    //     await roomObj.setInputSensitivity({ value: NOISE_SENSITIVITY })
-    //     await memberUpdatedEvent
-    //   })
+    //       await roomObj.setInputSensitivity({ value: NOISE_SENSITIVITY })
+    //       await memberUpdatedEvent
+    //     },
+    //     { memberId }
+    //   )
     // })
 
     const roomSessionAfter =
@@ -255,6 +291,207 @@ test.describe('CallFabric Reattach', () => {
     })
   })
 
+  test('should join a room, update other member states, reload and reattach with correct states', async ({
+    createCustomPage,
+    resource,
+  }) => {
+    const pageOne = await createCustomPage({ name: '[pageOne]' })
+    const pageTwo = await createCustomPage({ name: '[pageTwo]' })
+    await pageOne.goto(SERVER_URL)
+    await pageTwo.goto(SERVER_URL)
+
+    const roomName = `e2e-video-room-${uuid()}`
+    await resource.createVideoRoomResource(roomName)
+
+    await test.step('[pageOne] create client and join a room', async () => {
+      await createCFClient(pageOne)
+      // Dial an address and join a video room
+      const roomSession: CallJoinedEventParams = await dialAddress(pageOne, {
+        address: `/public/${roomName}?channel=video`,
+      })
+      expect(roomSession.room_session).toBeDefined()
+      expect(roomSession.room_session.members).toBeDefined()
+      expect(roomSession.room_session.members).toHaveLength(1)
+      await expectMCUVisible(pageOne)
+      return roomSession
+    })
+
+    const roomSessionTwo =
+      await test.step('[pageTwo] create client and join a room', async () => {
+        await createCFClient(pageTwo)
+        // Dial an address and join a video room
+        const roomSession: CallJoinedEventParams = await dialAddress(pageTwo, {
+          address: `/public/${roomName}?channel=video`,
+        })
+        expect(roomSession.room_session).toBeDefined()
+        expect(roomSession.room_session.members).toBeDefined()
+        expect(roomSession.room_session.members).toHaveLength(2)
+        await expectMCUVisible(pageTwo)
+        return roomSession
+      })
+
+    const [_memberOneId, memberTwoId] = roomSessionTwo.room_session.members.map(
+      (member) => member.member_id
+    )
+
+    // --------------- Muting Video (other member) ---------------
+    await test.step('[pageOne] mute video of memberTwo', async () => {
+      await pageOne.evaluate(async (memberTwoId) => {
+        // @ts-expect-error
+        const roomObj: FabricRoomSession = window._roomObj
+
+        const memberUpdatedMutedEvent = new Promise((res) => {
+          roomObj.on('member.updated.videoMuted', (event) => {
+            if (
+              event.member.member_id === memberTwoId &&
+              event.member.video_muted == true
+            ) {
+              res(true)
+            }
+          })
+        })
+
+        await roomObj.videoMute({ memberId: memberTwoId })
+        await memberUpdatedMutedEvent
+      }, memberTwoId)
+    })
+
+    // --------------- Muting Audio (other member) ---------------
+    await test.step('[pageOne] mute audio of memberTwo', async () => {
+      await pageOne.evaluate(async (memberTwoId) => {
+        // @ts-expect-error
+        const roomObj: FabricRoomSession = window._roomObj
+
+        const memberUpdatedMutedEvent = new Promise((res) => {
+          roomObj.on('member.updated.audioMuted', (event) => {
+            if (
+              event.member.member_id === memberTwoId &&
+              event.member.video_muted == true
+            ) {
+              res(true)
+            }
+          })
+        })
+
+        await roomObj.audioMute({ memberId: memberTwoId })
+        await memberUpdatedMutedEvent
+      }, memberTwoId)
+    })
+
+    const MIC_VOLUME = 10
+    const SPEAKER_VOLUME = 10
+
+    // --------------- Change Audio Volume (other member) ---------------
+    await test.step('[pageOne] change mic volume for memberTwo', async () => {
+      await pageOne.evaluate(
+        async ({ MIC_VOLUME, memberTwoId }) => {
+          // @ts-expect-error
+          const roomObj: FabricRoomSession = window._roomObj
+
+          const memberUpdatedEvent = new Promise((res) => {
+            roomObj.on('member.updated', (event) => {
+              if (
+                event.member.input_volume === MIC_VOLUME &&
+                event.member.member_id === memberTwoId
+              )
+                res(true)
+            })
+          })
+
+          await roomObj.setInputVolume({
+            volume: MIC_VOLUME,
+            memberId: memberTwoId,
+          })
+          await memberUpdatedEvent
+        },
+        { MIC_VOLUME, memberTwoId }
+      )
+    })
+
+    // --------------- Change Speaker Volume (other member) ---------------
+    await test.step('[pageOne] change speaker volume for memberTwo', async () => {
+      await pageOne.evaluate(
+        async ({ SPEAKER_VOLUME, memberTwoId }) => {
+          // @ts-expect-error
+          const roomObj: FabricRoomSession = window._roomObj
+
+          const memberUpdatedEvent = new Promise((res) => {
+            roomObj.on('member.updated', (event) => {
+              if (
+                event.member.input_volume === SPEAKER_VOLUME &&
+                event.member.member_id === memberTwoId
+              )
+                res(true)
+            })
+          })
+
+          await roomObj.setOutputVolume({ volume: SPEAKER_VOLUME })
+          await memberUpdatedEvent
+        },
+        { SPEAKER_VOLUME, memberTwoId }
+      )
+    })
+
+    // --------------- Change Noise Gate ---------------
+    // TODO: Add "setInputSensitivity" this when the server issue is fixed
+
+    const roomSessionTwoAfter =
+      await test.step('[pageTwo] relaod page and reattach', async () => {
+        await pageTwo.reload({ waitUntil: 'domcontentloaded' })
+        await createCFClient(pageTwo)
+
+        // Reattach to an address to join the same call session
+        const roomSession: CallJoinedEventParams = await pageTwo.evaluate(
+          async ({ roomName }) => {
+            return new Promise<any>(async (resolve, _reject) => {
+              const client = window._client!
+
+              const call = await client.reattach({
+                to: `/public/${roomName}?channel=video`,
+                rootElement: document.getElementById('rootElement'),
+              })
+
+              call.on('call.joined', resolve)
+
+              // @ts-expect-error
+              window._roomObj = call
+              await call.start()
+            })
+          },
+          { roomName }
+        )
+
+        return roomSession
+      })
+
+    await test.step('[pageTwo] assert room state', async () => {
+      expect(roomSessionTwoAfter.room_session).toBeDefined()
+      expect(roomSessionTwoAfter.call_id).toEqual(roomSessionTwo.call_id)
+      expect(roomSessionTwoAfter.room_session.members).toHaveLength(2)
+
+      const selfMember = roomSessionTwoAfter.room_session.members.find(
+        (member) => member.member_id === roomSessionTwoAfter.member_id
+      )
+
+      expect(selfMember).toBeDefined()
+      expect(selfMember?.audio_muted).toBe(true)
+      expect(selfMember?.video_muted).toBe(true)
+      expect(selfMember?.input_volume).toBe(MIC_VOLUME)
+      expect(selfMember?.output_volume).toBe(SPEAKER_VOLUME)
+
+      const localVideoTrack = await pageTwo.evaluate(
+        // @ts-expect-error
+        () => window._roomObj.peer.localVideoTrack
+      )
+      expect(localVideoTrack).toEqual({})
+      const localAudioTrack = await pageTwo.evaluate(
+        // @ts-expect-error
+        () => window._roomObj.peer.localAudioTrack
+      )
+      expect(localAudioTrack).toEqual({})
+    })
+  })
+
   // TODO uncomment after fixed in the backend
   // test('WebRTC to SWML to Room', async ({
   //   createCustomPage,
@@ -264,7 +501,7 @@ test.describe('CallFabric Reattach', () => {
   //   const page = await createCustomPage({ name: '[page]' })
   //   await page.goto(SERVER_URL)
 
-  //   const roomName = `e2e-video-room_${uuid()}`
+  //   const roomName = `e2e-video-room-${uuid()}`
   //   await resource.createVideoRoomResource(roomName)
   //   const resourceName = `e2e-swml-app_${uuid()}`
   //   await resource.createSWMLAppResource({

--- a/packages/js/src/fabric/index.ts
+++ b/packages/js/src/fabric/index.ts
@@ -23,5 +23,7 @@ export {
   SignalWireClientParams,
   GetSubscriberInfoResponse,
   GetSubscriberInfoResult,
+  PaginatedResponse,
+  PaginatedResult,
 } from './interfaces'
 export { FabricRoomSession, isFabricRoomSession } from './FabricRoomSession'


### PR DESCRIPTION
# Description

Bug fix: Expose the pagination types

E2E tests covering mute and volume APIs for the other member in the call with reattach. 

## Type of change

- [x] Internal refactoring
- [x] Bug fix (bugfix - non-breaking)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Code snippets

In case of new feature or breaking changes, please include code snippets.
