### PR TITLE
fix callfabric conversation spec

### DIFF
--- a/.changeset/rich-bugs-own.md
+++ b/.changeset/rich-bugs-own.md
@@ -1,0 +1,5 @@
+---
+'@sw-internal/e2e-js': patch
+---
+
+Fix conversation spec by making sure promise doesn't resolve on call logs conversation.message and also allow for GET messages response assert to include more than 2 messages in case they include call logs

--- a/internal/e2e-js/tests/callfabric/conversation.spec.ts
+++ b/internal/e2e-js/tests/callfabric/conversation.spec.ts
@@ -34,7 +34,13 @@ test.describe('Conversation Room', () => {
           })
           const roomAddress = addresses.data[0]
           const addressId = roomAddress.id
-          client.conversation.subscribe(resolve)
+          // Note: subscribe will trigger for call logs too
+          // we need to make sure call logs don't resolve promise
+          client.conversation.subscribe((event) => {
+            if (event.subtype == 'chat') {
+              resolve(event)
+            }
+          })
           client.conversation.sendMessage({
             text: '1st message from 1st subscriber',
             addressId,
@@ -52,7 +58,14 @@ test.describe('Conversation Room', () => {
       return new Promise<ConversationMessageEventParams>((resolve) => {
         // @ts-expect-error
         const client: SignalWireClient = window._client
-        client.conversation.subscribe(resolve)
+        // Note: subscribe will trigger for call logs too
+        // we need to make sure call logs don't resolve promise
+        client.conversation.subscribe((event) => {
+          // Note we need to do this
+          if (event.subtype == 'chat') {
+            resolve(event)
+          }
+        })
       })
     })
 
@@ -61,7 +74,13 @@ test.describe('Conversation Room', () => {
         return new Promise<ConversationMessageEventParams>(async (resolve) => {
           // @ts-expect-error
           const client: SignalWireClient = window._client
-          client.conversation.subscribe(resolve)
+          // Note: subscribe will trigger for call logs too
+          // we need to make sure call logs don't resolve promise
+          client.conversation.subscribe((event) => {
+            if (event.subtype == 'chat') {
+              resolve(event)
+            }
+          })
           const result = await client.conversation.getConversations()
           const convo = result.data.filter((c) => c.id == addressId)[0]
           convo.sendMessage({
@@ -94,29 +113,35 @@ test.describe('Conversation Room', () => {
 
     expect(messages).not.toBeUndefined()
 
-    expect(messages.data.length).toEqual(2)
-    expect(messages.data[0]).toMatchObject({
-      conversation_id: addressId,
-      details: {},
-      id: expect.anything(),
-      kind: null,
-      subtype: 'chat',
-      text: '1st message from 2nd subscriber',
-      ts: expect.anything(),
-      type: 'message',
-      user_id: expect.anything(),
-    })
+    // Note: even though we are only sending 2 messages
+    // there can be call logs inside the messages
+    expect(messages.data.length).toBeGreaterThanOrEqual(2)
 
-    expect(messages.data[1]).toMatchObject({
-      conversation_id: addressId,
-      details: {},
-      id: expect.anything(),
-      kind: null,
-      subtype: 'chat',
-      text: '1st message from 1st subscriber',
-      ts: expect.anything(),
-      type: 'message',
-      user_id: expect.anything(),
-    })
+    expect(messages.data).toEqual(expect.arrayContaining(
+      [
+        expect.objectContaining({
+          conversation_id: addressId,
+          details: {},
+          id: expect.anything(),
+          kind: null,
+          subtype: 'chat',
+          text: '1st message from 2nd subscriber',
+          ts: expect.anything(),
+          type: 'message',
+          user_id: expect.anything(),
+        }),
+        expect.objectContaining({
+          conversation_id: addressId,
+          details: {},
+          id: expect.anything(),
+          kind: null,
+          subtype: 'chat',
+          text: '1st message from 1st subscriber',
+          ts: expect.anything(),
+          type: 'message',
+          user_id: expect.anything(),
+        })
+      ]
+    ))
   })
 })


### PR DESCRIPTION
# Description

- Made sure `conversation.message` event's with `subtype: "log"` doesn't resolve promises by accidents
- Allow for GET messages response to contain more then 2 messages, in case if it has call logs in it

 ## Type of change

- [ ] Internal refactoring
- [x] Bug fix (bugfix - non-breaking)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

