### PR TITLE
(Bug Fix)Allow to receive Push Notifications without calling online

### DIFF
--- a/.changeset/angry-bags-relax.md
+++ b/.changeset/angry-bags-relax.md
@@ -2,4 +2,4 @@
 '@signalwire/js': patch
 ---
 
-Added optional `incomingCallHandler` parameter to `handlePushNotification()`
+CF SDK: Optional `incomingCallHandler` parameter to `handlePushNotification()`

--- a/.changeset/angry-bags-relax.md
+++ b/.changeset/angry-bags-relax.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/js': patch
+---
+
+Added optional `incomingCallHandler` parameter to `handlePushNotification()`

--- a/packages/js/src/fabric/WSClient.ts
+++ b/packages/js/src/fabric/WSClient.ts
@@ -329,8 +329,10 @@ export class WSClient extends BaseClient<{}> implements WSClientContract {
 
   public handlePushNotification(params: HandlePushNotificationParams) {
     const { pushNotificationPayload, incomingCallHandler } = params
-    this._incomingCallManager.setNotificationHandlers({ pushNotification: incomingCallHandler })
-    
+    this._incomingCallManager.setNotificationHandlers({
+      pushNotification: incomingCallHandler,
+    })
+
     return new Promise<HandlePushNotificationResult>(
       async (resolve, reject) => {
         const { decrypted, type } = pushNotificationPayload
@@ -383,7 +385,9 @@ export class WSClient extends BaseClient<{}> implements WSClientContract {
    */
   public async online({ incomingCallHandlers }: OnlineParams) {
     if (incomingCallHandlers.all || incomingCallHandlers.pushNotification) {
-      this.logger.warn(`Don't use online with Push Notification`)
+      this.logger.warn(
+        `Make sure the device is not register to receive Push Notification while is online`
+      )
     }
     this._incomingCallManager.setNotificationHandlers(incomingCallHandlers)
     return this.execute<unknown, void>({

--- a/packages/js/src/fabric/WSClient.ts
+++ b/packages/js/src/fabric/WSClient.ts
@@ -328,19 +328,19 @@ export class WSClient extends BaseClient<{}> implements WSClientContract {
   }
 
   public handlePushNotification(params: HandlePushNotificationParams) {
-    const { pushNotificationPayload, incomingCallHandler } = params
+    const { incomingCallHandler } = params
     this._incomingCallManager.setNotificationHandlers({
       pushNotification: incomingCallHandler,
     })
 
     return new Promise<HandlePushNotificationResult>(
       async (resolve, reject) => {
-        const { decrypted, type } = pushNotificationPayload
+        const { decrypted, type } = params
         if (type !== 'call_invite') {
-          this.logger.warn('Unknown notification type', pushNotificationPayload)
+          this.logger.warn('Unknown notification type', params)
           reject('Unknown notification type')
         }
-        this.logger.debug('handlePushNotification', pushNotificationPayload)
+        this.logger.debug('handlePushNotification', params)
         const {
           params: { params: payload },
           node_id: nodeId,

--- a/packages/js/src/fabric/WSClient.ts
+++ b/packages/js/src/fabric/WSClient.ts
@@ -386,7 +386,7 @@ export class WSClient extends BaseClient<{}> implements WSClientContract {
   public async online({ incomingCallHandlers }: OnlineParams) {
     if (incomingCallHandlers.all || incomingCallHandlers.pushNotification) {
       this.logger.warn(
-        `Make sure the device is not register to receive Push Notification while is online`
+        `Make sure the device is not registered to receive Push Notifications while it is online`
       )
     }
     this._incomingCallManager.setNotificationHandlers(incomingCallHandlers)

--- a/packages/js/src/fabric/interfaces/wsClient.ts
+++ b/packages/js/src/fabric/interfaces/wsClient.ts
@@ -1,8 +1,5 @@
 import { SessionOptions, UserOptions } from '@signalwire/core'
-import {
-  IncomingCallHandler,
-  IncomingCallHandlers,
-} from './incomingCallManager'
+import { IncomingCallHandlers } from './incomingCallManager'
 import { FabricRoomSession } from '../FabricRoomSession'
 
 export interface WSClientContract {
@@ -57,13 +54,7 @@ export interface WSClientContract {
 }
 
 export interface OnlineParams {
-  incomingCallHandlers: {
-  /** @deprecated */
-  all?: IncomingCallHandler
-  /** @deprecated */
-  pushNotification?: IncomingCallHandler
-  websocket?: IncomingCallHandler
-}
+  incomingCallHandlers: IncomingCallHandlers
 }
 
 export interface PushNotificationPayload {
@@ -81,10 +72,7 @@ export interface PushNotificationPayload {
   decrypted: Record<string, any>
 }
 
-export interface HandlePushNotificationParams {
-  pushNotificationPayload: PushNotificationPayload
-  incomingCallHandler: IncomingCallHandler
-}
+export type HandlePushNotificationParams = PushNotificationPayload
 
 export interface HandlePushNotificationResult {
   resultType: 'inboundCall'

--- a/packages/js/src/fabric/interfaces/wsClient.ts
+++ b/packages/js/src/fabric/interfaces/wsClient.ts
@@ -1,5 +1,8 @@
 import { SessionOptions, UserOptions } from '@signalwire/core'
-import { IncomingCallHandlers } from './incomingCallManager'
+import {
+  IncomingCallHandler,
+  IncomingCallHandlers,
+} from './incomingCallManager'
 import { FabricRoomSession } from '../FabricRoomSession'
 
 export interface WSClientContract {
@@ -54,7 +57,13 @@ export interface WSClientContract {
 }
 
 export interface OnlineParams {
-  incomingCallHandlers: IncomingCallHandlers
+  incomingCallHandlers: {
+  /** @deprecated */
+  all?: IncomingCallHandler
+  /** @deprecated */
+  pushNotification?: IncomingCallHandler
+  websocket?: IncomingCallHandler
+}
 }
 
 export interface PushNotificationPayload {
@@ -72,7 +81,10 @@ export interface PushNotificationPayload {
   decrypted: Record<string, any>
 }
 
-export type HandlePushNotificationParams = PushNotificationPayload
+export interface HandlePushNotificationParams {
+  pushNotificationPayload: PushNotificationPayload
+  incomingCallHandler: IncomingCallHandler
+}
 
 export interface HandlePushNotificationResult {
   resultType: 'inboundCall'

--- a/packages/js/src/fabric/interfaces/wsClient.ts
+++ b/packages/js/src/fabric/interfaces/wsClient.ts
@@ -1,5 +1,8 @@
 import { SessionOptions, UserOptions } from '@signalwire/core'
-import { IncomingCallHandlers } from './incomingCallManager'
+import {
+  IncomingCallHandler,
+  IncomingCallHandlers,
+} from './incomingCallManager'
 import { FabricRoomSession } from '../FabricRoomSession'
 
 export interface WSClientContract {
@@ -72,7 +75,9 @@ export interface PushNotificationPayload {
   decrypted: Record<string, any>
 }
 
-export type HandlePushNotificationParams = PushNotificationPayload
+export type HandlePushNotificationParams = PushNotificationPayload & {
+  incomingCallHandler?: IncomingCallHandler
+}
 
 export interface HandlePushNotificationResult {
   resultType: 'inboundCall'


### PR DESCRIPTION
# Description

The same client/device can't be reachable via WebSocket and Push Notifications at the same time, since the server can't tell that both gateways belong to the client/device. The server will then send 2 invites for the same client/device, and once any of them are answered, a `verto.bye` is sent to the same client/device, hanging up the call.  

To allow the developer to receive the Push Notifications without being online at the same time, this adds an optional `incomingCallHandler` handlePushNotification` method. 


## Type of change

- [ ] Internal refactoring
- [X] Bug fix (bugfix - non-breaking)
- [X] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Code snippets

In case of new features or breaking changes, please include code snippets.
