### PR TITLE
skip origin in prepare_public_folder.sh

### DIFF
--- a/prepare_public_folder.sh
+++ b/prepare_public_folder.sh
@@ -15,7 +15,7 @@ git fetch --no-tags
 for branch_name in $(git for-each-ref --format='%(refname:short)' refs/remotes/origin/); do
   # Remove `remote/` from refname
   branch=${branch_name/origin\//}
-  if [[ $branch == "canary" ]]; then
+  if [[ $branch == "canary" || $branch == "origin"]]; then
     # canary branch is too old!
     echo "Skip canary branch"
     continue


### PR DESCRIPTION
# Description

Since `origin` is not a branch we need to skip it too.

## Type of change

- [ ] Internal refactoring
- [ ] Bug fix (bugfix - non-breaking)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Code snippets

In case of new feature or breaking changes, please include code snippets.
