### PR TITLE
temporarily disable status webhook callback tests

### DIFF
--- a/.changeset/soft-shoes-bathe.md
+++ b/.changeset/soft-shoes-bathe.md
@@ -1,0 +1,5 @@
+---
+'@sw-internal/e2e-js': patch
+---
+
+Temporarily disable status webhook callback tests

--- a/internal/e2e-js/tests/v2Webrtc/v2WebrtcFromRest.spec.ts
+++ b/internal/e2e-js/tests/v2Webrtc/v2WebrtcFromRest.spec.ts
@@ -484,7 +484,7 @@ test.describe('v2WebrtcFromRest422', () => {
 
 const callStatusWebhookDescription = 'should receive call status webhook callback'
 
-test.describe('v2WebRTCFromRestCallStatusWebhook', () => {
+test.describe.skip('v2WebRTCFromRestCallStatusWebhook', () => {
   test(callStatusWebhookDescription, async ({
     createCustomVanillaPage,
   }) => {
@@ -631,7 +631,7 @@ test.describe('v2WebRTCFromRestCallStatusWebhook', () => {
 
 
 const conferenceWebhookDescription = 'should receive conference status webhook callbacks'
-test.describe('v2WebrtcFromRest', () => {
+test.describe.skip('v2WebrtcFromRest', () => {
   test(conferenceWebhookDescription, async ({
     createCustomVanillaPage,
   }) => {


### PR DESCRIPTION
# Description

Temporarily disable call/conference status webhook callback tests

## Type of change

- [ ] Internal refactoring
- [ ] Bug fix (bugfix - non-breaking)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Patch

## Code snippets

In case of new feature or breaking changes, please include code snippets.
