### PR TITLE
Playground support for the Fabric Address ID

### DIFF
--- a/internal/playground-js/src/fabric/index.html
+++ b/internal/playground-js/src/fabric/index.html
@@ -70,6 +70,16 @@
                 />
               </div>
               <div class="form-group">
+                <label for="fromFabricAddressId">From Fabric Address ID</label>
+                <input
+                  type="text"
+                  class="form-control"
+                  id="fromFabricAddressId"
+                  placeholder="4454-4454-4454-4454"
+                  onchange="saveInLocalStorage(event)"
+                />
+              </div>
+              <div class="form-group">
                 <div>Call Options:</div>
                 <div class="form-check">
                   <input

--- a/internal/playground-js/src/fabric/index.js
+++ b/internal/playground-js/src/fabric/index.js
@@ -311,6 +311,7 @@ window.dial = async ({ reattach = false } = {}) => {
     nodeId: steeringId,
     to: document.getElementById('destination').value,
     rootElement: document.getElementById('rootElement'),
+    fromFabricAddressId: document.getElementById('fromFabricAddressId').value,
     video: document.getElementById('video').checked,
     audio: document.getElementById('audio').checked,
   })
@@ -904,6 +905,8 @@ window.ready(async function () {
     localStorage.getItem('fabric.ws.token') || ''
   document.getElementById('destination').value =
     localStorage.getItem('fabric.ws.destination') || ''
+  document.getElementById('fromFabricAddressId').value =
+    localStorage.getItem('fabric.ws.fromFabricAddressId') || ''
   document.getElementById('audio').checked = true
   document.getElementById('video').checked =
     localStorage.getItem('fabric.ws.video') === 'true'


### PR DESCRIPTION
# Description

Allow playground to pass the fromFabricAddressId through a text field. (For internal testing)

## Type of change

- [x] Internal refactoring
- [ ] Bug fix (bugfix - non-breaking)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Code snippets

In case of new feature or breaking changes, please include code snippets.
