### PR TITLE
Fix streaming test race condition by closing pageTwo before cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,9 +36,4 @@ public/
 .devcontainer/
 CLAUDE.md
 .claude/settings.local.json
-.my-notes/components.md
-.my-notes/ComponentRelations.md
-.my-notes/next-steps-protocol-exploration.md
-.my-notes/signalwire-protocol-documentation.md
-.my-notes/signalwire-protocol-exploration-plan.md
-.my-notes/websocket_reconnections.md
+.my-notes/

--- a/internal/e2e-js/tests/roomSessionStreamingAPI.spec.ts
+++ b/internal/e2e-js/tests/roomSessionStreamingAPI.spec.ts
@@ -52,6 +52,10 @@ test.describe('Room Streaming from REST API', () => {
     const STREAM_CHECK_URL = process.env.STREAM_CHECK_URL!
     await pageTwo.goto(STREAM_CHECK_URL, { waitUntil: 'domcontentloaded' })
     await pageTwo.waitForSelector(`text=${streamName}`, { timeout: 10_000 })
+    
+    // Close pageTwo explicitly before cleanup to prevent race condition
+    await pageTwo.close()
+    
     await deleteRoom(roomData.id)
   })
 })


### PR DESCRIPTION
- Add explicit pageTwo.close() before deleteRoom() in roomSessionStreamingAPI test
- Prevents 'Execution context was destroyed' error during fixture cleanup
- Fixes race condition where cleanup runs while page is navigating to external URL
- Solution addresses timing differences between local and CI environments

🤖 Generated with [Claude Code](https://claude.ai/code)

