### PR TITLE
WIP: Fix streaming test race condition with navigation wait

### DIFF
--- a/internal/e2e-js/tests/roomSessionStreamingAPI.spec.ts
+++ b/internal/e2e-js/tests/roomSessionStreamingAPI.spec.ts
@@ -52,6 +52,13 @@ test.describe('Room Streaming from REST API', () => {
     const STREAM_CHECK_URL = process.env.STREAM_CHECK_URL!
     await pageTwo.goto(STREAM_CHECK_URL, { waitUntil: 'domcontentloaded' })
     await pageTwo.waitForSelector(`text=${streamName}`, { timeout: 10_000 })
+    
+    // Wait for page to be stable before cleanup
+    await pageTwo.waitForLoadState('domcontentloaded')
+    
+    // Additional wait to ensure external page is fully loaded
+    await pageTwo.waitForTimeout(3000)
+    
     await deleteRoom(roomData.id)
   })
 })


### PR DESCRIPTION
Add explicit wait for external page navigation to complete before test cleanup runs, preventing race condition failures:

- Wait for domcontentloaded state after navigation
- Add 3-second timeout to ensure page is fully stable
- Ensures external page (STREAM_CHECK_URL) is completely loaded before cleanup

This eliminates the "Execution context was destroyed" error that occurs when the test fixture cleanup runs while the external page is still navigating or loading, specifically fixing the streaming test failures in GitHub Actions.

🤖 Generated with [Claude Code](https://claude.ai/code)

# Description

Please include a summary of the change and which issue is fixed. 

## Type of change

- [ ] Internal refactoring
- [ ] Bug fix (bugfix - non-breaking)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Code snippets

In case of new feature or breaking changes, please include code snippets.
