### PR TITLE
BUg Fix: Incoming calls are unable to send the `verto.answer`

### DIFF
--- a/internal/e2e-client/tests/callfabric/incoming_call_over_websocket.spec.ts
+++ b/internal/e2e-client/tests/callfabric/incoming_call_over_websocket.spec.ts
@@ -1,0 +1,119 @@
+import { CallSession } from '@signalwire/client'
+import { test, expect } from '../../fixtures'
+import {
+  SERVER_URL,
+  createCFClient,
+  dialAddress,
+} from '../../utils'
+
+test.describe('CallFabric Incoming Call over WebSocket', () => {
+  test('should handle incoming call via WebSocket between two subscribers', async ({
+    createCustomPage,
+  }) => {
+    // Create a page named Callee
+    const calleePage = await createCustomPage({ name: '[callee]' })
+    await calleePage.goto(SERVER_URL)
+
+    // Create a page named Caller
+    const callerPage = await createCustomPage({ name: '[caller]' })
+    await callerPage.goto(SERVER_URL)
+
+    // Create clients for both pages
+    await createCFClient(calleePage, { reference: 'callee' })
+    await createCFClient(callerPage, { reference: 'caller' })
+
+    // In Callee page: use client.address.getMyAddresses to find the callee address
+    const calleeAddress = await calleePage.evaluate(async () => {
+      const client = window._client!
+      const addresses = await client.address.getMyAddresses()
+      
+      if (!addresses || addresses.length === 0) {
+        throw new Error('No addresses found for callee')
+      }
+      
+        const myAddressId = addresses[0].id
+        const myAddress = await client.address.getAddress({ id: myAddressId })
+        return myAddress.channels.video
+    })
+
+    expect(calleeAddress).toBeTruthy()
+
+    // In Callee page: set up promise to track call events
+    const calleeCallAnsweredPromise = calleePage.evaluate(() => {
+      return new Promise<boolean>((resolve) => {
+        // @ts-expect-error
+        window._calleeCallAnswered = resolve
+      })
+    })
+
+    const calleeCallDestroyedPromise = calleePage.evaluate(() => {
+      return new Promise<boolean>((resolve) => {
+        // @ts-expect-error
+        window._calleeCallDestroyed = resolve
+      })
+    })
+
+    // In Callee page: use client.online to register a listener for invites over WebSocket only
+    await calleePage.evaluate(async () => {
+      const client = window._client!
+      
+      await client.online({
+        incomingCallHandlers: {
+          websocket: (notification) => {
+            console.log('Callee received incoming call:', notification.invite.details)
+            
+            // Accept the call
+            notification.invite.accept({
+              rootElement: document.getElementById('rootElement')!,
+              audio: true,
+              video: true,
+            }).then(async calleeCall => {
+                // @ts-expect-error
+            window._calleeCall = calleeCall
+
+            // Set up event listeners
+            calleeCall.on('call.state', (state) => {
+              console.log('Callee call state:', state.call_state)
+            })
+
+            calleeCall.on('destroy', () => {
+              console.log('Callee call destroyed')
+              // @ts-expect-error
+              window._calleeCallDestroyed(true)
+            })
+            
+            // @ts-expect-error
+            window._calleeCallAnswered(true)
+            })
+          }
+        }
+      })
+    })
+
+    // In Caller: dial the callee address with "?channel=video"
+    const callerDialPromise = dialAddress(callerPage, {
+        address: calleeAddress ?? '',
+    })
+
+    // Wait for both the caller to connect and callee to answer
+    const [callerCallSession, calleeAnswered] = await Promise.all([
+      callerDialPromise,
+      calleeCallAnsweredPromise,
+    ])
+
+    expect(calleeAnswered).toBe(true)
+    expect(callerCallSession).toBeDefined()
+
+
+    // In Caller page: hang up the call
+    await callerPage.evaluate(async () => {
+      // @ts-expect-error
+      const callObj: CallSession = window._callObj
+      await callObj.hangup()
+    })
+
+    // In Callee page: expect the call to be destroyed
+    const calleeDestroyed = await calleeCallDestroyedPromise
+    expect(calleeDestroyed).toBe(true)
+  })
+})

--- a/internal/e2e-client/tests/callfabric/incoming_call_over_websocket.spec.ts
+++ b/internal/e2e-client/tests/callfabric/incoming_call_over_websocket.spec.ts
@@ -1,10 +1,6 @@
 import { CallSession } from '@signalwire/client'
 import { test, expect } from '../../fixtures'
-import {
-  SERVER_URL,
-  createCFClient,
-  dialAddress,
-} from '../../utils'
+import { SERVER_URL, createCFClient, dialAddress } from '../../utils'
 
 test.describe('CallFabric Incoming Call over WebSocket', () => {
   test('should handle incoming call via WebSocket between two subscribers', async ({
@@ -26,14 +22,14 @@ test.describe('CallFabric Incoming Call over WebSocket', () => {
     const calleeAddress = await calleePage.evaluate(async () => {
       const client = window._client!
       const addresses = await client.address.getMyAddresses()
-      
+
       if (!addresses || addresses.length === 0) {
         throw new Error('No addresses found for callee')
       }
-      
-        const myAddressId = addresses[0].id
-        const myAddress = await client.address.getAddress({ id: myAddressId })
-        return myAddress.channels.video
+
+      const myAddressId = addresses[0].id
+      const myAddress = await client.address.getAddress({ id: myAddressId })
+      return myAddress.channels.video
     })
 
     expect(calleeAddress).toBeTruthy()
@@ -56,43 +52,48 @@ test.describe('CallFabric Incoming Call over WebSocket', () => {
     // In Callee page: use client.online to register a listener for invites over WebSocket only
     await calleePage.evaluate(async () => {
       const client = window._client!
-      
+
       await client.online({
         incomingCallHandlers: {
           websocket: (notification) => {
-            console.log('Callee received incoming call:', notification.invite.details)
-            
+            console.log(
+              'Callee received incoming call:',
+              notification.invite.details
+            )
+
             // Accept the call
-            notification.invite.accept({
-              rootElement: document.getElementById('rootElement')!,
-              audio: true,
-              video: true,
-            }).then(async calleeCall => {
+            notification.invite
+              .accept({
+                rootElement: document.getElementById('rootElement')!,
+                audio: true,
+                video: true,
+              })
+              .then(async (calleeCall) => {
                 // @ts-expect-error
-            window._calleeCall = calleeCall
+                window._calleeCall = calleeCall
 
-            // Set up event listeners
-            calleeCall.on('call.state', (state) => {
-              console.log('Callee call state:', state.call_state)
-            })
+                // Set up event listeners
+                calleeCall.on('call.state', (state) => {
+                  console.log('Callee call state:', state.call_state)
+                })
 
-            calleeCall.on('destroy', () => {
-              console.log('Callee call destroyed')
-              // @ts-expect-error
-              window._calleeCallDestroyed(true)
-            })
-            
-            // @ts-expect-error
-            window._calleeCallAnswered(true)
-            })
-          }
-        }
+                calleeCall.on('destroy', () => {
+                  console.log('Callee call destroyed')
+                  // @ts-expect-error
+                  window._calleeCallDestroyed(true)
+                })
+
+                // @ts-expect-error
+                window._calleeCallAnswered(true)
+              })
+          },
+        },
       })
     })
 
     // In Caller: dial the callee address with "?channel=video"
     const callerDialPromise = dialAddress(callerPage, {
-        address: calleeAddress ?? '',
+      address: calleeAddress ?? '',
     })
 
     // Wait for both the caller to connect and callee to answer
@@ -103,7 +104,6 @@ test.describe('CallFabric Incoming Call over WebSocket', () => {
 
     expect(calleeAnswered).toBe(true)
     expect(callerCallSession).toBeDefined()
-
 
     // In Caller page: hang up the call
     await callerPage.evaluate(async () => {

--- a/internal/e2e-client/utils.ts
+++ b/internal/e2e-client/utils.ts
@@ -137,7 +137,7 @@ export const createTestJWTToken = async (body: CreateTestJWTOptions) => {
   return data.jwt_token
 }
 
-export const createTestSATToken = async (reference?:String) => {
+export const createTestSATToken = async (reference?: string) => {
   const response = await fetch(
     `https://${process.env.API_HOST}/api/fabric/subscribers/tokens`,
     {

--- a/internal/e2e-client/utils.ts
+++ b/internal/e2e-client/utils.ts
@@ -137,7 +137,7 @@ export const createTestJWTToken = async (body: CreateTestJWTOptions) => {
   return data.jwt_token
 }
 
-export const createTestSATToken = async () => {
+export const createTestSATToken = async (reference?:String) => {
   const response = await fetch(
     `https://${process.env.API_HOST}/api/fabric/subscribers/tokens`,
     {
@@ -147,7 +147,7 @@ export const createTestSATToken = async () => {
         Authorization: `Basic ${BASIC_TOKEN}`,
       },
       body: JSON.stringify({
-        reference: process.env.SAT_REFERENCE,
+        reference: reference || process.env.SAT_REFERENCE,
       }),
     }
   )
@@ -341,13 +341,14 @@ export const leaveRoom = async (page: Page) => {
 
 interface CreateCFClientParams {
   attachSagaMonitor?: boolean
+  reference?: string
 }
 
 export const createCFClient = async (
   page: Page,
   params?: CreateCFClientParams
 ) => {
-  const sat = await createTestSATToken()
+  const sat = await createTestSATToken(params?.reference)
   return createCFClientWithToken(page, sat, params)
 }
 

--- a/packages/webrtc/src/RTCPeer.ts
+++ b/packages/webrtc/src/RTCPeer.ts
@@ -891,10 +891,13 @@ export default class RTCPeer<EventTypes extends EventEmitter.ValidEventTypes> {
 
     // Check if we're still in the right state
     if (
+      this.type === 'offer' &&
       !['have-local-offer', 'have-local-pranswer'].includes(
         this.instance.signalingState
       )
     ) {
+      // the local SDP was processed already and onnegotiationneeded was not fired
+      // this happens because there multiple places calling _sdpReady
       this.logger.warn(
         `_sdpReady called in wrong state: ${this.instance.signalingState}`
       )
@@ -1020,7 +1023,7 @@ export default class RTCPeer<EventTypes extends EventEmitter.ValidEventTypes> {
       if (this.instance.localDescription?.sdp) {
         if (sdpHasValidCandidates(this.instance.localDescription.sdp)) {
           // Take a snapshot of candidates at this point
-          if (this._candidatesSnapshot.length === 0) {
+          if (this._candidatesSnapshot.length === 0 && this.type === 'offer') {
             this._candidatesSnapshot = [...this._allCandidates]
             this.logger.info(
               'SDP has candidates for all media sections, calling _sdpReady for early invite'

--- a/packages/webrtc/src/RTCPeer.ts
+++ b/packages/webrtc/src/RTCPeer.ts
@@ -897,7 +897,7 @@ export default class RTCPeer<EventTypes extends EventEmitter.ValidEventTypes> {
       )
     ) {
       // the local SDP was processed already and onnegotiationneeded was not fired
-      // this happens because there multiple places calling _sdpReady
+      // this happens because there are multiple places calling _sdpReady
       this.logger.warn(
         `_sdpReady called in wrong state: ${this.instance.signalingState}`
       )


### PR DESCRIPTION
# Description

The PR that fixed the race condition with `_sdpReady` didn't tested the incoming call use case. Only offers need to the `signalingState` in 'have-local-offer' or 'have-local-pranswer'. 

Added a incoming call e2e test to cover this case.

## Type of change

- [ ] Internal refactoring
- [x] Bug fix (bugfix - non-breaking)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Code snippets

In case of new feature or breaking changes, please include code snippets.
