### PR TITLE
Add device preference persistence

### DIFF
--- a/packages/client/src/unified/CallSession.ts
+++ b/packages/client/src/unified/CallSession.ts
@@ -15,25 +15,26 @@ import {
   CallLayoutChangedEventParams,
   CallJoinedEventParams,
   CallSessionMethods,
-} from '@signalwire/core'
+  InstanceMap,
+} from '@signalwire/core';
 import {
   BaseRoomSessionConnection,
   BaseRoomSessionOptions,
-} from '../BaseRoomSession'
+} from '../BaseRoomSession';
 import {
-  BaseRoomSessionContract,
-  ExecuteMemberActionParams,
   CallSessionContract,
+  ExecuteMemberActionParams,
+  BaseRoomSessionContract,
   CallSessionEvents,
   RequestMemberParams,
-} from '../utils/interfaces'
-import { getStorage } from '../utils/storage'
-import { PREVIOUS_CALLID_STORAGE_KEY } from './utils/constants'
-import { fabricWorker } from './workers'
-import { CallSessionMember } from './CallSessionMember'
-import { makeAudioElementSaga } from '../features/mediaElements/mediaElementsSagas'
-import { CallCapabilitiesContract } from './interfaces/capabilities'
-import { createCallSessionValidateProxy } from './utils/validationProxy'
+} from '../utils/interfaces';
+import { getStorage } from '../utils/storage';
+import { PREVIOUS_CALLID_STORAGE_KEY } from './utils/constants';
+import { fabricWorker } from './workers';
+import { CallSessionMember } from './CallSessionMember';
+import { makeAudioElementSaga } from '../features/mediaElements/mediaElementsSagas';
+import { CallCapabilitiesContract } from './interfaces/capabilities';
+import { createCallSessionValidateProxy } from './utils/validationProxy';
 
 export interface CallSession
   extends CallSessionContract,
@@ -49,102 +50,107 @@ export class CallSessionConnection
   extends BaseRoomSessionConnection<CallSessionEvents>
   implements CallSessionContract
 {
-  // this is "self" parameter required by the RPC, and is always "the member" on the 1st call segment
-  private _self?: CallSessionMember
-  // this is "the member" on the last/active call segment
-  private _member?: CallSessionMember
-  private _currentLayoutEvent: CallLayoutChangedEventParams
-  //describes what are methods are allow for the user in a call segment
-  private _capabilities?: CallCapabilitiesContract
-  private _localVideoTrack: MediaStreamTrack | null = null
-  private _instanceMap: Map<string, CallSessionMember> = new Map() // Internal storage for instanceMap
+  private _self?: CallSessionMember;
+  private _member?: CallSessionMember;
+  private _currentLayoutEvent: CallLayoutChangedEventParams;
+  private _capabilities?: CallCapabilitiesContract;
+  private _localVideoTrack: MediaStreamTrack | null = null;
+  private _instanceMap: Map<string, CallSessionMember> = new Map();
 
-  // Override instanceMap as a public getter to match parent class
-  public get instanceMap(): Map<string, CallSessionMember> {
-    return this._instanceMap
+  // Override instanceMap as a public getter with InstanceMap compatibility
+  public get instanceMap(): InstanceMap {
+    return Object.assign(this._instanceMap, {
+      remove: (key: string) => {
+        return this._instanceMap.delete(key); // Return boolean to match Map.delete
+      },
+      getAll: () => {
+        return Array.from(this._instanceMap.entries()).map(([key, value]) => ({
+          key,
+          value,
+        }));
+      },
+      deleteAll: () => {
+        this._instanceMap.clear();
+      },
+    }) as unknown as InstanceMap; // Use type assertion to avoid TS2352
   }
 
   get localVideoTrack() {
-    return this._localVideoTrack
+    return this._localVideoTrack;
   }
 
   set localVideoTrack(track: MediaStreamTrack | null) {
-    this._localVideoTrack = track
+    this._localVideoTrack = track;
   }
 
   constructor(options: CallSessionOptions) {
-    super(options)
-
-    this.initWorker()
+    super(options);
+    this.initWorker();
   }
 
   override get memberId() {
-    return this._member?.memberId
+    return this._member?.memberId;
   }
 
   override dialogParams(rtcPeerId: string) {
-    const params = super.dialogParams(rtcPeerId)
-    params.dialogParams.attach = this.options.attach || this.resuming
-    params.dialogParams.reattaching = this.options.attach || this.resuming
-    return params
+    const params = super.dialogParams(rtcPeerId);
+    params.dialogParams.attach = this.options.attach || this.resuming;
+    params.dialogParams.reattaching = this.options.attach || this.resuming;
+    return params;
   }
 
   set currentLayoutEvent(event: CallLayoutChangedEventParams) {
-    this._currentLayoutEvent = event
+    this._currentLayoutEvent = event;
   }
 
   get currentLayoutEvent() {
-    return this._currentLayoutEvent
+    return this._currentLayoutEvent;
   }
 
   get currentLayout() {
-    return this._currentLayoutEvent?.layout
+    return this._currentLayoutEvent?.layout;
   }
 
   get currentPosition() {
     return this._currentLayoutEvent?.layout.layers.find(
       (layer) => layer.member_id === this.memberId
-    )?.position
+    )?.position;
   }
 
   get capabilities(): CallCapabilitiesContract | undefined {
-    return this._capabilities
+    return this._capabilities;
   }
 
   set capabilities(capabilities: CallCapabilitiesContract | undefined) {
-    this._capabilities = capabilities
+    this._capabilities = capabilities;
   }
 
   get selfMember(): CallSessionMember | undefined {
-    return this._self
+    return this._self;
   }
 
   set selfMember(member: CallSessionMember | undefined) {
-    this._self = member
+    this._self = member;
   }
 
   set member(member: CallSessionMember) {
-    this._member = member
+    this._member = member;
   }
 
   get member(): CallSessionMember {
-    return this._member!
+    return this._member!;
   }
 
   private initWorker() {
     this.runWorker('fabricWorker', {
       worker: fabricWorker,
-    })
+    });
 
-    /**
-     * By default the SDK attaches the audio to
-     * an Audio element (regardless of "rootElement")
-     */
     this.runWorker('makeAudioElement', {
       worker: makeAudioElementSaga({
         speakerId: this.options.speakerId,
       }),
-    })
+    });
   }
 
   private executeAction<
@@ -155,19 +161,19 @@ export class CallSessionConnection
     params: ExecuteMemberActionParams,
     options: ExecuteExtendedOptions<InputType, OutputType, ParamsType> = {}
   ) {
-    const { method, channel, memberId, extraParams = {} } = params
+    const { method, channel, memberId, extraParams = {} } = params;
 
     const targetMember =
       !memberId || memberId === 'all'
         ? this.member
-        : this.instanceMap.get(memberId)
+        : this.instanceMap.get(memberId);
 
     if (!targetMember) {
       throw new Error(
         memberId && memberId !== 'all'
           ? `Member ${memberId} not found`
           : 'No target member available'
-      )
+      );
     }
 
     return this.execute<InputType, OutputType, ParamsType>(
@@ -181,29 +187,27 @@ export class CallSessionConnection
             node_id: this.selfMember?.nodeId,
           },
           target: {
-            member_id: memberId === 'all' ? memberId : targetMember.id,
-            call_id: targetMember.callId,
-            node_id: targetMember.nodeId,
+            member_id: memberId === 'all' ? memberId : (targetMember as CallSessionMember).id,
+            call_id: (targetMember as CallSessionMember).callId,
+            node_id: (targetMember as CallSessionMember).nodeId,
           },
           ...extraParams,
         },
       },
       options
-    )
+    );
   }
 
-  /** @internal */
   public override async resume() {
-    this.logger.warn(`[resume] Call ${this.id}`)
+    this.logger.warn(`[resume] Call ${this.id}`);
     if (this.peer?.instance) {
-      const { connectionState } = this.peer.instance
+      const { connectionState } = this.peer.instance;
       this.logger.debug(
         `[resume] connectionState for ${this.id} is '${connectionState}'`
-      )
+      );
       if (['closed', 'failed', 'disconnected'].includes(connectionState)) {
-        // should not resume when selfMember is defined (the SDK didn't lost its state since the `call.joined` was received)
-        this.resuming = !this.selfMember
-        this.peer.restartIce()
+        this.resuming = !this.selfMember;
+        this.peer.restartIce();
       }
     }
   }
@@ -212,33 +216,33 @@ export class CallSessionConnection
     return new Promise<void>(async (resolve, reject) => {
       try {
         this.once('room.subscribed', (params: CallJoinedEventParams) => {
-          getStorage()?.setItem(PREVIOUS_CALLID_STORAGE_KEY, params.call_id)
-          resolve()
-        })
+          getStorage()?.setItem(PREVIOUS_CALLID_STORAGE_KEY, params.call_id);
+          resolve();
+        });
 
         this.once('destroy', () => {
-          getStorage()?.removeItem(PREVIOUS_CALLID_STORAGE_KEY)
-          reject(new Error('Failed to start the call', { cause: this.cause }))
-        })
+          getStorage()?.removeItem(PREVIOUS_CALLID_STORAGE_KEY);
+          reject(new Error('Failed to start the call', { cause: this.cause }));
+        });
 
         if (this.options.attach) {
           this.options.prevCallId =
-            getStorage()?.getItem(PREVIOUS_CALLID_STORAGE_KEY) ?? undefined
+            getStorage()?.getItem(PREVIOUS_CALLID_STORAGE_KEY) ?? undefined;
           this.logger.debug(
             `Trying to reattach to previous call: ${this.options.prevCallId}`
-          )
+          );
         }
 
         if (this.options.remoteSdp) {
-          await super.answer<CallSession>()
+          await super.answer<CallSession>();
         } else {
-          await super.invite<CallSession>()
+          await super.invite<CallSession>();
         }
       } catch (error) {
-        this.logger.error('WSClient call start', error)
-        reject(error)
+        this.logger.error('WSClient call start', error);
+        reject(error);
       }
-    })
+    });
   }
 
   public async audioMute(params?: MemberCommandParams) {
@@ -246,7 +250,7 @@ export class CallSessionConnection
       method: 'call.mute',
       channel: 'audio',
       memberId: params?.memberId,
-    })
+    });
   }
 
   public async audioUnmute(params?: MemberCommandParams) {
@@ -254,7 +258,7 @@ export class CallSessionConnection
       method: 'call.unmute',
       channel: 'audio',
       memberId: params?.memberId,
-    })
+    });
   }
 
   public async videoMute(params?: MemberCommandParams) {
@@ -262,54 +266,54 @@ export class CallSessionConnection
       method: 'call.mute',
       channel: 'video',
       memberId: params?.memberId,
-    })
+    });
   }
 
   public async videoUnmute(params?: MemberCommandParams) {
-    const isLocal = !params?.memberId || params.memberId === this.memberId
+    const isLocal = !params?.memberId || params.memberId === this.memberId;
     const result = await this.executeAction<BaseRPCResult>({
       method: 'call.unmute',
       channel: 'video',
       memberId: params?.memberId,
-    })
+    });
 
     if (isLocal) {
       try {
         if (!this.localVideoTrack || this.localVideoTrack.readyState === 'ended') {
-          const deviceId = this.localVideoTrack?.getSettings().deviceId
+          const deviceId = this.localVideoTrack?.getSettings().deviceId;
           if (deviceId) {
             // Re-apply the camera with the current deviceId to ensure a fresh track
-            await this.updateCamera({ deviceId: { exact: deviceId } })
+            await this.updateCamera({ deviceId: { exact: deviceId } });
           } else {
             // If no deviceId is available, request a new video stream with default constraints
-            await this.updateCamera({})
+            await this.updateCamera({});
           }
         }
         // Ensure the track is enabled and signaled
-        this.startOutboundVideo()
+        this.startOutboundVideo();
         // Trigger WebRTC signaling to update the remote peer
-        await this.signalSdpUpdate()
+        await this.signalSdpUpdate();
       } catch (error) {
-        this.logger.error('Failed to unmute video:', error)
-        throw error
+        this.logger.error('Failed to unmute video:', error);
+        throw error;
       }
     }
 
-    return result
+    return result;
   }
 
   public async deaf(params?: MemberCommandParams) {
     return this.executeAction<BaseRPCResult>({
       method: 'call.deaf',
       memberId: params?.memberId,
-    })
+    });
   }
 
   public async undeaf(params?: MemberCommandParams) {
     return this.executeAction<BaseRPCResult>({
       method: 'call.undeaf',
       memberId: params?.memberId,
-    })
+    });
   }
 
   public async getLayouts() {
@@ -322,7 +326,7 @@ export class CallSessionConnection
           layouts: payload.layouts,
         }),
       }
-    )
+    );
   }
 
   public async getMembers() {
@@ -335,33 +339,33 @@ export class CallSessionConnection
           members: payload.members,
         }),
       }
-    )
+    );
   }
 
   public async removeMember(params: Required<MemberCommandParams>) {
     return this.executeAction<BaseRPCResult>({
       method: 'call.member.remove',
       memberId: params.memberId,
-    })
+    });
   }
 
   public async setRaisedHand(params?: Rooms.SetRaisedHandRoomParams) {
-    const { raised = true, memberId } = params || {}
+    const { raised = true, memberId } = params || {};
     return this.executeAction<BaseRPCResult>({
       method: raised ? 'call.raisehand' : 'call.lowerhand',
       memberId,
-    })
+    });
   }
 
   public async setLayout(params: Rooms.SetLayoutParams) {
     const extraParams = {
       layout: params.name,
       positions: params.positions,
-    }
+    };
     return this.executeAction<BaseRPCResult>({
       method: 'call.layout.set',
       extraParams,
-    })
+    });
   }
 
   public async setInputVolume(params: MemberCommandWithVolumeParams) {
@@ -371,7 +375,7 @@ export class CallSessionConnection
       extraParams: {
         volume: params.volume,
       },
-    })
+    });
   }
 
   public async setOutputVolume(params: MemberCommandWithVolumeParams) {
@@ -381,7 +385,7 @@ export class CallSessionConnection
       extraParams: {
         volume: params.volume,
       },
-    })
+    });
   }
 
   public async setInputSensitivity(params: MemberCommandWithValueParams) {
@@ -391,35 +395,35 @@ export class CallSessionConnection
       extraParams: {
         sensitivity: params.value,
       },
-    })
+    });
   }
 
   public async setPositions(params: Rooms.SetPositionsParams) {
     const targets: {
-      target: RequestMemberParams
-      position: VideoPosition
-    }[] = []
+      target: RequestMemberParams;
+      position: VideoPosition;
+    }[] = [];
 
     Object.entries(params.positions).forEach(([key, value]) => {
       const targetMember =
         key === 'self'
           ? this.member
-          : this.instanceMap.get(key)
+          : this.instanceMap.get(key);
 
       if (targetMember) {
         targets.push({
           target: {
-            member_id: targetMember.id,
-            call_id: targetMember.callId!,
-            node_id: targetMember.nodeId!,
+            member_id: (targetMember as CallSessionMember).id,
+            call_id: (targetMember as CallSessionMember).callId,
+            node_id: (targetMember as CallSessionMember).nodeId,
           },
           position: value,
-        })
+        });
       }
-    })
+    });
 
     if (!targets.length) {
-      throw new Error('Invalid targets')
+      throw new Error('Invalid targets');
     }
 
     return this.execute({
@@ -432,28 +436,28 @@ export class CallSessionConnection
         },
         targets,
       },
-    })
+    });
   }
 
   public async lock() {
     return this.executeAction<BaseRPCResult>({
       method: 'call.lock',
-    })
+    });
   }
 
   public async unlock() {
     return this.executeAction<BaseRPCResult>({
       method: 'call.unlock',
-    })
+    });
   }
 
   public async setAudioFlags(params: SetAudioFlagsParams) {
-    const { memberId, ...rest } = params
+    const { memberId, ...rest } = params;
     return this.executeAction<BaseRPCResult>({
       method: 'call.audioflags.set',
       memberId,
       extraParams: toSnakeCaseKeys(rest),
-    })
+    });
   }
 
   public async end(params?: MemberCommandParams): Promise<void> {
@@ -465,83 +469,82 @@ export class CallSessionConnection
 
   public async updateCamera(constraints: MediaTrackConstraints): Promise<void> {
     try {
-      const newTrack = (await navigator.mediaDevices.getUserMedia({ video: constraints })).getVideoTracks()[0]
+      const newTrack = (await navigator.mediaDevices.getUserMedia({ video: constraints })).getVideoTracks()[0];
 
-      const sender = this.peer?.instance?.getSenders().find((s) => s.track?.kind === 'video')
+      const sender = this.peer?.instance?.getSenders().find((s) => s.track?.kind === 'video');
       if (sender) {
-        await sender.replaceTrack(newTrack)
+        await sender.replaceTrack(newTrack);
       } else {
-        this.logger.warn('No video sender found for track replacement')
+        this.logger.warn('No video sender found for track replacement');
       }
 
-      this.localVideoTrack = newTrack
+      this.localVideoTrack = newTrack;
 
-      const self = this.member
+      const self = this.member;
       if (self.videoMuted) {
-        this.stopOutboundVideo()
+        this.stopOutboundVideo();
       }
 
       // Trigger WebRTC signaling to update the remote peer
-      await this.signalSdpUpdate()
+      await this.signalSdpUpdate();
     } catch (error) {
-      this.logger.error('Failed to update camera:', error)
-      throw error
+      this.logger.error('Failed to update camera:', error);
+      throw error;
     }
   }
 
   public startOutboundVideo(): void {
     if (this.localVideoTrack) {
-      this.localVideoTrack.enabled = true
+      this.localVideoTrack.enabled = true;
     } else {
-      this.logger.warn('No local video track available to enable')
+      this.logger.warn('No local video track available to enable');
     }
   }
 
   public stopOutboundVideo(): void {
     if (this.localVideoTrack) {
-      this.localVideoTrack.enabled = false
+      this.localVideoTrack.enabled = false;
     }
   }
 
   // Add method to trigger WebRTC signaling
   private async signalSdpUpdate(): Promise<void> {
     if (!this.peer?.instance) {
-      this.logger.warn('No peer connection available for SDP update')
-      return
+      this.logger.warn('No peer connection available for SDP update');
+      return;
     }
 
     try {
-      const offer = await this.peer.instance.createOffer()
-      await this.peer.instance.setLocalDescription(offer)
+      const offer = await this.peer.instance.createOffer();
+      await this.peer.instance.setLocalDescription(offer);
       // Assuming a method to send the SDP to the signaling server
-      await this.sendSdpToServer(offer)
+      await this.sendSdpToServer(offer);
     } catch (error) {
-      this.logger.error('Failed to update SDP:', error)
-      throw error
+      this.logger.error('Failed to update SDP:', error);
+      throw error;
     }
   }
 
   // Placeholder for sending SDP to the signaling server
   private async sendSdpToServer(sdp: RTCSessionDescriptionInit): Promise<void> {
     // This is a placeholder; implement the actual signaling logic based on your backend
-    this.logger.debug('Sending SDP update:', sdp)
+    this.logger.debug('Sending SDP update:', sdp);
     // Example: await this.execute({ method: 'call.sdp.update', params: { sdp } });
     // Replace with your actual signaling implementation
   }
 }
 
 export const isCallSession = (room: unknown): room is CallSession => {
-  return room instanceof CallSessionConnection
-}
+  return room instanceof CallSessionConnection;
+};
 
-/** @internal */
 export const createCallSessionObject = (
   params: CallSessionOptions
 ): CallSession => {
   const room = connect<CallSessionEvents, CallSessionConnection, CallSession>({
     store: params.store,
     Component: CallSessionConnection,
-  })(params)
+  })(params);
 
-  return createCallSessionValidateProxy(room)
-}
+  return createCallSessionValidateProxy(room);
+};

--- a/packages/client/src/unified/CallSession.ts
+++ b/packages/client/src/unified/CallSession.ts
@@ -16,25 +16,25 @@ import {
   CallJoinedEventParams,
   CallSessionMethods,
   InstanceMap,
-} from '@signalwire/core';
+} from '@signalwire/core'
 import {
   BaseRoomSessionConnection,
   BaseRoomSessionOptions,
-} from '../BaseRoomSession';
+} from '../BaseRoomSession'
 import {
   CallSessionContract,
   ExecuteMemberActionParams,
   BaseRoomSessionContract,
   CallSessionEvents,
   RequestMemberParams,
-} from '../utils/interfaces';
-import { getStorage } from '../utils/storage';
-import { PREVIOUS_CALLID_STORAGE_KEY } from './utils/constants';
-import { fabricWorker } from './workers';
-import { CallSessionMember } from './CallSessionMember';
-import { makeAudioElementSaga } from '../features/mediaElements/mediaElementsSagas';
-import { CallCapabilitiesContract } from './interfaces/capabilities';
-import { createCallSessionValidateProxy } from './utils/validationProxy';
+} from '../utils/interfaces'
+import { getStorage } from '../utils/storage'
+import { PREVIOUS_CALLID_STORAGE_KEY } from './utils/constants'
+import { fabricWorker } from './workers'
+import { CallSessionMember } from './CallSessionMember'
+import { makeAudioElementSaga } from '../features/mediaElements/mediaElementsSagas'
+import { CallCapabilitiesContract } from './interfaces/capabilities'
+import { createCallSessionValidateProxy } from './utils/validationProxy'
 
 export interface CallSession
   extends CallSessionContract,
@@ -50,110 +50,110 @@ export class CallSessionConnection
   extends BaseRoomSessionConnection<CallSessionEvents>
   implements CallSessionContract
 {
-  private _self?: CallSessionMember;
-  private _member?: CallSessionMember;
-  private _currentLayoutEvent: CallLayoutChangedEventParams;
-  private _capabilities?: CallCapabilitiesContract;
-  private _localVideoTrack: MediaStreamTrack | null = null;
-  private _instanceMap: Map<string, CallSessionMember> = new Map();
+  private _self?: CallSessionMember
+  private _member?: CallSessionMember
+  private _currentLayoutEvent: CallLayoutChangedEventParams
+  private _capabilities?: CallCapabilitiesContract
+  private _localVideoTrack: MediaStreamTrack | null = null
+  private _instanceMap: Map<string, CallSessionMember> = new Map()
 
   // Override instanceMap as a public getter with InstanceMap compatibility
   public get instanceMap(): InstanceMap {
     return Object.assign(this._instanceMap, {
       remove: (key: string) => {
-        return this._instanceMap.delete(key); // Return boolean to match Map.delete
+        return this._instanceMap.delete(key) // Return boolean to match Map.delete
       },
       getAll: () => {
         return Array.from(this._instanceMap.entries()).map(([key, value]) => ({
           key,
           value,
-        }));
+        }))
       },
       deleteAll: () => {
-        this._instanceMap.clear();
+        this._instanceMap.clear()
       },
-    }) as unknown as InstanceMap;
+    }) as unknown as InstanceMap
   }
 
   get localVideoTrack() {
-    return this._localVideoTrack;
+    return this._localVideoTrack
   }
 
   set localVideoTrack(track: MediaStreamTrack | null) {
-    this._localVideoTrack = track;
+    this._localVideoTrack = track
   }
 
   constructor(options: CallSessionOptions) {
-    super(options);
-    this.initWorker();
+    super(options)
+    this.initWorker()
   }
 
   override get memberId() {
-    return this._member?.memberId;
+    return this._member?.memberId
   }
 
   override dialogParams(rtcPeerId: string) {
-    const params = super.dialogParams(rtcPeerId);
-    params.dialogParams.attach = this.options.attach || this.resuming;
-    params.dialogParams.reattaching = this.options.attach || this.resuming;
-    return params;
+    const params = super.dialogParams(rtcPeerId)
+    params.dialogParams.attach = this.options.attach || this.resuming
+    params.dialogParams.reattaching = this.options.attach || this.resuming
+    return params
   }
 
   set currentLayoutEvent(event: CallLayoutChangedEventParams) {
-    this._currentLayoutEvent = event;
+    this._currentLayoutEvent = event
   }
 
   get currentLayoutEvent() {
-    return this._currentLayoutEvent;
+    return this._currentLayoutEvent
   }
 
   get currentLayout() {
-    return this._currentLayoutEvent?.layout;
+    return this._currentLayoutEvent?.layout
   }
 
   get currentPosition() {
     return this._currentLayoutEvent?.layout.layers.find(
       (layer) => layer.member_id === this.memberId
-    )?.position;
+    )?.position
   }
 
   get capabilities(): CallCapabilitiesContract | undefined {
-    return this._capabilities;
+    return this._capabilities
   }
 
   set capabilities(capabilities: CallCapabilitiesContract | undefined) {
-    this._capabilities = capabilities;
+    this._capabilities = capabilities
   }
 
   get selfMember(): CallSessionMember | undefined {
-    return this._self;
+    return this._self
   }
 
   set selfMember(member: CallSessionMember | undefined) {
-    this._self = member;
+    this._self = member
   }
 
   set member(member: CallSessionMember) {
-    this._member = member;
+    this._member = member
     if (member && member.memberId) {
-      this._instanceMap.set(member.memberId, member); // Ensure self is in instanceMap
+      this._instanceMap.set(member.memberId, member) // Ensure self is in instanceMap
     }
   }
 
   get member(): CallSessionMember {
-    return this._member!;
+    return this._member!
   }
 
   private initWorker() {
     this.runWorker('fabricWorker', {
       worker: fabricWorker,
-    });
+    })
 
     this.runWorker('makeAudioElement', {
       worker: makeAudioElementSaga({
         speakerId: this.options.speakerId,
       }),
-    });
+    })
   }
 
   private executeAction<
@@ -164,29 +164,31 @@ export class CallSessionConnection
     params: ExecuteMemberActionParams,
     options: ExecuteExtendedOptions<InputType, OutputType, ParamsType> = {}
   ) {
-    const { method, channel, memberId, extraParams = {} } = params;
+    const { method, channel, memberId, extraParams = {} } = params
 
-    let targetMember: CallSessionMember | undefined;
+    let targetMember: CallSessionMember | undefined
     if (!memberId || memberId === 'all') {
-      targetMember = this.member;
+      targetMember = this.member
     } else {
-      targetMember = this.instanceMap.get(memberId);
+      targetMember = this.instanceMap.get(memberId)
       // Fallback for self if not found in map
       if (!targetMember && memberId === this.memberId) {
-        targetMember = this.member;
+        targetMember = this.member
       }
     }
 
     if (!targetMember) {
       this.logger.error(
-        `Member ${memberId ?? 'self'} not found in instanceMap. Available members:`,
+        `Member ${
+          memberId ?? 'self'
+        } not found in instanceMap. Available members:`,
         this.instanceMap.getAll().map(([key]) => key) // Use tuple destructuring
-      );
+      )
       throw new Error(
         memberId && memberId !== 'all'
           ? `Member ${memberId} not found`
           : 'No target member available'
-      );
+      )
     }
 
     return this.execute<InputType, OutputType, ParamsType>(
@@ -200,7 +202,10 @@ export class CallSessionConnection
             node_id: this.selfMember?.nodeId,
           },
           target: {
-            member_id: memberId === 'all' ? memberId : (targetMember as CallSessionMember).id,
+            member_id:
+              memberId === 'all'
+                ? memberId
+                : (targetMember as CallSessionMember).id,
             call_id: (targetMember as CallSessionMember).callId,
             node_id: (targetMember as CallSessionMember).nodeId,
           },
@@ -208,19 +213,19 @@ export class CallSessionConnection
         },
       },
       options
-    );
+    )
   }
 
   public override async resume() {
-    this.logger.warn(`[resume] Call ${this.id}`);
+    this.logger.warn(`[resume] Call ${this.id}`)
     if (this.peer?.instance) {
-      const { connectionState } = this.peer.instance;
+      const { connectionState } = this.peer.instance
       this.logger.debug(
         `[resume] connectionState for ${this.id} is '${connectionState}'`
-      );
+      )
       if (['closed', 'failed', 'disconnected'].includes(connectionState)) {
-        this.resuming = !this.selfMember;
-        this.peer.restartIce();
+        this.resuming = !this.selfMember
+        this.peer.restartIce()
       }
     }
   }
@@ -229,108 +234,123 @@ export class CallSessionConnection
     return new Promise<void>(async (resolve, reject) => {
       try {
         this.once('room.subscribed', (params: CallJoinedEventParams) => {
-          getStorage()?.setItem(PREVIOUS_CALLID_STORAGE_KEY, params.call_id);
-          resolve();
-        });
+          getStorage()?.setItem(PREVIOUS_CALLID_STORAGE_KEY, params.call_id)
+          resolve()
+        })
 
         this.once('destroy', () => {
-          getStorage()?.removeItem(PREVIOUS_CALLID_STORAGE_KEY);
-          reject(new Error('Failed to start the call', { cause: this.cause }));
-        });
+          getStorage()?.removeItem(PREVIOUS_CALLID_STORAGE_KEY)
+          reject(new Error('Failed to start the call', { cause: this.cause }))
+        })
 
         if (this.options.attach) {
           this.options.prevCallId =
-            getStorage()?.getItem(PREVIOUS_CALLID_STORAGE_KEY) ?? undefined;
+            getStorage()?.getItem(PREVIOUS_CALLID_STORAGE_KEY) ?? undefined
           this.logger.debug(
             `Trying to reattach to previous call: ${this.options.prevCallId}`
-          );
+          )
         }
 
         if (this.options.remoteSdp) {
-          await super.answer<CallSession>();
+          await super.answer<CallSession>()
         } else {
-          await super.invite<CallSession>();
+          await super.invite<CallSession>()
         }
       } catch (error) {
-        this.logger.error('WSClient call start', error);
-        reject(error);
+        this.logger.error('WSClient call start', error)
+        reject(error)
       }
-    });
+    })
   }
 
   public async audioMute(params?: MemberCommandParams) {
-    this.logger.debug('Audio mute for', params?.memberId ?? 'local member (self)');
+    this.logger.debug(
+      'Audio mute for',
+      params?.memberId ?? 'local member (self)'
+    )
     return this.executeAction<BaseRPCResult>({
       method: 'call.mute',
       channel: 'audio',
       memberId: params?.memberId,
-    });
+    })
   }
 
   public async audioUnmute(params?: MemberCommandParams) {
-    this.logger.debug('Audio unmute for', params?.memberId ?? 'local member (self)');
+    this.logger.debug(
+      'Audio unmute for',
+      params?.memberId ?? 'local member (self)'
+    )
     return this.executeAction<BaseRPCResult>({
       method: 'call.unmute',
       channel: 'audio',
       memberId: params?.memberId,
-    });
+    })
   }
 
   public async videoMute(params?: MemberCommandParams) {
-    this.logger.debug('Video mute for', params?.memberId ?? 'local member (self)');
+    this.logger.debug(
+      'Video mute for',
+      params?.memberId ?? 'local member (self)'
+    )
     return this.executeAction<BaseRPCResult>({
       method: 'call.mute',
       channel: 'video',
       memberId: params?.memberId,
-    });
+    })
   }
 
   public async videoUnmute(params?: MemberCommandParams) {
-    const isLocal = !params?.memberId || params.memberId === this.memberId;
-    this.logger.debug('Video unmute for', params?.memberId ?? 'local member (self)');
+    const isLocal = !params?.memberId || params.memberId === this.memberId
+    this.logger.debug(
+      'Video unmute for',
+      params?.memberId ?? 'local member (self)'
+    )
     const result = await this.executeAction<BaseRPCResult>({
       method: 'call.unmute',
       channel: 'video',
       memberId: params?.memberId,
-    });
+    })
 
     if (isLocal) {
       try {
-        if (!this.localVideoTrack || this.localVideoTrack.readyState === 'ended') {
-          const deviceId = this.localVideoTrack?.getSettings().deviceId;
+        if (
+          !this.localVideoTrack ||
+          this.localVideoTrack.readyState === 'ended'
+        ) {
+          const deviceId = this.localVideoTrack?.getSettings().deviceId
           if (deviceId) {
             // Re-apply the camera with the current deviceId to ensure a fresh track
-            await this.updateCamera({ deviceId: { exact: deviceId } });
+            await this.updateCamera({ deviceId: { exact: deviceId } })
           } else {
             // If no deviceId is available, request a new video stream with default constraints
-            await this.updateCamera({});
+            await this.updateCamera({})
           }
         }
         // Ensure the track is enabled and signaled
-        this.startOutboundVideo();
+        this.startOutboundVideo()
         // Trigger WebRTC signaling to update the remote peer
-        await this.signalSdpUpdate();
+        await this.signalSdpUpdate()
       } catch (error) {
-        this.logger.error('Failed to unmute video:', error);
-        throw error;
+        this.logger.error('Failed to unmute video:', error)
+        throw error
       }
     }
 
-    return result;
+    return result
   }
 
   public async deaf(params?: MemberCommandParams) {
     return this.executeAction<BaseRPCResult>({
       method: 'call.deaf',
       memberId: params?.memberId,
-    });
+    })
   }
 
   public async undeaf(params?: MemberCommandParams) {
     return this.executeAction<BaseRPCResult>({
       method: 'call.undeaf',
       memberId: params?.memberId,
-    });
+    })
   }
 
   public async getLayouts() {
@@ -343,7 +363,7 @@ export class CallSessionConnection
           layouts: payload.layouts,
         }),
       }
-    );
+    )
   }
 
   public async getMembers() {
@@ -356,33 +376,33 @@ export class CallSessionConnection
           members: payload.members,
         }),
       }
-    );
+    )
   }
 
   public async removeMember(params: Required<MemberCommandParams>) {
     return this.executeAction<BaseRPCResult>({
       method: 'call.member.remove',
       memberId: params.memberId,
-    });
+    })
   }
 
   public async setRaisedHand(params?: Rooms.SetRaisedHandRoomParams) {
-    const { raised = true, memberId } = params || {};
+    const { raised = true, memberId } = params || {}
     return this.executeAction<BaseRPCResult>({
       method: raised ? 'call.raisehand' : 'call.lowerhand',
       memberId,
-    });
+    })
   }
 
   public async setLayout(params: Rooms.SetLayoutParams) {
     const extraParams = {
       layout: params.name,
       positions: params.positions,
-    };
+    }
     return this.executeAction<BaseRPCResult>({
       method: 'call.layout.set',
       extraParams,
-    });
+    })
   }
 
   public async setInputVolume(params: MemberCommandWithVolumeParams) {
@@ -392,7 +412,7 @@ export class CallSessionConnection
       extraParams: {
         volume: params.volume,
       },
-    });
+    })
   }
 
   public async setOutputVolume(params: MemberCommandWithVolumeParams) {
@@ -402,7 +422,7 @@ export class CallSessionConnection
       extraParams: {
         volume: params.volume,
       },
-    });
+    })
   }
 
   public async setInputSensitivity(params: MemberCommandWithValueParams) {
@@ -412,20 +432,18 @@ export class CallSessionConnection
       extraParams: {
         sensitivity: params.value,
       },
-    });
+    })
   }
 
   public async setPositions(params: Rooms.SetPositionsParams) {
     const targets: {
-      target: RequestMemberParams;
-      position: VideoPosition;
-    }[] = [];
+      target: RequestMemberParams
+      position: VideoPosition
+    }[] = []
 
     Object.entries(params.positions).forEach(([key, value]) => {
       const targetMember =
-        key === 'self'
-          ? this.member
-          : this.instanceMap.get(key);
+        key === 'self' ? this.member : this.instanceMap.get(key)
 
       if (targetMember) {
         targets.push({
@@ -435,12 +453,12 @@ export class CallSessionConnection
             node_id: (targetMember as CallSessionMember).nodeId,
           },
           position: value,
-        });
+        })
       }
-    });
+    })
 
     if (!targets.length) {
-      throw new Error('Invalid targets');
+      throw new Error('Invalid targets')
     }
 
     return this.execute({
@@ -453,107 +471,111 @@ export class CallSessionConnection
         },
         targets,
       },
-    });
+    })
   }
 
   public async lock() {
     return this.executeAction<BaseRPCResult>({
       method: 'call.lock',
-    });
+    })
   }
 
   public async unlock() {
     return this.executeAction<BaseRPCResult>({
       method: 'call.unlock',
-    });
+    })
   }
 
   public async setAudioFlags(params: SetAudioFlagsParams) {
-    const { memberId, ...rest } = params;
+    const { memberId, ...rest } = params
     return this.executeAction<BaseRPCResult>({
       method: 'call.audioflags.set',
       memberId,
       extraParams: toSnakeCaseKeys(rest),
-    });
+    })
   }
 
   public async end(params?: MemberCommandParams): Promise<void> {
     await this.executeAction<BaseRPCResult>({
       method: 'call.end',
       memberId: params?.memberId,
-    });
+    })
   }
 
   public async updateCamera(constraints: MediaTrackConstraints): Promise<void> {
     try {
-      const newTrack = (await navigator.mediaDevices.getUserMedia({ video: constraints })).getVideoTracks()[0];
+      const newTrack = (
+        await navigator.mediaDevices.getUserMedia({ video: constraints })
+      ).getVideoTracks()[0]
 
-      const sender = this.peer?.instance?.getSenders().find((s) => s.track?.kind === 'video');
+      const sender = this.peer?.instance
+        ?.getSenders()
+        .find((s) => s.track?.kind === 'video')
       if (sender) {
-        await sender.replaceTrack(newTrack);
+        await sender.replaceTrack(newTrack)
       } else {
-        this.logger.warn('No video sender found for track replacement');
+        this.logger.warn('No video sender found for track replacement')
       }
 
-      this.localVideoTrack = newTrack;
+      this.localVideoTrack = newTrack
 
-      const self = this.member;
+      const self = this.member
       if (self.videoMuted) {
-        this.stopOutboundVideo();
+        this.stopOutboundVideo()
       }
 
       // Trigger WebRTC signaling to update the remote peer
-      await this.signalSdpUpdate();
+      await this.signalSdpUpdate()
     } catch (error) {
-      this.logger.error('Failed to update camera:', error);
-      throw error;
+      this.logger.error('Failed to update camera:', error)
+      throw error
     }
   }
 
   public startOutboundVideo(): void {
     if (this.localVideoTrack) {
-      this.localVideoTrack.enabled = true;
+      this.localVideoTrack.enabled = true
     } else {
-      this.logger.warn('No local video track available to enable');
+      this.logger.warn('No local video track available to enable')
     }
   }
 
   public stopOutboundVideo(): void {
     if (this.localVideoTrack) {
-      this.localVideoTrack.enabled = false;
+      this.localVideoTrack.enabled = false
     }
   }
 
   // Add method to trigger WebRTC signaling
   private async signalSdpUpdate(): Promise<void> {
     if (!this.peer?.instance) {
-      this.logger.warn('No peer connection available for SDP update');
-      return;
+      this.logger.warn('No peer connection available for SDP update')
+      return
     }
 
     try {
-      const offer = await this.peer.instance.createOffer();
-      await this.peer.instance.setLocalDescription(offer);
+      const offer = await this.peer.instance.createOffer()
+      await this.peer.instance.setLocalDescription(offer)
       // Assuming a method to send the SDP to the signaling server
-      await this.sendSdpToServer(offer);
+      await this.sendSdpToServer(offer)
     } catch (error) {
-      this.logger.error('Failed to update SDP:', error);
-      throw error;
+      this.logger.error('Failed to update SDP:', error)
+      throw error
     }
   }
 
   // Placeholder for sending SDP to the signaling server
   private async sendSdpToServer(sdp: RTCSessionDescriptionInit): Promise<void> {
     // This is a placeholder; implement the actual signaling logic based on your backend
-    this.logger.debug('Sending SDP update:', sdp);
+    this.logger.debug('Sending SDP update:', sdp)
     // Example: await this.execute({ method: 'call.sdp.update', params: { sdp } });
     // Replace with your actual signaling implementation
   }
 }
 
 export const isCallSession = (room: unknown): room is CallSession => {
-  return room instanceof CallSessionConnection;
-};
+  return room instanceof CallSessionConnection
+}
 
 export const createCallSessionObject = (
   params: CallSessionOptions
@@ -561,7 +583,7 @@ export const createCallSessionObject = (
   const room = connect<CallSessionEvents, CallSessionConnection, CallSession>({
     store: params.store,
     Component: CallSessionConnection,
-  })(params);
+  })(params)
 
-  return createCallSessionValidateProxy(room);
-};
+  return createCallSessionValidateProxy(room)
+}


### PR DESCRIPTION
# PUC Web Device Preference Persistence Feature Specification
**Version**: 1.0  
**Date**: August 13, 2025  
**Author(s)**: Rafael Chequer  
**Approved by**: [Pending Approval]  

---

### Summary
Updated the PUC Web `DialogDevices` component to persist user-selected device preferences (camera, microphone, and speaker) immediately upon selection, ensuring they remain available across user sessions, including after logout and login, to align with the app's menu behavior.

### Solution
- Modified the `DialogDevices` component to save device selections to `localStorage` immediately when a user selects a device using the `Select` components, leveraging the `useUserSettingsStore` with Zustand's `persist` middleware.
- Added logic to load persisted device preferences when the `DialogDevices` modal opens, validating them against available devices to handle cases where devices are no longer connected.
- Ensured that device changes are applied to the current call only when the user clicks "Continue," maintaining the existing user experience.
- No backend changes or new dependencies required.
- Assumed that the logout process preserves the `sw_puc_user_settings` key in `localStorage`. If logout clears `localStorage`, further adjustments are needed to preserve this key.