### PR TITLE
Rename subscribeChatMessages from addressId to groupId

### DIFF
--- a/packages/client/src/unified/Conversation.test.ts
+++ b/packages/client/src/unified/Conversation.test.ts
@@ -396,17 +396,61 @@ describe('Conversation', () => {
       // Mock getConversationMessages to return properly typed data
       jest.spyOn(conversation, 'getConversationMessages').mockResolvedValue({
         data: [
-          { subtype: 'log', group_id: 'abc', from_fabric_address_id: 'fa1' } as any,
-          { subtype: 'chat', group_id: 'abc', from_fabric_address_id: 'fa1' } as any,
-          { subtype: 'chat', group_id: 'abc', from_fabric_address_id: 'fa1' } as any,
-          { subtype: 'chat', group_id: 'abc', from_fabric_address_id: 'fa1' } as any,
-          { subtype: 'chat', group_id: 'abc', from_fabric_address_id: 'fa1' } as any,
-          { subtype: 'chat', group_id: 'abc', from_fabric_address_id: 'fa1' } as any,
-          { subtype: 'chat', group_id: 'abc', from_fabric_address_id: 'fa1' } as any,
-          { subtype: 'chat', group_id: 'abc', from_fabric_address_id: 'fa1' } as any,
-          { subtype: 'chat', group_id: 'abc', from_fabric_address_id: 'fa1' } as any,
-          { subtype: 'chat', group_id: 'abc', from_fabric_address_id: 'fa1' } as any,
-          { subtype: 'chat', group_id: 'abc', from_fabric_address_id: 'fa1' } as any,
+          {
+            subtype: 'log',
+            group_id: 'abc',
+            from_fabric_address_id: 'fa1',
+          } as any,
+          {
+            subtype: 'chat',
+            group_id: 'abc',
+            from_fabric_address_id: 'fa1',
+          } as any,
+          {
+            subtype: 'chat',
+            group_id: 'abc',
+            from_fabric_address_id: 'fa1',
+          } as any,
+          {
+            subtype: 'chat',
+            group_id: 'abc',
+            from_fabric_address_id: 'fa1',
+          } as any,
+          {
+            subtype: 'chat',
+            group_id: 'abc',
+            from_fabric_address_id: 'fa1',
+          } as any,
+          {
+            subtype: 'chat',
+            group_id: 'abc',
+            from_fabric_address_id: 'fa1',
+          } as any,
+          {
+            subtype: 'chat',
+            group_id: 'abc',
+            from_fabric_address_id: 'fa1',
+          } as any,
+          {
+            subtype: 'chat',
+            group_id: 'abc',
+            from_fabric_address_id: 'fa1',
+          } as any,
+          {
+            subtype: 'chat',
+            group_id: 'abc',
+            from_fabric_address_id: 'fa1',
+          } as any,
+          {
+            subtype: 'chat',
+            group_id: 'abc',
+            from_fabric_address_id: 'fa1',
+          } as any,
+          {
+            subtype: 'chat',
+            group_id: 'abc',
+            from_fabric_address_id: 'fa1',
+          } as any,
         ],
         hasNext: false,
         hasPrev: false,
@@ -434,17 +478,61 @@ describe('Conversation', () => {
       // Mock getConversationMessages to return properly typed data
       jest.spyOn(conversation, 'getConversationMessages').mockResolvedValue({
         data: [
-          { subtype: 'log', group_id: 'abc', from_fabric_address_id: 'fa1' } as any,
-          { subtype: 'chat', group_id: 'abc', from_fabric_address_id: 'fa1' } as any,
-          { subtype: 'chat', group_id: 'abc', from_fabric_address_id: 'fa2' } as any,
-          { subtype: 'chat', group_id: 'abc', from_fabric_address_id: 'fa3' } as any,
-          { subtype: 'chat', group_id: 'abc', from_fabric_address_id: 'fa1' } as any,
-          { subtype: 'chat', group_id: 'abc', from_fabric_address_id: 'fa2' } as any,
-          { subtype: 'chat', group_id: 'abc', from_fabric_address_id: 'fa3' } as any,
-          { subtype: 'chat', group_id: 'abc', from_fabric_address_id: 'fa1' } as any,
-          { subtype: 'chat', group_id: 'abc', from_fabric_address_id: 'fa2' } as any,
-          { subtype: 'chat', group_id: 'abc', from_fabric_address_id: 'fa3' } as any,
-          { subtype: 'chat', group_id: 'abc', from_fabric_address_id: 'fa1' } as any,
+          {
+            subtype: 'log',
+            group_id: 'abc',
+            from_fabric_address_id: 'fa1',
+          } as any,
+          {
+            subtype: 'chat',
+            group_id: 'abc',
+            from_fabric_address_id: 'fa1',
+          } as any,
+          {
+            subtype: 'chat',
+            group_id: 'abc',
+            from_fabric_address_id: 'fa2',
+          } as any,
+          {
+            subtype: 'chat',
+            group_id: 'abc',
+            from_fabric_address_id: 'fa3',
+          } as any,
+          {
+            subtype: 'chat',
+            group_id: 'abc',
+            from_fabric_address_id: 'fa1',
+          } as any,
+          {
+            subtype: 'chat',
+            group_id: 'abc',
+            from_fabric_address_id: 'fa2',
+          } as any,
+          {
+            subtype: 'chat',
+            group_id: 'abc',
+            from_fabric_address_id: 'fa3',
+          } as any,
+          {
+            subtype: 'chat',
+            group_id: 'abc',
+            from_fabric_address_id: 'fa1',
+          } as any,
+          {
+            subtype: 'chat',
+            group_id: 'abc',
+            from_fabric_address_id: 'fa2',
+          } as any,
+          {
+            subtype: 'chat',
+            group_id: 'abc',
+            from_fabric_address_id: 'fa3',
+          } as any,
+          {
+            subtype: 'chat',
+            group_id: 'abc',
+            from_fabric_address_id: 'fa1',
+          } as any,
         ],
         hasNext: false,
         hasPrev: false,
@@ -585,9 +673,9 @@ describe('Conversation', () => {
 
     it('should get only address chat event', async () => {
       const mockCallback = jest.fn()
-      const addressId = 'abc'
+      const groupId = 'abc'
       await conversation.subscribeChatMessages({
-        addressId,
+        groupId,
         onMessage: mockCallback,
       })
 
@@ -633,16 +721,14 @@ describe('Conversation', () => {
     })
 
     it('should register the chat callback', async () => {
-      const addressId = 'abc'
+      const groupId = 'abc'
       const mockCallback = jest.fn()
       await conversation.subscribeChatMessages({
-        addressId,
+        groupId,
         onMessage: mockCallback,
       })
 
-      expect(conversation['chatSubscriptions'][addressId]).toContain(
-        mockCallback
-      )
+      expect(conversation['chatSubscriptions'][groupId]).toContain(mockCallback)
     })
 
     it('should cancel the correct chat subscription', async () => {
@@ -652,15 +738,15 @@ describe('Conversation', () => {
       const addressId1 = 'abc'
       const addressId2 = 'xyz'
       await conversation.subscribeChatMessages({
-        addressId: addressId1,
+        groupId: addressId1,
         onMessage: mockCallback1,
       })
       const subscription2 = await conversation.subscribeChatMessages({
-        addressId: addressId1,
+        groupId: addressId1,
         onMessage: mockCallback2,
       })
       await conversation.subscribeChatMessages({
-        addressId: addressId2,
+        groupId: addressId2,
         onMessage: mockCallback3,
       })
 

--- a/packages/client/src/unified/Conversation.ts
+++ b/packages/client/src/unified/Conversation.ts
@@ -323,15 +323,15 @@ export class Conversation {
   public async subscribeChatMessages(
     params: ConversationChatMessagesSubscribeParams
   ): Promise<ConversationChatMessagesSubscribeResult> {
-    const { addressId, onMessage } = params
+    const { groupId, onMessage } = params
 
-    if (!(addressId in this.chatSubscriptions)) {
-      this.chatSubscriptions[addressId] = new Set()
+    if (!(groupId in this.chatSubscriptions)) {
+      this.chatSubscriptions[groupId] = new Set()
     }
 
-    this.chatSubscriptions[addressId].add(onMessage)
+    this.chatSubscriptions[groupId].add(onMessage)
     return {
-      unsubscribe: () => this.chatSubscriptions[addressId].delete(onMessage),
+      unsubscribe: () => this.chatSubscriptions[groupId].delete(onMessage),
     }
   }
 

--- a/packages/client/src/unified/interfaces/conversation.ts
+++ b/packages/client/src/unified/interfaces/conversation.ts
@@ -65,7 +65,7 @@ export interface ConversationSubscribeResult {
 }
 
 export interface ConversationChatMessagesSubscribeParams {
-  addressId: string
+  groupId: string
   onMessage: ConversationChatSubscribeCallback
 }
 


### PR DESCRIPTION
# Description

Simple change to match the others chat APIs cahnges. This is just renaming the parameter name for consistency.
The logic still the same.

*No changeset is required, since the chat changes where part of non release changeset already*

## Type of change

- [ ] Internal refactoring
- [ ] Bug fix (bugfix - non-breaking)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Code snippets

In case of new feature or breaking changes, please include code snippets.

```
const subscription2 = await conversation.subscribeChatMessages({
        groupId,
        onMessage: (message) => {...},
      })
``