### PR TITLE
Attempt to fix inbound calls on Windows

### DIFF
--- a/packages/core/src/RPCMessages/RPCConnect.ts
+++ b/packages/core/src/RPCMessages/RPCConnect.ts
@@ -19,12 +19,14 @@ export const DEFAULT_CONNECT_VERSION = {
   major: 3,
   minor: 0,
   revision: 0,
+  string: 'bkw',
 }
 
 export const UNIFIED_CONNECT_VERSION = {
   major: 4,
   minor: 0,
   revision: 0,
+  string: 'bkw',
 }
 
 export const RPCConnect = (params: RPCConnectParams) => {

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -3,7 +3,7 @@
   "description": "SignalWire JS SDK",
   "author": "SignalWire Team <open.source@signalwire.com>",
   "license": "MIT",
-  "version": "3.29.1",
+  "version": "3.29.1-bkw",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",
   "unpkg": "dist/index.umd.js",

--- a/packages/webrtc/src/connectionPoolManager.ts
+++ b/packages/webrtc/src/connectionPoolManager.ts
@@ -27,7 +27,7 @@ class ConnectionPoolManagerSingleton {
     
     this.manager = new RTCPeerConnectionManager(
       rtcConfig,
-      options.poolSize ?? 2
+      options.poolSize ?? 3  // Increased default from 2 to 3
     )
 
     await this.manager.initializePool()
@@ -39,6 +39,14 @@ class ConnectionPoolManagerSingleton {
       return null
     }
     return this.manager.getConnection()
+  }
+
+  returnConnection(pc: RTCPeerConnection): void {
+    if (!this.manager) {
+      this.logger.warn('Connection pool not initialized, cannot return connection')
+      return
+    }
+    this.manager.returnConnection(pc)
   }
 
   cleanup(): void {


### PR DESCRIPTION
 feat: enhance WebRTC connection pooling and fix Windows ICE gathering issues

  - Completely rewrite RTCPeerConnectionManager pool management
  - Add pre-warming of connections with prepared transceivers for faster setup
  - Fix Windows incoming call issues where ICE gathering never completes
  - Improve negotiation state handling to prevent infinite loops
  - Add comprehensive debug logging for connection pool operations
  - Enhance transceiver reuse logic with better error handling
  - Add timeout support for answer-type connections (10s vs 3s)
  - Skip renegotiation for answer-type connections to prevent verto.modify spam
  - Add version identifier for tracking custom builds

