### PR TITLE
New Early Invite Implementation (Cherrypick from main)

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,7 +7,7 @@
   "commit": false,
   "linked": [],
   "access": "restricted",
-  "baseBranch": "main",
+  "baseBranch": "main_video_v3",
   "updateInternalDependencies": "patch",
   "ignore": []
 }

--- a/.changeset/swift-moles-arrive.md
+++ b/.changeset/swift-moles-arrive.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/webrtc': patch
+---
+
+FIXED inbound calls negotiation

--- a/.changeset/tender-falcons-think.md
+++ b/.changeset/tender-falcons-think.md
@@ -1,0 +1,5 @@
+---
+'@signalwire/webrtc': patch
+---
+
+refactored the early invites implementation to make it more stable.

--- a/packages/webrtc/src/RTCPeer.ts
+++ b/packages/webrtc/src/RTCPeer.ts
@@ -987,11 +987,10 @@ export default class RTCPeer<EventTypes extends EventEmitter.ValidEventTypes> {
      */
     if (!event.candidate) {
       this.instance.removeEventListener('icecandidate', this._onIce)
-      // not call _sdpReady if an early invite has been sent
-      if (this._candidatesSnapshot.length > 0) {
-        this.logger.debug('No more candidates, calling _sdpReady')
-        this._sdpReady()
-      }
+      clearTimeout(this._iceTimeout)
+      this.logger.debug('No more candidates, calling _sdpReady')
+      this._sdpReady()
+
       return
     }
 

--- a/packages/webrtc/src/RTCPeer.ts
+++ b/packages/webrtc/src/RTCPeer.ts
@@ -1134,9 +1134,8 @@ export default class RTCPeer<EventTypes extends EventEmitter.ValidEventTypes> {
           // Workaround to skip nested negotiations
           // Chrome bug: https://bugs.chromium.org/p/chromium/issues/detail?id=740501
 
-          // signalingState means we have both remote and local SDP
           if (this.isOffer) {
-            // when it's an offer that means the negotiation is done
+            // only when it's an offer that means the negotiation is done
             this._negotiating = false
             this._restartingIce = false
             this.resetNeedResume()

--- a/packages/webrtc/src/RTCPeer.ts
+++ b/packages/webrtc/src/RTCPeer.ts
@@ -923,6 +923,7 @@ export default class RTCPeer<EventTypes extends EventEmitter.ValidEventTypes> {
       await this.call.onLocalSDPReady(this)
       this._processingLocalSDP = false
       if (this.isAnswer) {
+        this.logger.debug('Setting negotiating false for inbound calls')
         this._negotiating = false
         this._restartingIce = false
         this.resetNeedResume()
@@ -1136,6 +1137,7 @@ export default class RTCPeer<EventTypes extends EventEmitter.ValidEventTypes> {
 
           if (this.isOffer) {
             // only when it's an offer that means the negotiation is done
+            this.logger.debug('Setting negotiating false for outbound calls')
             this._negotiating = false
             this._restartingIce = false
             this.resetNeedResume()

--- a/packages/webrtc/src/RTCPeer.ts
+++ b/packages/webrtc/src/RTCPeer.ts
@@ -29,6 +29,7 @@ export default class RTCPeer<EventTypes extends EventEmitter.ValidEventTypes> {
   public instance: RTCPeerConnection
 
   private _iceTimeout: any
+  private _iceGatheringTimeout: any
   private _negotiating = false
   private _processingRemoteSDP = false
   private _restartingIce = false
@@ -36,8 +37,6 @@ export default class RTCPeer<EventTypes extends EventEmitter.ValidEventTypes> {
   private _connectionStateTimer: ReturnType<typeof setTimeout>
   private _resumeTimer?: ReturnType<typeof setTimeout>
   private _mediaWatcher: ReturnType<typeof watchRTCPeerMediaPackets>
-  private _candidatesSnapshot: RTCIceCandidate[] = []
-  private _allCandidates: RTCIceCandidate[] = []
   private _processingLocalSDP = false
   /**
    * Both of these properties are used to have granular
@@ -451,7 +450,6 @@ export default class RTCPeer<EventTypes extends EventEmitter.ValidEventTypes> {
     if (this._negotiating) {
       return this.logger.warn('Skip twice onnegotiationneeded!')
     }
-
     this._negotiating = true
 
     try {
@@ -506,11 +504,6 @@ export default class RTCPeer<EventTypes extends EventEmitter.ValidEventTypes> {
       }
 
       this.logger.info('iceGatheringState', this.instance.iceGatheringState)
-      if (this.instance.iceGatheringState === 'gathering') {
-        this._iceTimeout = setTimeout(() => {
-          this._onIceTimeout()
-        }, this.options.maxIceGatheringTimeout)
-      }
     } catch (error) {
       this.logger.error(`Error creating ${this.type}:`, error)
       this._negotiationCompleted(error)
@@ -950,6 +943,8 @@ export default class RTCPeer<EventTypes extends EventEmitter.ValidEventTypes> {
   }
 
   private _onIceTimeout() {
+    this.instance.removeEventListener('icecandidate', this._onIce)
+
     if (this._sdpIsValid()) {
       this._sdpReady()
       return
@@ -975,12 +970,15 @@ export default class RTCPeer<EventTypes extends EventEmitter.ValidEventTypes> {
   }
 
   private _onIce(event: RTCPeerConnectionIceEvent) {
-    /**
-     * Clear _iceTimeout on each single candidate
-     */
+    // Clear _iceTimeout on each single candidate
     if (this._iceTimeout) {
       clearTimeout(this._iceTimeout)
     }
+
+    // Add new _newTimeout for next candidate
+    this._iceTimeout = setTimeout(() => {
+      this._onIceTimeout()
+    }, this.options.iceGatheringTimeout)
 
     /**
      * Following spec: no candidate means the gathering is completed.
@@ -994,74 +992,7 @@ export default class RTCPeer<EventTypes extends EventEmitter.ValidEventTypes> {
       return
     }
 
-    // Store all candidates
-    this._allCandidates.push(event.candidate)
-
     this.logger.debug('RTCPeer Candidate:', event.candidate)
-    if (event.candidate.type === 'host') {
-      /**
-       * With `host` candidate set timeout to
-       * maxIceGatheringTimeout and then invoke
-       * _onIceTimeout to check if the SDP is valid
-       */
-      this._iceTimeout = setTimeout(() => {
-        this.instance.removeEventListener('icecandidate', this._onIce)
-        this._onIceTimeout()
-      }, this.options.maxIceGatheringTimeout)
-    } else {
-      /**
-       * With non-HOST candidate (srflx, prflx or relay), check if we have
-       * candidates for all media sections to support early invite
-       */
-      if (this.instance.localDescription?.sdp) {
-        if (sdpHasValidCandidates(this.instance.localDescription.sdp)) {
-          // Take a snapshot of candidates at this point
-          if (this._candidatesSnapshot.length === 0 && this.type === 'offer') {
-            this._candidatesSnapshot = [...this._allCandidates]
-            this.logger.info(
-              'SDP has candidates for all media sections, calling _sdpReady for early invite'
-            )
-            setTimeout(() => this._sdpReady(), 0) // Defer to allow any pending operations to complete
-          }
-        } else {
-          this.logger.info(
-            'SDP does not have candidates for all media sections, waiting for more candidates'
-          )
-          this.logger.debug(this.instance.localDescription?.sdp)
-        }
-      }
-    }
-  }
-
-  private _retryWithMoreCandidates() {
-    // Check if we have better candidates now than when we first sent SDP
-    const hasMoreCandidates = this._hasMoreCandidates()
-
-    if (hasMoreCandidates && this.instance.connectionState !== 'connected') {
-      this.logger.info(
-        'More candidates found after ICE gathering complete, triggering renegotiation'
-      )
-      // Reset negotiation state to allow new negotiation
-      this._negotiating = false
-      this._candidatesSnapshot = []
-      this._allCandidates = []
-
-      // set the SDP type to 'offer' since the client is initiating a new negotiation
-      this.type = 'offer'
-      // Start negotiation with force=true
-      if (this.instance.signalingState === 'stable') {
-        this.startNegotiation(true)
-      } else {
-        this.logger.warn(
-          'Signaling state is not stable, cannot start negotiation immediately'
-        )
-        this.restartIce()
-      }
-    }
-  }
-
-  private _hasMoreCandidates(): boolean {
-    return this._allCandidates.length > this._candidatesSnapshot.length
   }
 
   private _setLocalDescription(localDescription: RTCSessionDescriptionInit) {
@@ -1087,12 +1018,6 @@ export default class RTCPeer<EventTypes extends EventEmitter.ValidEventTypes> {
         googleStartBitrate
       )
     }
-    // this.logger.debug(
-    //   'LOCAL SDP \n',
-    //   `Type: ${localDescription.type}`,
-    //   '\n\n',
-    //   localDescription.sdp
-    // )
     return this.instance.setLocalDescription(localDescription)
   }
 
@@ -1171,14 +1096,6 @@ export default class RTCPeer<EventTypes extends EventEmitter.ValidEventTypes> {
         // case 'new':
         //   break
         case 'connecting':
-          this._connectionStateTimer = setTimeout(() => {
-            this.logger.warn('connectionState timed out')
-            if (this._hasMoreCandidates()) {
-              this._retryWithMoreCandidates()
-            } else {
-              this.restartIceWithRelayOnly()
-            }
-          }, this.options.maxConnectionStateTimeout)
           break
         case 'connected':
           this.clearConnectionStateTimer()
@@ -1207,18 +1124,34 @@ export default class RTCPeer<EventTypes extends EventEmitter.ValidEventTypes> {
 
     this.instance.addEventListener('icegatheringstatechange', () => {
       this.logger.debug('iceGatheringState:', this.instance.iceGatheringState)
-      if (this.instance.iceGatheringState === 'complete') {
-        this.logger.debug('ICE gathering complete')
-        void this._sdpReady()
+      switch (this.instance.iceGatheringState) {
+        case 'gathering':
+          this._iceGatheringTimeout = setTimeout(() => {
+            this._onIceTimeout()
+          }, this.options.maxIceGatheringTimeout)
+          break
+        case 'complete':
+          this.clearIceGatheringTimer()
+
+          // start connectionState timer after the gathering is complete
+          this._connectionStateTimer = setTimeout(() => {
+            this.logger.warn('connectionState timed out')
+            this.restartIceWithRelayOnly()
+          }, this.options.maxConnectionStateTimeout)
+
+          this.logger.debug('ICE gathering complete')
+          void this._sdpReady()
+          break
       }
     })
 
     // this.instance.addEventListener('icecandidateerror', (event) => {
     //   this.logger.warn('IceCandidate Error:', event)
+    //   this.clearTimers()
+    //   this._forceNegotiation()
     // })
 
     this.instance.addEventListener('track', (event: RTCTrackEvent) => {
-      this.logger.debug('Track event:', event, event.track.kind)
       // @ts-expect-error
       this.call.emit('track', event)
 
@@ -1243,7 +1176,12 @@ export default class RTCPeer<EventTypes extends EventEmitter.ValidEventTypes> {
   private clearTimers() {
     this.clearResumeTimer()
     this.clearWatchMediaPacketsTimer()
+    this.clearIceGatheringTimer()
     this.clearConnectionStateTimer()
+  }
+
+  clearIceGatheringTimer() {
+    clearTimeout(this._iceGatheringTimeout)
   }
 
   private clearConnectionStateTimer() {
@@ -1260,7 +1198,6 @@ export default class RTCPeer<EventTypes extends EventEmitter.ValidEventTypes> {
   }
 
   private emitMediaConnected() {
-    this.logger.debug('Emitting media.connected event')
     this.call.emit('media.connected')
   }
 

--- a/packages/webrtc/src/RTCPeer.ts
+++ b/packages/webrtc/src/RTCPeer.ts
@@ -20,8 +20,8 @@ import {
 } from './utils'
 import { watchRTCPeerMediaPackets } from './utils/watchRTCPeerMediaPackets'
 import { connectionPoolManager } from './connectionPoolManager'
+
 const RESUME_TIMEOUT = 12_000
-const MAX_RESTARTS = 5
 
 export default class RTCPeer<EventTypes extends EventEmitter.ValidEventTypes> {
   public uuid = uuid()
@@ -39,7 +39,6 @@ export default class RTCPeer<EventTypes extends EventEmitter.ValidEventTypes> {
   private _candidatesSnapshot: RTCIceCandidate[] = []
   private _allCandidates: RTCIceCandidate[] = []
   private _processingLocalSDP = false
-  private _renegotiationCount = 0
   /**
    * Both of these properties are used to have granular
    * control over when to `resolve` and when `reject` the
@@ -200,7 +199,6 @@ export default class RTCPeer<EventTypes extends EventEmitter.ValidEventTypes> {
   }
 
   private _negotiationCompleted(error?: unknown) {
-    this._renegotiationCount = 0
     if (!error) {
       this._resolveStartMethod()
       this._pendingNegotiationPromise?.resolve()
@@ -453,14 +451,9 @@ export default class RTCPeer<EventTypes extends EventEmitter.ValidEventTypes> {
     if (this._negotiating) {
       return this.logger.warn('Skip twice onnegotiationneeded!')
     }
-    this._renegotiationCount += 1
-
-    if (this._renegotiationCount > MAX_RESTARTS) {
-      const error = new Error('too many negotiations restarts')
-      this._negotiationCompleted(error)
-    }
 
     this._negotiating = true
+
     try {
       /**
        * additionalDevice and screenShare are `sendonly`
@@ -930,6 +923,9 @@ export default class RTCPeer<EventTypes extends EventEmitter.ValidEventTypes> {
       await this.call.onLocalSDPReady(this)
       this._processingLocalSDP = false
       if (this.isAnswer) {
+        this._negotiating = false
+        this._restartingIce = false
+        this.resetNeedResume()
         this._negotiationCompleted()
       }
     } catch (error) {
@@ -1137,9 +1133,14 @@ export default class RTCPeer<EventTypes extends EventEmitter.ValidEventTypes> {
         case 'stable':
           // Workaround to skip nested negotiations
           // Chrome bug: https://bugs.chromium.org/p/chromium/issues/detail?id=740501
-          this._negotiating = false
-          this._restartingIce = false
-          this.resetNeedResume()
+
+          // signalingState means we have both remote and local SDP
+          if (this.isOffer) {
+            // when it's an offer that means the negotiation is done
+            this._negotiating = false
+            this._restartingIce = false
+            this.resetNeedResume()
+          }
 
           if (this.instance.connectionState === 'connected') {
             // An ice restart won't change the connectionState so we emit the same event in here

--- a/packages/webrtc/src/RTCPeerConnectionManager.ts
+++ b/packages/webrtc/src/RTCPeerConnectionManager.ts
@@ -110,7 +110,6 @@ export class RTCPeerConnectionManager {
     return null
   }
 
-
   /**
    * Clean up the manager and all connections
    */
@@ -185,10 +184,6 @@ export class RTCPeerConnectionManager {
       }
 
       this.logger.debug(`Pooled connection ${id} created successfully`)
-      this.logger.debug(
-        `ICE candidates gathered for connection ${id}:`,
-        pc.localDescription?.sdp
-      )
       return pooledConnection
     } catch (error) {
       this.logger.error('Failed to create pooled connection:', error)


### PR DESCRIPTION
# Description

A new approach trying to make the early invites more stable. Instead of forcing an early invite after the first non-host candidate. This new implementation allows all FAST candidates to be gathered, potentially even completing the gathering. If a single candidate takes longer than 300ms to gether, then we try an early invite with the candidates gathered so far. 

## Type of change

- [X] Internal refactoring
- [ ] Bug fix (bugfix - non-breaking)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Code snippets

In case of new feature or breaking changes, please include code snippets.

