### PR TITLE
Disable scheduled test runs

### DIFF
--- a/.github/workflows/browser-js-production.yml
+++ b/.github/workflows/browser-js-production.yml
@@ -3,8 +3,8 @@ name: Browser SDK [production]
 on:
   workflow_call:
   workflow_dispatch:
-  schedule:
-    - cron: '0 */4 * * *'
+  # schedule:
+  #   - cron: '0 */4 * * *'
 
 concurrency:
   group: ${{ github.workflow }}-e2e-js-production-${{ github.ref }}

--- a/.github/workflows/browser-js-staging.yml
+++ b/.github/workflows/browser-js-staging.yml
@@ -3,8 +3,8 @@ name: Browser SDK [staging]
 on:
   workflow_call:
   workflow_dispatch:
-  schedule:
-    - cron: '10 */4 * * *'
+  # schedule:
+  #   - cron: '10 */4 * * *'
 
 concurrency:
   group: ${{ github.workflow }}-e2e-js-staging-${{ github.ref }}

--- a/.github/workflows/realtime-api-production.yml
+++ b/.github/workflows/realtime-api-production.yml
@@ -3,8 +3,8 @@ name: RealtimeAPI SDK [production]
 on:
   workflow_call:
   workflow_dispatch:
-  schedule:
-    - cron: '20 * * * *'
+  # schedule:
+  #   - cron: '20 * * * *'
 
 concurrency:
   group: ${{ github.workflow }}-realtime-api-production-${{ github.ref }}

--- a/.github/workflows/realtime-api-staging.yml
+++ b/.github/workflows/realtime-api-staging.yml
@@ -3,8 +3,8 @@ name: RealtimeAPI SDK [staging]
 on:
   workflow_call:
   workflow_dispatch:
-  schedule:
-    - cron: '30 */2 * * *'
+  # schedule:
+  #   - cron: '30 */2 * * *'
 
 concurrency:
   group: ${{ github.workflow }}-realtime-api-staging-${{ github.ref }}


### PR DESCRIPTION
## Summary

Disables the `schedule:` (cron) triggers on the GitHub Actions test workflows.

These SDKs are being **deprecated**. The scheduled end-to-end / monitoring test runs now live in [`signalwire/rtc-testing`](https://github.com/signalwire/rtc-testing) with proper monitoring and alerting, so running them on a cron here is redundant.

## Changes

The `schedule:` blocks were commented out (cron values preserved for easy re-enable) in:

| Workflow | Disabled cron |
|---|---|
| `browser-js-production.yml` | `0 */4 * * *` |
| `browser-js-staging.yml` | `10 */4 * * *` |
| `realtime-api-production.yml` | `20 * * * *` |
| `realtime-api-staging.yml` | `30 */2 * * *` |

Each workflow retains its `workflow_call` and `workflow_dispatch` triggers, so they can still be invoked manually or by other workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)